### PR TITLE
Move some functionality to ejml for performance, add a microbenchmarking package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,22 +4,29 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                echo 'Building  ogolem and running unit tests'
+                echo 'Building ogolem and running unit tests'
                 sh 'gradle build -i'
             }
         }
-	stage('Build ogolem manual') {
-	    steps {
-	        echo 'Building ogolem manual'
-		sh 'cd manual && pdflatex manual.tex && bibtex manual && pdflatex manual.tex && pdflatex manual.tex && cd -'
-	    }
-	}
+        stage('Microbenchmark') {
+            steps {
+	        echo 'Running ogolem internal microbenchmarks'
+                sh 'java -jar build/libs/ogolem-snapshot.jar --microbenchmarks > microbenchmark_results.txt'
+            }
+        }
+        stage('Build ogolem manual') {
+            steps {
+                echo 'Building ogolem manual'
+                sh 'cd manual && pdflatex manual.tex && bibtex manual && pdflatex manual.tex && pdflatex manual.tex && cd -'
+            }
+        }
     }
-
+    
     post {
         always {
             archiveArtifacts artifacts: 'build/libs/ogolem-snapshot.jar', fingerprint: true
-	    archiveArtifacts artifacts: 'manual/manual.pdf', fingerprint: true
+            archiveArtifacts artifacts: 'manual/manual.pdf', fingerprint: true
+            archiveArtifacts artifacts: 'microbenchmark_results.txt', fingerprint: true
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,12 @@ dependencies {
   implementation name: 'skalevala'
   implementation 'org.apache.commons:commons-math3:3.6.1'
   implementation 'com.github.fommil.netlib:native_ref-java:1.1'
+  implementation 'org.ejml:ejml-all:0.38'
   implementation 'org.jgrapht:jgrapht-core:1.3.1'
   implementation 'org.jgrapht:jgrapht-ext:1.3.1'
   implementation 'org.scala-lang:scala-library:2.12.9'
-  implementation 'org.slf4j:slf4j-api:1.7.26'
+  implementation 'org.slf4j:slf4j-api:1.7.30'
+  implementation 'org.slf4j:slf4j-simple:1.7.30'
   testImplementation(
     'junit:junit:4.12',
     'org.junit.jupiter:junit-jupiter-api:5.4.2'

--- a/src/org/ogolem/core/CoordTranslation.java
+++ b/src/org/ogolem/core/CoordTranslation.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2019, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -49,7 +49,7 @@ import static org.ogolem.math.TrivialLinearAlgebra.crossProduct;
  * This class transforms coordinates back and forth from different coordinate
  * systems and object representations.
  * @author Johannes Dieterich
- * @version 2016-08-29
+ * @version 2019-12-30
  */
 public final class CoordTranslation {
 
@@ -311,6 +311,18 @@ public final class CoordTranslation {
             final List<boolean[][]> degreesOfFreedom, final boolean[] molConstraints,
             final boolean[][] constraintsXYZ, final String[] sids, final BondInfo bonds) {
 
+        assert(cartesian != null);
+        assert(noOfMols >= 0);
+        assert(atsPerMol != null);
+        assert(atsPerMol.length >= noOfMols);
+        assert(molFlexies != null);
+        assert(molFlexies.length >= noOfMols);
+        assert(degreesOfFreedom != null);
+        assert(!degreesOfFreedom.isEmpty());
+        assert(molConstraints != null);
+        assert(molConstraints.length >= noOfMols);
+        assert(bonds != null);
+        
         final GeometryConfig gc = cartesianToGeomConfig(cartesian, noOfMols,
                 atsPerMol, molFlexies, degreesOfFreedom, molConstraints, constraintsXYZ, sids, bonds);
         final Geometry geom = new Geometry(gc);
@@ -446,6 +458,8 @@ public final class CoordTranslation {
     public static MoleculeConfig cartesianToBareMolConfig(final CartesianCoordinates cartesian,
             final int moleculeID, final String sID, final boolean flexyMolecule, final boolean[][] zmatDoFs,
             final boolean constrictedMol, final boolean[][] molConstraints) {
+        
+        assert(cartesian != null);
         
         // 1. STEP: CREATE THE NEEDED CONFIG OBJECTS
         final MoleculeConfig mc = new MoleculeConfig(true);
@@ -632,6 +646,12 @@ public final class CoordTranslation {
      */
     public static double[][] rotateXYZAroundY(final double[][] xyz, final double rotation){
         
+        assert(xyz != null);
+        assert(xyz.length == 3);
+        assert(xyz[0].length > 0);
+        assert(xyz[0].length == xyz[1].length);
+        assert(xyz[0].length == xyz[2].length);
+        
         final double[][] rotated = new double[3][xyz[0].length];
         final double[][] rot = new double[3][3];
         
@@ -685,6 +705,12 @@ public final class CoordTranslation {
      * @return the rotated set of Cartesian coordinates. Will be of dimensions [3][N].
      */
     public static double[][] rotateXYZAroundZ(final double[][] xyz, final double rotation){
+        
+        assert(xyz != null);
+        assert(xyz.length == 3);
+        assert(xyz[0].length > 0);
+        assert(xyz[0].length ==xyz[1].length);
+        assert(xyz[0].length ==xyz[2].length);
         
         final double[][] rotated = new double[3][xyz[0].length];
         final double[][] rot = new double[3][3];
@@ -1024,7 +1050,7 @@ public final class CoordTranslation {
         rot[0][2] = 0.0;
         rot[1][2] = 0.0;
         rot[2][2] = 0.0;
-         
+        
         // call the matrix multiplication
         org.ogolem.math.TrivialLinearAlgebra.matMult(rot, xyz, rotated, 3, 3, xyz[0].length, cache);
     }
@@ -1166,6 +1192,10 @@ public final class CoordTranslation {
      */
     public static SimpleBondInfo checkForBonds(final CartesianCoordinates cartes, final double blowFacBonds) {
 
+        assert(cartes != null);
+        assert(cartes.getNoOfAtoms() > 0);
+        assert(blowFacBonds > 0.0);
+        
         final int noOfAtoms = cartes.getNoOfAtoms();
         final SimpleBondInfo bonds = new SimpleBondInfo(noOfAtoms);
 
@@ -1208,6 +1238,9 @@ public final class CoordTranslation {
      */
     public static CartesianCoordinates zMatToCartesians(final ZMatrix zmat) {
         
+        assert(zmat != null);
+        assert(zmat.getNoOfAtoms() > 0);
+        
         final int noOfAtoms = zmat.getNoOfAtoms();
         final int[] atsPerMol = {noOfAtoms};
         final CartesianCoordinates cartes = new CartesianCoordinates(noOfAtoms, 1, atsPerMol);
@@ -1223,6 +1256,8 @@ public final class CoordTranslation {
     
     public static void updateCartesians(final ZMatrix zmat, final CartesianCoordinates cartes) {
         
+        assert(zmat != null);
+        assert(cartes != null);
         assert(cartes.getNoOfMolecules() == 1);
         assert(cartes.getNoOfAtoms() == zmat.getNoOfAtoms());
 
@@ -1366,6 +1401,11 @@ public final class CoordTranslation {
      */
     public static double distance(final double[] a, final double[] b){
         
+        assert(a != null);
+        assert(b != null);
+        assert(a.length >= 3);
+        assert(b.length >= 3);
+        
         final double dx = a[0]-b[0];
         final double dy = a[1]-b[1];
         final double dz = a[2]-b[2];
@@ -1386,8 +1426,11 @@ public final class CoordTranslation {
         assert(j >= 0);
         assert(xyz != null);
         assert(xyz.length == 3);
+        assert(xyz[0].length == xyz[1].length);
+        assert(xyz[0].length == xyz[2].length);
         assert(xyz[0].length > i);
         assert(xyz[0].length > j);
+        
         final double dx = xyz[0][i]-xyz[0][j];
         final double dy = xyz[1][i]-xyz[1][j];
         final double dz = xyz[2][i]-xyz[2][j];
@@ -1397,6 +1440,17 @@ public final class CoordTranslation {
 
     public static double calcAngle(final double[][] xyz, final int i, final int j, final int k){
 
+        assert(i >= 0);
+        assert(j >= 0);
+        assert(k >= 0);
+        assert(xyz != null);
+        assert(xyz.length == 3);
+        assert(xyz[0].length == xyz[1].length);
+        assert(xyz[0].length == xyz[2].length);
+        assert(xyz[0].length > i);
+        assert(xyz[0].length > j);
+        assert(xyz[0].length > k);
+        
         // the angle is given by acos of the dot product of the two (normalised) direction vectors: v1 v2 = |v1||v2| cos(angle)
         final double[] daVectorOne = new double[3];
         final double[] daVectorTwo = new double[3];
@@ -1415,23 +1469,43 @@ public final class CoordTranslation {
     public static double calcAngle(final double[][] xyz, final int i, final int j,
             final int k, final double[] scr1, final double[] scr2){
 
+        assert(i >= 0);
+        assert(j >= 0);
+        assert(k >= 0);
+        assert(xyz != null);
+        assert(xyz.length == 3);
+        assert(xyz[0].length == xyz[1].length);
+        assert(xyz[0].length == xyz[2].length);
+        assert(xyz[0].length > i);
+        assert(xyz[0].length > j);
+        assert(xyz[0].length > k);
+        assert(scr1 != null);
+        assert(scr2 != null);
+        assert(scr1.length >= 3);
+        assert(scr2.length >= 3);
+        
         // the angle is given by acos of the dot product of the two (normalised) direction vectors: v1 v2 = |v1||v2| cos(angle)
-        final double[] daVectorOne = scr1;
-        final double[] daVectorTwo = scr2;
         // calculate the direction vectors
         for (int c = 0; c < 3; c++) {
-            daVectorOne[c] = xyz[c][i] - xyz[c][j];
-            daVectorTwo[c] = xyz[c][k] - xyz[c][j];
+            scr1[c] = xyz[c][i] - xyz[c][j];
+            scr2[c] = xyz[c][k] - xyz[c][j];
         }
 
-        final double dAngle = angle(daVectorOne, daVectorTwo);
+        final double angle = angle(scr1, scr2);
 
-        return dAngle;
+        return angle;
 
     }
     
     public static double calcAngle(final double[] pos1, final double[] pos2, final double[] pos3){
 
+        assert(pos1 != null);
+        assert(pos1.length >=3);
+        assert(pos2 != null);
+        assert(pos2.length >=3);
+        assert(pos3 != null);
+        assert(pos3.length >=3);
+        
         // the angle is given by acos of the dot product of the two (normalised) direction vectors: v1 v2 = |v1||v2| cos(angle)
         final double[] daVectorOne = new double[3];
         final double[] daVectorTwo = new double[3];
@@ -1450,16 +1524,25 @@ public final class CoordTranslation {
     public static double calcAngle(final double[] pos1, final double[] pos2,
             final double[] pos3, final double[] scr1, final double[] scr2){
 
+        assert(pos1 != null);
+        assert(pos1.length >=3);
+        assert(pos2 != null);
+        assert(pos2.length >=3);
+        assert(pos3 != null);
+        assert(pos3.length >=3);
+        assert(scr1 != null);
+        assert(scr1.length >=3);
+        assert(scr2 != null);
+        assert(scr2.length >=3);
+        
         // the angle is given by acos of the dot product of the two (normalised) direction vectors: v1 v2 = |v1||v2| cos(angle)
-        final double[] daVectorOne = scr1;
-        final double[] daVectorTwo = scr2;
         // calculate the direction vectors
         for (int c = 0; c < 3; c++) {
-            daVectorOne[c] = pos1[c] - pos2[c];
-            daVectorTwo[c] = pos3[c] - pos2[c];
+            scr1[c] = pos1[c] - pos2[c];
+            scr2[c] = pos3[c] - pos2[c];
         }
 
-        final double dAngle = angle(daVectorOne, daVectorTwo);
+        final double dAngle = angle(scr1, scr2);
 
         return dAngle;
 
@@ -1502,6 +1585,29 @@ public final class CoordTranslation {
             final double[] scr1, final double[] scr2, final double[] scr3,
             final double[] scr4, final double[] scr5) {
         
+        assert(k >= 0);
+        assert(l >= 0);
+        assert(m >= 0);
+        assert(n >= 0);
+        assert(xyz != null);
+        assert(xyz.length == 3);
+        assert(xyz[0].length == xyz[1].length);
+        assert(xyz[0].length == xyz[2].length);
+        assert(xyz[0].length > k);
+        assert(xyz[0].length > l);
+        assert(xyz[0].length > m);
+        assert(xyz[0].length > n);
+        assert(scr1 != null);
+        assert(scr1.length >= 3);
+        assert(scr2 != null);
+        assert(scr2.length >= 3);
+        assert(scr3 != null);
+        assert(scr3.length >= 3);
+        assert(scr4 != null);
+        assert(scr4.length >= 3);
+        assert(scr5 != null);
+        assert(scr5.length >= 3);
+        
         for (int i = 0; i < 3; i++) {
             scr1[i] = xyz[i][k] - xyz[i][l];
             scr2[i] = xyz[i][l] - xyz[i][m];
@@ -1543,6 +1649,25 @@ public final class CoordTranslation {
             final double[] scr1, final double[] scr2, final double[] scr3,
             final double[] scr4, final double[] scr5) {
         
+        assert(pos1 != null);
+        assert(pos1.length >=3);
+        assert(pos2 != null);
+        assert(pos2.length >=3);
+        assert(pos3 != null);
+        assert(pos3.length >=3);
+        assert(pos4 != null);
+        assert(pos4.length >=3);
+        assert(scr1 != null);
+        assert(scr1.length >=3);
+        assert(scr2 != null);
+        assert(scr2.length >=3);
+        assert(scr3 != null);
+        assert(scr3.length >=3);
+        assert(scr4 != null);
+        assert(scr4.length >=3);
+        assert(scr5 != null);
+        assert(scr5.length >=3);
+        
         for (int i = 0; i < 3; i++) {
             scr1[i] = pos1[i] - pos2[i];
             scr2[i] = pos2[i] - pos3[i];
@@ -1570,6 +1695,15 @@ public final class CoordTranslation {
     public static double calcDihedral(final double[] pos1, final double[] pos2,
             final double[] pos3, final double[] pos4) {
 
+        assert(pos1 != null);
+        assert(pos1.length >=3);
+        assert(pos2 != null);
+        assert(pos2.length >=3);
+        assert(pos3 != null);
+        assert(pos3.length >=3);
+        assert(pos4 != null);
+        assert(pos4.length >=3);
+        
         final double[] scr1 = new double[3];
         final double[] scr2 = new double[3];
         final double[] scr3 = new double[3];
@@ -1614,35 +1748,66 @@ public final class CoordTranslation {
         assert(refCartes != null);
         assert(refCartes.length == 3);
         assert(refCartes[0].length > 0);
+        assert(refCartes[0].length == refCartes[1].length);
+        assert(refCartes[0].length == refCartes[2].length);        
         assert(cartes != null);
         assert(cartes.getNoOfAtoms() > 0);
+        assert(refCartes[0].length == cartes.getNoOfAtoms());
         
         final CartesianCoordinates aligned = new CartesianCoordinates(cartes);
         aligned.moveCoordsToCOM();
         
         // set up the kearsley matrix
-        final contrib.jama.Matrix matKearsley = new contrib.jama.Matrix(4,4);
-        setupKearsleyMatrix(refCartes, aligned.getAllXYZCoord(), matKearsley.getArray());
-
-        final contrib.jama.EigenvalueDecomposition eigen = new contrib.jama.EigenvalueDecomposition(matKearsley, true);
-        final contrib.jama.Matrix matEigenVec = eigen.getV();
-        final double[] evals = eigen.getRealEigenvalues();
-        /*
-        for(final double e : evals){
-            System.err.println("Eigenval " + e);
-        }*/
-
+        final org.ejml.data.DMatrixRMaj matKearsley = setupKearsleyMatrix(refCartes, aligned.getAllXYZCoord());
+        
+        final org.ejml.interfaces.decomposition.EigenDecomposition_F64<org.ejml.data.DMatrixRMaj> eig = org.ejml.dense.row.factory.DecompositionFactory_DDRM.eig(4, true,true);
+        eig.decompose(matKearsley);
+        final int noEigenVals = eig.getNumberOfEigenvalues();
+        if(noEigenVals == 0){
+            throw new Exception("Kearsely matrix decomposition has no eigenvalues.");
+        }
+        
+        int minEigenValueIndex = -1;
+        double minEigenValue = Double.MAX_VALUE;
+        for(int i = 0; i < noEigenVals; i++){
+            final org.ejml.data.Complex_F64 eval = eig.getEigenvalue(i);
+            if(!eval.isReal()){continue;} // do not check if the eigenvalue is complex and error (since symmetric matrices have no complex ones) - has caused numerical issues
+            final double d = eval.getReal();
+            if(d < minEigenValue){
+                minEigenValue = d;
+                minEigenValueIndex = i;
+            }
+        }
+        if(minEigenValueIndex <= 0){
+            throw new Exception("Kearsely matrix has no real eigenvalues - this shouldn't happen.");
+        }
+        
+        final org.ejml.data.DMatrixRMaj matEigenVec = eig.getEigenVector(minEigenValueIndex);
+        if(matEigenVec == null){
+            // this really shouldn't happen here as we checked above
+            throw new Exception("Kearsley matrix decomposition - minimal eigenvalue is complex, should not happen here.");
+        }
+        
         // calculate the rotation matrix
-        final double[][] rot = new double[3][3];
-        calculateRotationMatrix(matEigenVec.getArray(), rot);
+        final org.ejml.data.DMatrixRMaj rotMat = calculateRotationMatrix(matEigenVec);        
+        final org.ejml.data.DMatrixRMaj unrotCoordsMat = new org.ejml.data.DMatrixRMaj(aligned.getAllXYZCoord());
 
-        // rotate the cartesians
-        final double[][] newCartes = new double[3][cartes.getNoOfAtoms()];
-        TrivialLinearAlgebra.matMult(rot, aligned.getAllXYZCoord(), newCartes);
+        final org.ejml.data.DMatrixRMaj rotCoordsMat = new org.ejml.data.DMatrixRMaj(3, cartes.getNoOfAtoms());
 
-        aligned.setAllXYZ(newCartes);
+        org.ejml.dense.row.CommonOps_DDRM.mult(rotMat, unrotCoordsMat, rotCoordsMat);
 
-        final double rmsd = Math.sqrt(evals[0]/Math.min(refCartes[0].length,cartes.getNoOfAtoms()));
+        final double[][] xyzAligned = aligned.getAllXYZCoord();
+        final int startX = rotCoordsMat.getIndex(0,0);
+        final int startY = rotCoordsMat.getIndex(1,0);
+        final int startZ = rotCoordsMat.getIndex(2,0);
+
+        final int noAtoms = aligned.getNoOfAtoms();
+        final double[] rotCoordsMatData = rotCoordsMat.getData();
+        System.arraycopy(rotCoordsMatData, startX, xyzAligned[0], 0, noAtoms);
+        System.arraycopy(rotCoordsMatData, startY, xyzAligned[1], 0, noAtoms);
+        System.arraycopy(rotCoordsMatData, startZ, xyzAligned[2], 0, noAtoms);
+
+        final double rmsd = Math.sqrt(minEigenValue/Math.min(refCartes[0].length,cartes.getNoOfAtoms()));
         
         return new Tuple<>(aligned, rmsd);
     }
@@ -1660,6 +1825,9 @@ public final class CoordTranslation {
      */
     public static CartesianCoordinates alignTwoCartes(final CartesianCoordinates refCartes,
             final CartesianCoordinates cartes) {
+        
+        assert(refCartes != null);
+        assert(cartes != null);
 
         /*
          * first move the cartesian coordinate set to the COM. this might not be needed in all
@@ -1866,6 +2034,12 @@ public final class CoordTranslation {
      */
     public static double[][] cartesianToSphericalCoord(final double[][] xyz) {
 
+        assert(xyz != null);
+        assert(xyz.length == 3);
+        assert(xyz[0].length > 0);
+        assert(xyz[0].length == xyz[1].length);
+        assert(xyz[0].length == xyz[2].length);
+        
         final int noOfAtoms = xyz[0].length;
         final double[][] sphericalCoords = new double[3][noOfAtoms];
 
@@ -1911,6 +2085,12 @@ public final class CoordTranslation {
      * @return cartesian coordinates as a double[][]
      */
     public static double[][] sphericalToCartesianCoord(final double[][] spherical) {
+        
+        assert(spherical != null);
+        assert(spherical.length == 3);
+        assert(spherical[0].length > 0);
+        assert(spherical[0].length == spherical[1].length);
+        assert(spherical[0].length == spherical[2].length);
 
         final int noOfAtoms = spherical[0].length;
         final double[][] xyz = new double[3][noOfAtoms];
@@ -1952,19 +2132,26 @@ public final class CoordTranslation {
      * Sets the Kearsley matrix up.
      * @param refCoords The reference coordinate set, with the COM being 0.0,0.0,0.0.
      * @param coords The to be moved coordinate set, with the COM being 0.0,0.0,0.0.
-     * @param kearsley The kearsley matrix, needs to be initialized with zeros!
+     * @return The Kearsley matrix, needs to be initialized with zeros!
      */
-    private static void setupKearsleyMatrix(final double[][] refCoords, final double[][] coords, final double[][] kearsley) {
-        
-        assert(kearsley != null);
-        assert(kearsley.length == 4);
-        assert(kearsley[0].length == 4);
+    private static org.ejml.data.DMatrixRMaj setupKearsleyMatrix(final double[][] refCoords, final double[][] coords) {
 
+        assert(refCoords != null);
+        assert(coords != null);
+        assert(refCoords.length == 3);
+        assert(coords.length == 3);
+        
         final int noOfAtoms = refCoords[0].length;
 
         // set the actual kearsley matrix up
         final double[] diff = new double[3];
         final double[] summ = new double[3];
+        double kearsley00 = 0.0, kearsley01 = 0.0, kearsley02 = 0.0, kearsley03 = 0.0,
+                kearsley11 = 0.0, kearsley12 = 0.0, kearsley13 = 0.0, kearsley22 = 0.0,
+                kearsley23 = 0.0, kearsley33 = 0.0;
+        
+        // NOTE: this is clearly not an efficient way to set the matrix up, we'd
+        //   prefer to loop the other way round
         for (int i = 0; i < noOfAtoms; i++) {
 
             for(int j = 0; j < 3; j++){
@@ -1972,30 +2159,40 @@ public final class CoordTranslation {
                 summ[j] = refCoords[j][i] + coords[j][i];
             }
 
-            kearsley[0][0] += diff[0]*diff[0] + diff[1]*diff[1] + diff[2]*diff[2];
-            kearsley[0][1] += summ[1]*diff[2] - diff[1]*summ[2];
-            kearsley[0][2] += diff[0]*summ[2] - summ[0]*diff[2];
-            kearsley[0][3] += summ[0]*diff[1] - diff[0]*summ[1];
+            kearsley00 += diff[0]*diff[0] + diff[1]*diff[1] + diff[2]*diff[2];
+            kearsley01 += summ[1]*diff[2] - diff[1]*summ[2];
+            kearsley02 += diff[0]*summ[2] - summ[0]*diff[2];
+            kearsley03 += summ[0]*diff[1] - diff[0]*summ[1];
 
-            kearsley[1][1] += summ[1]*summ[1] + summ[2]*summ[2] + diff[0]*diff[0];
-            kearsley[1][2] += diff[0]*diff[1] - summ[0]*summ[1];
-            kearsley[1][3] += diff[0]*diff[2] - summ[0]*summ[2];
+            kearsley11 += summ[1]*summ[1] + summ[2]*summ[2] + diff[0]*diff[0];
+            kearsley12 += diff[0]*diff[1] - summ[0]*summ[1];
+            kearsley13 += diff[0]*diff[2] - summ[0]*summ[2];
 
-            kearsley[2][2] += summ[0]*summ[0] + summ[2]*summ[2] + diff[1]*diff[1];
-            kearsley[2][3] += diff[1]*diff[2] - summ[1]*summ[2];
+            kearsley22 += summ[0]*summ[0] + summ[2]*summ[2] + diff[1]*diff[1];
+            kearsley23 += diff[1]*diff[2] - summ[1]*summ[2];
 
-            kearsley[3][3] += summ[0]*summ[0] + summ[1]*summ[1] + diff[2]*diff[2];
+            kearsley33 += summ[0]*summ[0] + summ[1]*summ[1] + diff[2]*diff[2];
         }
 
-        /*
-         * only upper half is filled so far, we transpose this down now since the matrix is
-         * symmetric
-         */
-        for (int i = 0; i < 3; i++) {
-            for (int j = i+1; j < 4; j++) {
-                kearsley[j][i] = kearsley[i][j];
-            }
-        }
+        final org.ejml.data.DMatrixRMaj matKearsley = new org.ejml.data.DMatrixRMaj(4,4);
+        matKearsley.unsafe_set(0,0, kearsley00);
+        matKearsley.unsafe_set(0,1, kearsley01);
+        matKearsley.unsafe_set(0,2, kearsley02);
+        matKearsley.unsafe_set(0,3, kearsley03);
+        matKearsley.unsafe_set(1,0, kearsley01);
+        matKearsley.unsafe_set(1,1, kearsley11);
+        matKearsley.unsafe_set(1,2, kearsley12);
+        matKearsley.unsafe_set(1,3, kearsley13);
+        matKearsley.unsafe_set(2,0, kearsley02);
+        matKearsley.unsafe_set(2,1, kearsley12);
+        matKearsley.unsafe_set(2,2, kearsley22);
+        matKearsley.unsafe_set(2,3, kearsley23);
+        matKearsley.unsafe_set(3,0, kearsley03);
+        matKearsley.unsafe_set(3,1, kearsley13);
+        matKearsley.unsafe_set(3,2, kearsley23);
+        matKearsley.unsafe_set(3,3, kearsley33);
+        
+        return matKearsley;
     }
 
     /**
@@ -2004,28 +2201,37 @@ public final class CoordTranslation {
      * @param rot The minimum [3,3] rotation matrix, changed on exit.
      * @return The rotation matrix.
      */
-    private static void calculateRotationMatrix(final double[][] eigen, final double[][] rot) {
+    private static org.ejml.data.DMatrixRMaj calculateRotationMatrix(final org.ejml.data.DMatrixRMaj eigen) {
         
-        assert(rot != null);
-        assert(rot.length >= 3);
-        assert(rot[0].length >= 3);
-
-        final double q1 = eigen[0][0];
-        final double q2 = eigen[1][0];
-        final double q3 = eigen[2][0];
-        final double q4 = eigen[3][0];
+        final org.ejml.data.DMatrixRMaj rot = new org.ejml.data.DMatrixRMaj(3,3);
         
-        rot[0][0] = q1*q1 + q2*q2 - q3*q3 - q4*q4;
-        rot[0][1] = 2 * (q2*q3 + q1*q4);
-        rot[0][2] = 2 * (q2*q4 - q1*q3);
+        final double q1 = eigen.get(0,0);
+        final double q2 = eigen.get(1,0);
+        final double q3 = eigen.get(2,0);
+        final double q4 = eigen.get(3,0);
+        
+        final double rot00 = q1*q1 + q2*q2 - q3*q3 - q4*q4;
+        rot.unsafe_set(0, 0, rot00);
+        final double rot01 = 2 * (q2*q3 + q1*q4);
+        rot.unsafe_set(0, 1, rot01);
+        final double rot02 = 2 * (q2*q4 - q1*q3);
+        rot.unsafe_set(0, 2, rot02);
 
-        rot[1][0] = 2 * (q2*q3 - q1*q4);
-        rot[1][1] = q1*q1 + q3*q3 - q2*q2 - q4*q4;
-        rot[1][2] = 2 * (q3*q4 + q1*q2);
+        final double rot10 = 2 * (q2*q3 - q1*q4);
+        rot.unsafe_set(1, 0, rot10);
+        final double rot11 = q1*q1 + q3*q3 - q2*q2 - q4*q4;
+        rot.unsafe_set(1, 1, rot11);
+        final double rot12 = 2 * (q3*q4 + q1*q2);
+        rot.unsafe_set(1, 2, rot12);        
 
-        rot[2][0] = 2 * (q2*q4 + q1*q3);
-        rot[2][1] = 2 * (q3*q4 - q1*q2);
-        rot[2][2] = q1*q1 + q4*q4 - q2*q2 - q3*q3;
+        final double rot20 = 2 * (q2*q4 + q1*q3);
+        rot.unsafe_set(2, 0, rot20);
+        final double rot21 = 2 * (q3*q4 - q1*q2);
+        rot.unsafe_set(2, 1, rot21);
+        final double rot22 = q1*q1 + q4*q4 - q2*q2 - q3*q3;
+        rot.unsafe_set(2, 2, rot22);
+        
+        return rot;
     }
     
     /**
@@ -2038,8 +2244,14 @@ public final class CoordTranslation {
      */
     public static double[][] rotatePointToZAxis(final double[][] xyz, final double[] point, final int ats){
         
+        assert(xyz != null);
         assert(xyz.length == 3);
-        assert(ats == xyz[0].length);
+        assert(ats >= 0);
+        assert(ats <= xyz[0].length);
+        assert(ats <= xyz[1].length);
+        assert(ats <= xyz[2].length);
+        assert(point != null);
+        assert(point.length == 3);
         
         // strategy: use the Euler angle rotation and determine the necessary Euler angles
 

--- a/src/org/ogolem/core/TIP3PForceField.java
+++ b/src/org/ogolem/core/TIP3PForceField.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2015, J. M. Dieterich
+              2019, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,7 +48,7 @@ import org.ogolem.math.GenericLookup;
  * Provides the TIP3P force field for an simple (and very biased) description of water clusters.
  * Numerical data from http://www1.lsbu.ac.uk/water/water_models.html and wiki
  * @author Johannes Dieterich
- * @version 2015-01-11
+ * @version 2019-12-28
  */
 public class TIP3PForceField implements RigidBodyBackend {
 
@@ -154,10 +155,9 @@ public class TIP3PForceField implements RigidBodyBackend {
         
         // first figure out whether the the first three could be a water
         final short[] atomNos = ref.getMoleculeAtPosition(0).getAtomNumbers();
-        if(atomNos[0] == 8
+        if(!(atomNos.length == 3 && atomNos[0] == 8
                 && atomNos[1] == 1
-                && atomNos[2] == 1){
-        } else{
+                && atomNos[2] == 1)){
             System.err.println("ERROR: We figured out that this is no suitable water (in O/H/H order) cluster!");
             return false;
         }
@@ -167,9 +167,7 @@ public class TIP3PForceField implements RigidBodyBackend {
             
             final short[] atomNosMol = ref.getMoleculeAtPosition(mol).getAtomNumbers();
             // check whether all molecules are having the right order
-            if (atomNosMol[0] == 8 && atomNosMol[1] == 1 && atomNosMol[2] == 1) {
-                // good
-            } else {
+            if (!(atomNosMol.length == 3 && atomNosMol[0] == 8 && atomNosMol[1] == 1 && atomNosMol[2] == 1)) {
                 // something is f***** up
                 System.err.println("ERROR: Some parts of your cluster aren't water (in O/H/H order).");
                 return false;

--- a/src/org/ogolem/core/TIP4PForceField.java
+++ b/src/org/ogolem/core/TIP4PForceField.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2015, J. M. Dieterich
+              2019, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,7 +49,7 @@ import org.ogolem.math.TrivialLinearAlgebra;
  * Provides the TIP4P force field for an simple description of water clusters.
  * Numerical data from http://www1.lsbu.ac.uk/water/water_models.html and wiki
  * @author Johannes Dieterich
- * @version 2015-01-08
+ * @version 2019-12-28
  */
 public class TIP4PForceField implements RigidBodyBackend {
 
@@ -161,10 +162,9 @@ public class TIP4PForceField implements RigidBodyBackend {
         
         // first figure out whether the the first three could be a water
         final short[] atomNos = ref.getMoleculeAtPosition(0).getAtomNumbers();
-        if(atomNos[0] == 8
+        if(!(atomNos.length == 3 && atomNos[0] == 8
                 && atomNos[1] == 1
-                && atomNos[2] == 1){
-        } else{
+                && atomNos[2] == 1)){
             System.err.println("ERROR: We figured out that this is no suitable water (in O/H/H order) cluster!");
             return false;
         }
@@ -174,9 +174,7 @@ public class TIP4PForceField implements RigidBodyBackend {
             
             final short[] atomNosMol = ref.getMoleculeAtPosition(mol).getAtomNumbers();
             // check whether all molecules are having the right order
-            if (atomNosMol[0] == 8 && atomNosMol[1] == 1 && atomNosMol[2] == 1) {
-                // good
-            } else {
+            if (!(atomNosMol.length == 3 && atomNosMol[0] == 8 && atomNosMol[1] == 1 && atomNosMol[2] == 1)) {
                 // something is f***** up
                 System.err.println("ERROR: Some parts of your cluster aren't water (in O/H/H order).");
                 return false;

--- a/src/org/ogolem/general/MainOgolem.java
+++ b/src/org/ogolem/general/MainOgolem.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2019, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@ package org.ogolem.general;
 /**
  * The unified entry point to the OGOLEM framework.
  * @author Johannes Dieterich
- * @version 2016-01-26
+ * @version 2019-12-29
  */
 public class MainOgolem {
 
@@ -96,6 +96,8 @@ public class MainOgolem {
             org.ogolem.ljreferences.MainLJRefs.main(strippedArgs);
         } else if(args[0].equalsIgnoreCase("--md")){
             org.ogolem.md.MainMolecularDynamics.run(strippedArgs);
+        } else if(args[0].equalsIgnoreCase("--microbenchmarks")){
+            org.ogolem.microbenchmarks.MainMicroBenchmarks.run(strippedArgs);
         } else if(args[0].equalsIgnoreCase("--ogo2atom")){
             org.ogolem.atom2ogo.MainOgo2Atom.run(strippedArgs);
         } else if(args[0].equalsIgnoreCase("--parameters")){
@@ -176,6 +178,8 @@ public class MainOgolem {
             System.out.println("     for ejecting LJ reference structures (deprecated!)");
             System.out.println("   --md");
             System.out.println("     for running simple molecular dynamics");
+            System.out.println("   --microbenchmarks");
+            System.out.println("     for running some micro benchmarks");
             System.out.println("   --molecules");
             System.out.println("     to optimize molecules with respect to a or multiple properties");
             System.out.println("   --ogo2atom");

--- a/src/org/ogolem/microbenchmarks/AligningBench.java
+++ b/src/org/ogolem/microbenchmarks/AligningBench.java
@@ -1,0 +1,70 @@
+/**
+Copyright (c) 2019, J. M. Dieterich and B. Hartke
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * All advertising materials mentioning features or use of this software
+      must display the following acknowledgement:
+
+      This product includes software of the ogolem.org project developed by
+      J. M. Dieterich and B. Hartke (Christian-Albrechts-University Kiel, Germany)
+      and contributors.
+
+    * Neither the name of the ogolem.org project, the University of Kiel
+      nor the names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.ogolem.microbenchmarks;
+
+import org.ogolem.core.CartesianCoordinates;
+import org.ogolem.core.CoordTranslation;
+import org.ogolem.helpers.Tuple;
+
+/**
+ * Benchmark aligning of Cartesian coordinates.
+ * @author Johannes Dieterich
+ * @version 2019-12-29
+ */
+class AligningBench implements SingleMicroBenchmark {
+
+    private final CartesianCoordinates reference;
+    private final CartesianCoordinates toBeRotated;
+    
+    AligningBench(){
+        this.reference = CartesianCoordinatesLibrary.getKanamycinAMP2Opt();
+        this.toBeRotated = CartesianCoordinatesLibrary.getKanamycinAPM3Opt();
+    }
+    
+    @Override
+    public double runSingle() throws Exception {
+        
+        final Tuple<CartesianCoordinates, Double> tup = CoordTranslation.alignTwoCartesians(reference, toBeRotated);
+        
+        return tup.getObject2();
+    }
+
+    @Override
+    public String name() {
+        return "aligning bench";
+    }
+}

--- a/src/org/ogolem/microbenchmarks/CartesianCoordinatesLibrary.java
+++ b/src/org/ogolem/microbenchmarks/CartesianCoordinatesLibrary.java
@@ -1,0 +1,220 @@
+/**
+Copyright (c) 2019, J. M. Dieterich and B. Hartke
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * All advertising materials mentioning features or use of this software
+      must display the following acknowledgement:
+
+      This product includes software of the ogolem.org project developed by
+      J. M. Dieterich and B. Hartke (Christian-Albrechts-University Kiel, Germany)
+      and contributors.
+
+    * Neither the name of the ogolem.org project, the University of Kiel
+      nor the names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.ogolem.microbenchmarks;
+
+import org.ogolem.core.CartesianCoordinates;
+import org.ogolem.core.Input;
+
+/**
+ * A library of cartesian coordinates which may be used for benchmarks.
+ * @author Johannes Dieterich
+ * @version 2019-12-29
+ */
+class CartesianCoordinatesLibrary {
+    
+    private static final String KANAMP2 = "69\n" +
+"Coordinates from ORCA-job kana_mp2_tzvpp\n" +
+"  C       0.539877     -0.718820     -1.345908\n" +
+"  C       1.842787     -1.478957     -1.530449\n" +
+"  C       3.003270     -0.488603     -1.510472\n" +
+"  C       0.520974      0.155488     -0.096000\n" +
+"  C       1.704985      1.110411     -0.081472\n" +
+"  C       3.027505      0.347587     -0.235315\n" +
+"  O       1.719178      1.813495      1.165317\n" +
+"  O      -0.576126     -1.607260     -1.193129\n" +
+"  C      -1.384640     -1.852469     -2.311705\n" +
+"  C      -2.845542     -1.727565     -1.884469\n" +
+"  C      -2.871644     -4.174946     -1.418625\n" +
+"  C      -1.422689     -4.199451     -1.925754\n" +
+"  O      -1.163813     -3.136386     -2.854913\n" +
+"  C      -3.218924     -2.800245     -0.874414\n" +
+"  C       1.821754      3.216921      1.054069\n" +
+"  C       2.278243      3.739900      2.414517\n" +
+"  C      -0.117131      4.233862      2.911889\n" +
+"  C      -0.454931      3.595108      1.568432\n" +
+"  O       0.618991      3.813289      0.644922\n" +
+"  H       0.377796     -0.083677     -2.223230\n" +
+"  H       1.947077     -2.167573     -0.680658\n" +
+"  H       2.915176      0.166303     -2.383549\n" +
+"  H       3.952245     -1.019037     -1.602156\n" +
+"  H       0.591132     -0.493752      0.785206\n" +
+"  H       1.583934      1.828559     -0.899560\n" +
+"  H       3.111165     -0.321982      0.626414\n" +
+"  H      -1.145144     -1.154838     -3.115863\n" +
+"  H      -3.476617     -1.848726     -2.767286\n" +
+"  H      -3.543839     -4.385811     -2.261002\n" +
+"  H      -0.757996     -4.101916     -1.061167\n" +
+"  H      -2.648738     -2.640471      0.045348\n" +
+"  H       2.551242      4.788436      2.302612\n" +
+"  H       0.029449      5.311738      2.771937\n" +
+"  H      -0.612944      2.523360      1.702426\n" +
+"  C       1.170146      3.632421      3.454577\n" +
+"  H       0.969540      2.566741      3.632935\n" +
+"  H       2.546252      3.481220      0.282559\n" +
+"  O      -0.684751      0.903106     -0.059763\n" +
+"  H      -1.401992      0.287446     -0.271964\n" +
+"  N       1.808287     -2.159880     -2.825613\n" +
+"  N       4.219460      1.192617     -0.232515\n" +
+"  H       1.038236     -2.819328     -2.859768\n" +
+"  H       2.662185     -2.687837     -2.960334\n" +
+"  H       4.204490      1.815862     -1.032183\n" +
+"  H       4.238452      1.777282      0.595218\n" +
+"  C      -1.674443      4.197253      0.888122\n" +
+"  O      -2.870040      3.976929      1.644354\n" +
+"  H      -1.757296      3.776317     -0.114729\n" +
+"  H      -1.564464      5.277304      0.805936\n" +
+"  H      -3.051073      3.032644      1.622854\n" +
+"  O       3.462164      3.067196      2.832428\n" +
+"  O      -1.125289      3.986346      3.885086\n" +
+"  H       3.235980      2.130169      2.837461\n" +
+"  H      -1.972400      4.177883      3.464049\n" +
+"  N       1.576099      4.356615      4.655856\n" +
+"  H       2.418760      3.937451      5.029964\n" +
+"  H       0.851417      4.259236      5.356683\n" +
+"  O      -3.093196     -0.459714     -1.266388\n" +
+"  H      -3.313690      0.178328     -1.950336\n" +
+"  O      -3.049544     -5.108992     -0.374336\n" +
+"  H      -2.676875     -5.942309     -0.703736\n" +
+"  O      -4.612543     -2.763547     -0.618480\n" +
+"  H      -4.801840     -1.892409     -0.257028\n" +
+"  C      -1.090438     -5.468702     -2.702923\n" +
+"  H      -0.090679     -5.357245     -3.132550\n" +
+"  H      -1.795442     -5.555125     -3.530071\n" +
+"  N      -1.233797     -6.657263     -1.848478\n" +
+"  H      -1.218792     -7.495069     -2.415286\n" +
+"  H      -0.448448     -6.726317     -1.212296";
+    
+    private static final String KANAPM3 = "69\n" +
+" \n" +
+"  C    0.609720698    -0.798206372    -1.459959438  \n" +
+"  C    1.994419034    -1.485478547    -1.507660218  \n" +
+"  C    3.090108203    -0.417904626    -1.534996023  \n" +
+"  C    0.505135008     0.172107564    -0.240760977  \n" +
+"  C    1.684712378     1.186533579    -0.205179979  \n" +
+"  C    3.040251301     0.428504198    -0.263034288  \n" +
+"  O    1.596711385     1.861219429     1.054955515  \n" +
+"  O   -0.386758726    -1.810299294    -1.254143909  \n" +
+"  C   -1.352750176    -1.927762211    -2.275998499  \n" +
+"  C   -2.806494310    -1.741055772    -1.740561033  \n" +
+"  C   -2.946246949    -4.238799565    -1.486112891  \n" +
+"  C   -1.466521247    -4.308352913    -1.956029225  \n" +
+"  O   -1.130415814    -3.208718819    -2.807834861  \n" +
+"  C   -3.194982103    -2.885431948    -0.768859778  \n" +
+"  C    1.784029118     3.263577749     1.036103863  \n" +
+"  C    2.269276475     3.717402010     2.453066198  \n" +
+"  C   -0.129395399     4.315097201     2.959250657  \n" +
+"  C   -0.496147048     3.731877987     1.565464092  \n" +
+"  O    0.580339095     3.865045105     0.639001703  \n" +
+"  H    0.416240678    -0.243654076    -2.415276783  \n" +
+"  H    2.114678182    -2.111838261    -0.583258158  \n" +
+"  H    2.980358725     0.223448474    -2.434714196  \n" +
+"  H    4.087254370    -0.896065474    -1.627422949  \n" +
+"  H    0.493175342    -0.420277568     0.708975650  \n" +
+"  H    1.595552770     1.899264875    -1.063191414  \n" +
+"  H    3.123294088    -0.239384323     0.631215660  \n" +
+"  H   -1.143388153    -1.257538822    -3.145248365  \n" +
+"  H   -3.497788325    -1.744440614    -2.620894507  \n" +
+"  H   -3.637855647    -4.335220551    -2.360452456  \n" +
+"  H   -0.786171037    -4.300672525    -1.068202782  \n" +
+"  H   -2.599040214    -2.822639064     0.175365486  \n" +
+"  H    2.636988787     4.768410637     2.377412302  \n" +
+"  H    0.045182904     5.417945524     2.881519764  \n" +
+"  H   -0.761071613     2.648455058     1.660167103  \n" +
+"  C    1.137369302     3.616903250     3.508243243  \n" +
+"  H    0.902569459     2.535135290     3.698569606  \n" +
+"  H    2.483433801     3.606046016     0.236881459  \n" +
+"  O   -0.674549880     0.942341826    -0.320894162  \n" +
+"  H   -1.402950703     0.336001072    -0.453785121  \n" +
+"  N    2.109623490    -2.312398315    -2.742815652  \n" +
+"  N    4.234877299     1.306355355    -0.229108126  \n" +
+"  H    1.410016772    -3.024837037    -2.739187356  \n" +
+"  H    3.012119395    -2.739488086    -2.763001761  \n" +
+"  H    4.186050636     1.976209144    -0.969298432  \n" +
+"  H    4.278802085     1.785064689     0.646466915  \n" +
+"  C   -1.680378281     4.509902399     0.947548006  \n" +
+"  O   -2.831226892     4.365229305     1.747269493  \n" +
+"  H   -1.871502598     4.192344451    -0.094800971  \n" +
+"  H   -1.507628045     5.601041258     0.946792440  \n" +
+"  H   -3.165613006     3.487906750     1.601153074  \n" +
+"  O    3.432548074     3.027823627     2.832684435  \n" +
+"  O   -1.182420703     4.083764011     3.875479897  \n" +
+"  H    3.202295645     2.114360501     2.959033593  \n" +
+"  H   -1.983694369     4.350633127     3.420588993  \n" +
+"  N    1.587694565     4.311715926     4.746858885  \n" +
+"  H    2.361793775     3.815358470     5.135321376  \n" +
+"  H    0.842690663     4.335304998     5.409959977  \n" +
+"  O   -2.873983226    -0.462869826    -1.143092379  \n" +
+"  H   -3.714646419    -0.407495309    -0.706026778  \n" +
+"  O   -3.248955053    -5.266102400    -0.567632880  \n" +
+"  H   -2.809879118    -6.056741232    -0.904342699  \n" +
+"  O   -4.562001508    -2.693628392    -0.458782780  \n" +
+"  H   -4.843572759    -3.460781380     0.021467258  \n" +
+"  C   -1.216365541    -5.570682126    -2.806043080  \n" +
+"  H   -0.195080392    -5.542244351    -3.242180674  \n" +
+"  H   -1.916599729    -5.600056551    -3.665991196  \n" +
+"  N   -1.448984306    -6.771075073    -1.961248900  \n" +
+"  H   -1.602332717    -7.563988181    -2.547228956  \n" +
+"  H   -0.647145512    -6.939997801    -1.389454007  ";
+    
+    static CartesianCoordinates getKanamycinAPM3Opt(){
+        
+        try {
+            final String[] fileCont = KANAMP2.split("\n");
+            final CartesianCoordinates kana = Input.parseCartesFromFileData(fileCont, 1, new int[]{69}, new short[69], new float[69]);
+            
+            return kana;
+        } catch(Exception e){
+            System.err.println("Failure to create kanamycin A MP2 cartesians. This should never happen!");
+        }
+        
+        return null;
+    }
+    
+    static CartesianCoordinates getKanamycinAMP2Opt(){
+        
+        try {
+            final String[] fileCont = KANAPM3.split("\n");
+            final CartesianCoordinates kana = Input.parseCartesFromFileData(fileCont, 1, new int[]{69}, new short[69], new float[69]);
+            
+            return kana;
+        } catch(Exception e){
+            System.err.println("Failure to create kanamycin A PM3 cartesians. This should never happen!");
+        }
+        
+        return null;
+    }
+}

--- a/src/org/ogolem/microbenchmarks/MainMicroBenchmarks.java
+++ b/src/org/ogolem/microbenchmarks/MainMicroBenchmarks.java
@@ -1,0 +1,129 @@
+/**
+Copyright (c) 2019, J. M. Dieterich and B. Hartke
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * All advertising materials mentioning features or use of this software
+      must display the following acknowledgement:
+
+      This product includes software of the ogolem.org project developed by
+      J. M. Dieterich and B. Hartke (Christian-Albrechts-University Kiel, Germany)
+      and contributors.
+
+    * Neither the name of the ogolem.org project, the University of Kiel
+      nor the names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.ogolem.microbenchmarks;
+
+import org.ogolem.helpers.StatisticUtils;
+import org.ogolem.helpers.Tuple;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Designed to run microbenchmarks of some performance-critical functionalities
+ * of ogolem.
+ * Benchmarked functionalities should be micro - hence fast to benchmark and
+ * fundamental.
+ * @author Johannes Dieterich
+ * @version 2019-12-29
+ */
+public class MainMicroBenchmarks {
+    
+    private static final Logger LOG = LoggerFactory.getLogger(MainMicroBenchmarks.class);
+    
+    /*
+    number of macro iterations for performance benchmarking
+    */
+    private static final int NOPERFMACROITERATIONS = 3;
+        
+    /*
+    number of micro iterations for performance benchmarking
+    */
+    private static final int NOPERFMICROITERATIONS = 1000;
+        
+    /*
+    this should be a threshold large enough to ensure the JIT kicks in and
+    optimizes the functions. Typical rule of thumb is 1000 function calls
+    will do that - so play it safe
+    */
+    private static final int NOWARMUPITERATIONS = 10000;
+    
+    public static void run(final String[] args){
+        
+        // run aligning benchmark
+        final AligningBench alignBench = new AligningBench();
+        runOne(alignBench, 1000);
+        
+    }
+    
+    /**
+     * Run one micro benchmark
+     * @param bench the micro benchmark
+     * @param microBenchMultiplier multiplier for the micro perf iterations. Should be selected to yield a macro iteration larger than 1000 ms.
+     */
+    private static void runOne(final SingleMicroBenchmark bench, final int microBenchMultiplier){
+        
+        final String name = bench.name();
+        
+        // first do the warmup iterations to give JIT/JVM some time to equillibrate
+        LOG.debug("Benchmark " + name + " warming up...");
+        double sideEffectAvoider = 0.0;
+        try{
+            for(int i = 0; i < NOWARMUPITERATIONS; i++){
+                sideEffectAvoider += bench.runSingle();
+            }
+        } catch (Exception e){
+            System.err.println("ERROR: Failure in warm up - should never happen!");
+            e.printStackTrace(System.err);
+        }
+        LOG.debug("Benchmark " + name + " side effect avoider (warmup) " + sideEffectAvoider);
+        
+        // now do the real performance run
+        final double[] times = new double[NOPERFMACROITERATIONS];
+        LOG.debug("Benchmark " + name + " starting...");        
+        
+        for(int macro = 0; macro < NOPERFMACROITERATIONS; macro++){
+            sideEffectAvoider = 0.0;
+            final long tStart = System.currentTimeMillis();
+            try{
+                for(int i = 0; i < NOPERFMICROITERATIONS*microBenchMultiplier; i++){
+                    sideEffectAvoider += bench.runSingle();
+                }
+            } catch (Exception e){
+                System.err.println("ERROR: Failure in perf run - should never happen!");
+                e.printStackTrace(System.err);
+            }
+            
+            long tEnd = System.currentTimeMillis();
+            LOG.debug("Benchmark " + name + " side effect avoider (perf run) " + sideEffectAvoider);
+            times[macro] = (tEnd-tStart);
+        }
+        
+        final Tuple<Double,Double> meanStdDev = StatisticUtils.meanAndStdDev(times);
+        
+        LOG.info("Benchmark " + name + " took " + Math.round(meanStdDev.getObject1()) + " +/- " + Math.round(meanStdDev.getObject2()) + " ms per macro iteration\n"
+            + "                         or " + Math.round(1000.0/meanStdDev.getObject1()*microBenchMultiplier*NOPERFMICROITERATIONS) + " calls per second on average");
+    }
+}

--- a/src/org/ogolem/microbenchmarks/SingleMicroBenchmark.java
+++ b/src/org/ogolem/microbenchmarks/SingleMicroBenchmark.java
@@ -1,0 +1,54 @@
+/**
+Copyright (c) 2019, J. M. Dieterich and B. Hartke
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * All advertising materials mentioning features or use of this software
+      must display the following acknowledgement:
+
+      This product includes software of the ogolem.org project developed by
+      J. M. Dieterich and B. Hartke (Christian-Albrechts-University Kiel, Germany)
+      and contributors.
+
+    * Neither the name of the ogolem.org project, the University of Kiel
+      nor the names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package org.ogolem.microbenchmarks;
+
+/**
+ * Interface for a single microbenchmark.
+ * @author Johannes Dieterich
+ * @version 2019-12-29
+ */
+public interface SingleMicroBenchmark {
+    
+    /**
+     * Run a single microbenchmark.
+     * @throws exceptions possible but of course shouldn't happen in a benchmark
+     * @return a double - this value can be meaningless but must be sufficiently much of a side-effect that the JIT compiler cannot eliminate "dead" code which in real production actually runs
+     */
+    double runSingle() throws Exception;
+    
+    String name();
+}

--- a/tests/org/ogolem/core/RigidBodyCoordinatesTest.java
+++ b/tests/org/ogolem/core/RigidBodyCoordinatesTest.java
@@ -1043,7 +1043,7 @@ public class RigidBodyCoordinatesTest {
         try{
             ar = Input.parseCartesFromFileData(lj, 1, atsPerMol, spins, charges);
         } catch(Exception e){
-            throw new Error("Error to parse in known w20 global minimum.",e);
+            throw new Error("Error to parse in Ar single atom.",e);
         }
         
         final int noOfMols = 1;


### PR DESCRIPTION
In detail:

    Fix a wrong error output.
    Make checking of whether something is water or not a bit more stable.
    Import latest ejml release.

    Switch Kearsley matrix alignment strategy to ejml.

    Now, there is a lot that could be done beyond this. However, this is the first step to get rid of Jama and replace it with a more efficient and maintained (!) alternative. So for now, I am not too worried that we are leaving still more performance on the table in these routines - as important as they are. In general, there is more to do in CoordTranslation (I'd like to get rid of a lot of the scratch arrays etc)

    While there, add a whole bunch of asserts to public functions and do some minor cosmetic stuff.

    Annotate the matrix row/col size for the factory
    Don't call it svd when it's eig
    Add a microbenchmarking package and a microbenchmark for the aligning functionality.