### PR TITLE
Major refactor to switch to Copyable versus using Cloneable.

### DIFF
--- a/src/org/ogolem/adaptive/AdaptiveMopacCaller.java
+++ b/src/org/ogolem/adaptive/AdaptiveMopacCaller.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -53,12 +53,12 @@ import org.ogolem.properties.Property;
 /**
  * Provides global optimization of MOPAC parameters.
  * @author Johannes Dieterich
- * @version 2016-09-02
+ * @version 2020-04-29
  */
 public final class AdaptiveMopacCaller extends AbstractAdaptivable implements Newton{
 
     // the ID
-    private static final long serialVersionUID = (long) 20101108;
+    private static final long serialVersionUID = (long) 20200429;
 
     private static long noOfGeomLocalOpts = (long) 0;
     private static long noOfMolLocalOpts = (long) 0;
@@ -96,7 +96,7 @@ public final class AdaptiveMopacCaller extends AbstractAdaptivable implements Ne
         this.azoBenzene = orig.azoBenzene;
         this.doSanityCheck = orig.doSanityCheck;
         this.blowBonds = orig.blowBonds;
-        this.parameters = (orig.parameters == null) ? null : orig.parameters.clone();
+        this.parameters = (orig.parameters == null) ? null : orig.parameters.copy();
     }
 
     @Override

--- a/src/org/ogolem/adaptive/AdaptiveParameters.java
+++ b/src/org/ogolem/adaptive/AdaptiveParameters.java
@@ -54,12 +54,12 @@ import org.ogolem.generic.ContinuousProblem;
  * cache is not thread-safe. Therefore in a multi-threaded environment, it is
  * absolutely required to generate a copy of this class for each thread.
  * @author Johannes Dieterich
- * @version 2020-03-21
+ * @version 2020-04-29
  */
 public class AdaptiveParameters extends ContinuousProblem<Double> {
 
     // for serialization purposes
-    private static final long serialVersionUID = (long) 20150730;
+    private static final long serialVersionUID = (long) 20200429;
 
     private final HashMap<String,int[]> hashPosition;
     private final String forMethod;
@@ -291,7 +291,7 @@ public class AdaptiveParameters extends ContinuousProblem<Double> {
     }
     
     @Override
-    public AdaptiveParameters clone(){
+    public AdaptiveParameters copy(){
         return new AdaptiveParameters(this);
     }
 

--- a/src/org/ogolem/adaptive/ArcticAdaptiveCrossover.java
+++ b/src/org/ogolem/adaptive/ArcticAdaptiveCrossover.java
@@ -50,7 +50,7 @@ import org.ogolem.random.RandomUtils;
  * alleles.
  *
  * @author Mark Dittner
- * @version 2020-04-25
+ * @version 2020-04-29
  */
 class ArcticAdaptiveCrossover implements GenericCrossover<Double, AdaptiveParameters> {
 
@@ -82,8 +82,8 @@ class ArcticAdaptiveCrossover implements GenericCrossover<Double, AdaptiveParame
     public Tuple<AdaptiveParameters, AdaptiveParameters> crossover(AdaptiveParameters mother,
             AdaptiveParameters father, long futureID) {
 
-        final AdaptiveParameters child1 = mother.clone();
-        final AdaptiveParameters child2 = father.clone();
+        final AdaptiveParameters child1 = mother.copy();
+        final AdaptiveParameters child2 = father.copy();
         final Double[] genomeChild1 = child1.getGenomeCopy();
         final Double[] genomeChild2 = child2.getGenomeCopy();
 

--- a/src/org/ogolem/adaptive/FitFuncToBackend.java
+++ b/src/org/ogolem/adaptive/FitFuncToBackend.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,11 +42,11 @@ import org.ogolem.generic.GenericBackend;
 /**
  * An adapter from adaptivable to backend.
  * @author Johannes Dieterich
- * @version 2015-03-28
+ * @version 2020-04-29
  */
 final class FitFuncToBackend implements GenericBackend<Double,AdaptiveParameters> {
     
-    private static final long serialVersionUID = (long) 20150323;
+    private static final long serialVersionUID = (long) 2020429;
     
     private final GenericFitnessFunction fitfunc;
     private final boolean normParams;
@@ -71,7 +71,7 @@ final class FitFuncToBackend implements GenericBackend<Double,AdaptiveParameters
     }
     
     @Override
-    public GenericBackend<Double, AdaptiveParameters> clone() {
+    public GenericBackend<Double, AdaptiveParameters> copy() {
         return new FitFuncToBackend(this);
     }
     

--- a/src/org/ogolem/adaptive/GenericParameterDarwin.java
+++ b/src/org/ogolem/adaptive/GenericParameterDarwin.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,11 +47,11 @@ import org.ogolem.generic.IndividualWriter;
 /**
  * A generified (or de-generified?) Darwin implementation based off GenericAbstractDarwin.
  * @author Johannes Dieterich
- * @version 2014-05-02
+ * @version 2020-04-29
  */
 public class GenericParameterDarwin extends GenericAbstractDarwin<Double,AdaptiveParameters> {
     
-    private static final long serialVersionUID = (long) 20140502;
+    private static final long serialVersionUID = (long) 20200429;
 
     GenericParameterDarwin(final GenericCrossover<Double,AdaptiveParameters> cross, final GenericMutation<Double,AdaptiveParameters> mut,
             final GenericSanityCheck<Double,AdaptiveParameters> sanity, final GenericFitnessFunction<Double,AdaptiveParameters> fitness,
@@ -65,7 +66,7 @@ public class GenericParameterDarwin extends GenericAbstractDarwin<Double,Adaptiv
     }
     
     @Override
-    public GenericParameterDarwin clone() {
+    public GenericParameterDarwin copy() {
         return new GenericParameterDarwin(this);
     }
 

--- a/src/org/ogolem/adaptive/MainOgoAdaptive.java
+++ b/src/org/ogolem/adaptive/MainOgoAdaptive.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -60,7 +60,7 @@ import org.ogolem.properties.Energy;
 /**
  * The main class of the adaptive package designed to do a paramterization.
  * @author Johannes Dieterich
- * @version 2016-07-20
+ * @version 2020-04-29
  */
 public class MainOgoAdaptive {
 
@@ -192,7 +192,7 @@ public class MainOgoAdaptive {
                 params = gate.createInitialParameterStub(adapConf.getAllReferenceGeoms(), sMethod);
             }
         }
-        adapConf.paramExample = params.clone();
+        adapConf.paramExample = params.copy();
 
         // let's first check wether there is any borders file
         final String sBorderFile = configFile.substring(0,configFile.lastIndexOf(".")) + "-borders.aux";

--- a/src/org/ogolem/adaptive/ParameterInit.java
+++ b/src/org/ogolem/adaptive/ParameterInit.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +44,11 @@ import org.ogolem.generic.GenericInitializer;
 /**
  * An adapter from the generic to ParameterInit. One day remove..
  * @author Johannes Dieterich
- * @version 2014-05-02
+ * @version 2020-04-29
  */
 public class ParameterInit implements GenericInitializer<Double,AdaptiveParameters>{
     
-    private static final long serialVersionUID = (long) 20140502;
+    private static final long serialVersionUID = (long) 20200429;
     private final Random random = new Random();
     private final GenericFitnessFunction<Double,AdaptiveParameters> fitness;
     private final double[] lower;
@@ -63,11 +64,11 @@ public class ParameterInit implements GenericInitializer<Double,AdaptiveParamete
     ParameterInit(final ParameterInit orig){
         this.upper = orig.upper.clone();
         this.lower = orig.lower.clone();
-        this.fitness = orig.fitness.clone();
+        this.fitness = orig.fitness.copy();
     }
 
     @Override
-    public GenericInitializer<Double, AdaptiveParameters> clone() {
+    public GenericInitializer<Double, AdaptiveParameters> copy() {
         return new ParameterInit(this);
     }
 

--- a/src/org/ogolem/adaptive/ParameterReader.java
+++ b/src/org/ogolem/adaptive/ParameterReader.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2017, J. M. Dieterich and B. Hartke
+              2017-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,15 +45,15 @@ import org.slf4j.LoggerFactory;
 /**
  * A reader for parameters.
  * @author Johannes Dieterich
- * @version 2017-11-16
+ * @version 2020-04-29
  */
 public class ParameterReader implements IndividualReader<AdaptiveParameters>{
 
-    private static final long serialVersionUID = (long) 20140502;
+    private static final long serialVersionUID = (long) 20200429;
     private static final Logger LOG = LoggerFactory.getLogger(ParameterReader.class);
     
     @Override
-    public IndividualReader<AdaptiveParameters> clone() {
+    public IndividualReader<AdaptiveParameters> copy() {
         return new ParameterReader();
     }
 

--- a/src/org/ogolem/adaptive/RangedFitFuncToBackend.java
+++ b/src/org/ogolem/adaptive/RangedFitFuncToBackend.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,11 +46,11 @@ import org.ogolem.generic.GenericBackend;
  * A ranged fitness function. E.g., it can be used to optimize only a subset
  * of parameters.
  * @author Johannes Dieterich
- * @version 2015-04-04
+ * @version 2020-04-29
  */
 class RangedFitFuncToBackend  implements GenericBackend<Double,AdaptiveParameters> {
 
-    private static final long serialVersionUID = (long) 20150404;
+    private static final long serialVersionUID = (long) 2020429;
     
     private final GenericFitnessFunction fitfunc;
     private final boolean normParams;
@@ -90,7 +90,7 @@ class RangedFitFuncToBackend  implements GenericBackend<Double,AdaptiveParameter
     }
     
     @Override
-    public GenericBackend<Double, AdaptiveParameters> clone() {
+    public GenericBackend<Double, AdaptiveParameters> copy() {
         return new RangedFitFuncToBackend(this);
     }
     
@@ -161,7 +161,7 @@ class RangedFitFuncToBackend  implements GenericBackend<Double,AdaptiveParameter
         
         final double fit = fitfunc.evaluateFitness(individual);
         
-        final AdaptiveParameters copy = individual.clone();
+        final AdaptiveParameters copy = individual.copy();
         copy.setFitness(fit);
         
         return copy;

--- a/src/org/ogolem/adaptive/StaticGridNiches.java
+++ b/src/org/ogolem/adaptive/StaticGridNiches.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2010, J. M. Dieterich and B. Hartke
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,7 +45,7 @@ import org.ogolem.generic.genericpool.NicheComputer;
  * N-D grid over the search space.
  * @author Johannes Dieterich
  * @author Mark Dittner
- * @version 2015-05-26
+ * @version 2020-04-29
  */
 final class StaticGridNiches implements NicheComputer<Double,AdaptiveParameters>{
 
@@ -85,7 +85,7 @@ final class StaticGridNiches implements NicheComputer<Double,AdaptiveParameters>
     }
     
     @Override
-    public StaticGridNiches clone(){
+    public StaticGridNiches copy(){
         return new StaticGridNiches(this);
     }
 

--- a/src/org/ogolem/adaptive/UnaryGaussianMutation.java
+++ b/src/org/ogolem/adaptive/UnaryGaussianMutation.java
@@ -42,7 +42,7 @@ import org.ogolem.random.RandomUtils;
  * Gaussian-based fluctuations about the current input-value, within constraints.
  *
  * @author Mark Dittner
- * @version 2020-04-25
+ * @version 2020-04-29
  */
 class UnaryGaussianMutation implements GenericMutation<Double, AdaptiveParameters> {
 
@@ -105,7 +105,7 @@ class UnaryGaussianMutation implements GenericMutation<Double, AdaptiveParameter
     @Override
     public AdaptiveParameters mutate(AdaptiveParameters orig) {
 
-        final AdaptiveParameters mut = orig.clone();
+        final AdaptiveParameters mut = orig.copy();
 
         final Double[] params = mut.getGenomeCopy();
         final int dims = params.length;

--- a/src/org/ogolem/core/AdvancedGraphBasedDirMut.java
+++ b/src/org/ogolem/core/AdvancedGraphBasedDirMut.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2013-2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2013-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -54,11 +54,11 @@ import org.ogolem.generic.GenericLocOpt;
  * A directed mutation using a graph-based analysis of the cluster in question.
  * @author Johannes Dieterich
  * @author Bernd Hartke
- * @version 2015-07-18
+ * @version 2020-04-29
  */
 public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule,Geometry>{
     
-    private static final long serialVersionUID = (long) 20140906;
+    private static final long serialVersionUID = (long) 20200429;
     
     private final boolean DEBUG;
     private final double blowBonds;
@@ -122,15 +122,15 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule,Geomet
         this.blowBonds = orig.blowBonds;
         this.collDetect = orig.collDetect.clone();
         this.blowColl = orig.blowColl;
-        this.back = orig.back.clone();
-        this.locopt = orig.locopt.clone();
+        this.back = orig.back.copy();
+        this.locopt = orig.locopt.copy();
         this.realCD = orig.realCD;
         this.realDD = orig.realDD;
         this.doLocOpt = orig.doLocOpt;
         this.fullyRelaxed = orig.fullyRelaxed;
         this.doCDFirst = orig.doCDFirst;
         this.pointProv = orig.pointProv.clone();
-        this.pointOpt = orig.pointOpt.clone();
+        this.pointOpt = orig.pointOpt.copy();
         this.markMovedMolsUnmovable = orig.markMovedMolsUnmovable;
         this.noMoved = orig.noMoved;
         this.doCDForEveryTrial = orig.doCDForEveryTrial;
@@ -179,7 +179,7 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule,Geomet
         final BondInfo bonds = work.getBondInfo();
         
         // get the energy before we manipulate
-        final double[] currCoords = back.getActiveCoordinates(work.clone());
+        final double[] currCoords = back.getActiveCoordinates(work.copy());
         final double eBefore = back.fitness(currCoords, 42);
         
         final List<Integer> movedMols = new ArrayList<>(noMoved);
@@ -401,13 +401,13 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule,Geomet
                         moved, movePartner);
                 if(bestFoundGeom == null){
                     if(DEBUG){System.out.println("DEBUG: Unconditionally making this best found.");}
-                    bestFoundGeom = res.getObject2().clone();
+                    bestFoundGeom = res.getObject2().copy();
                     bestFoundFitness = res.getObject1();
                     continue;
                 }
                 if(res.getObject1() < bestFoundFitness){
                     if(DEBUG){System.out.println("DEBUG: Conditionally making this best found.");}
-                    bestFoundGeom = res.getObject2().clone();
+                    bestFoundGeom = res.getObject2().copy();
                     bestFoundFitness = res.getObject1();
                 }
             }
@@ -417,7 +417,7 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule,Geomet
             if(bestFoundGeom != null){
             
                 // well, just continue with the best we found :-)
-                final Geometry mutationResult = bestFoundGeom.clone();
+                final Geometry mutationResult = bestFoundGeom.copy();
                 mutationResult.setFitness(bestFoundFitness);
             
                 work = mutationResult;

--- a/src/org/ogolem/core/CartesianToRigidCoordinates.java
+++ b/src/org/ogolem/core/CartesianToRigidCoordinates.java
@@ -44,11 +44,11 @@ import org.ogolem.generic.GenericBackend;
 /**
  * Turns a Cartesian backend into a rigid body one.
  * @author Johannes Dieterich
- * @version 2020-02-09
+ * @version 2020-04-29
  */
 public class CartesianToRigidCoordinates implements CoordinateRepresentation {
     
-    private static final long serialVersionUID = (long) 20200209;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     
     private final CartesianFullBackend back;
@@ -78,7 +78,7 @@ public class CartesianToRigidCoordinates implements CoordinateRepresentation {
     }
 
     @Override
-    public CartesianToRigidCoordinates clone() {
+    public CartesianToRigidCoordinates copy() {
         return new CartesianToRigidCoordinates(this);
     }
     
@@ -241,7 +241,7 @@ public class CartesianToRigidCoordinates implements CoordinateRepresentation {
     public double fitness(final double[] currCoords, final int iteration) {
 
         if(DEBUG){
-            final Geometry scr = cache.clone();
+            final Geometry scr = cache.copy();
             updateActiveCoordinates(scr,currCoords);
             final String[] cart = scr.makePrintableAbsoluteCoord(true);
             System.out.println("DEBUG: AT ENERGY EVALUTION " + iteration);
@@ -265,7 +265,7 @@ public class CartesianToRigidCoordinates implements CoordinateRepresentation {
     @Override
     public Geometry fitness(final Geometry individual, final boolean forceOneEval) {
         
-        final double[] coords = getActiveCoordinates(individual.clone());
+        final double[] coords = getActiveCoordinates(individual.copy());
         final double e = fitness(coords, 42);
         
         assert(!Double.isInfinite(e));
@@ -287,7 +287,7 @@ public class CartesianToRigidCoordinates implements CoordinateRepresentation {
          */
         
         if(DEBUG){
-            final Geometry scr = cache.clone();
+            final Geometry scr = cache.copy();
             updateActiveCoordinates(scr,currCoords);
             final String[] cart = scr.makePrintableAbsoluteCoord(true);
             System.out.println("DEBUG: AT GRADIENT EVALUTION " + iteration);

--- a/src/org/ogolem/core/ChainedNicheComp.java
+++ b/src/org/ogolem/core/ChainedNicheComp.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,11 +45,11 @@ import org.ogolem.generic.genericpool.NicheComputer;
 /**
  * Chains multiple niche computations together.
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  */
 class ChainedNicheComp implements NicheComputer<Molecule,Geometry> {
     
-    private static final long serialVersionUID = (long) 20140107;
+    private static final long serialVersionUID = (long) 20200429;
     private final List<NicheComputer<Molecule,Geometry>> nicheComps;
     
     ChainedNicheComp(final List<NicheComputer<Molecule,Geometry>> nicheComps){
@@ -59,12 +59,12 @@ class ChainedNicheComp implements NicheComputer<Molecule,Geometry> {
     private ChainedNicheComp(final ChainedNicheComp orig){
         this.nicheComps = new ArrayList<>();
         orig.nicheComps.forEach((nicher) -> {
-            nicheComps.add(nicher.clone());
+            nicheComps.add(nicher.copy());
         });
     }
     
     @Override
-    public ChainedNicheComp clone(){
+    public ChainedNicheComp copy(){
         return new ChainedNicheComp(this);
     }
     

--- a/src/org/ogolem/core/DirMutOptStrategies.java
+++ b/src/org/ogolem/core/DirMutOptStrategies.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2014-2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2014-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@ import contrib.bobyqa.BOBYQAOptimizer;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import org.ogolem.generic.Copyable;
 import org.ogolem.generic.GenericFitnessBackend;
 import org.ogolem.generic.GenericLocOpt;
 import org.ogolem.helpers.Tuple;
@@ -48,16 +49,17 @@ import org.ogolem.helpers.Tuple;
 /**
  * A collection of optimization strategies for GDM.
  * @author Johannes Dieterich
- * @version 2015-07-18
+ * @version 2020-04-29
  */
 public class DirMutOptStrategies implements Serializable {
     
     private static final boolean DEBUG = false;
-    private static final long serialVersionUID = (long) 20140526;
+    private static final long serialVersionUID = (long) 20200429;
     
-    static interface PointOptStrategy extends Cloneable, Serializable {
+    static interface PointOptStrategy extends Copyable, Serializable {
         
-        public PointOptStrategy clone();
+    	@Override
+        PointOptStrategy copy();
         
         String getMyID();
         
@@ -116,7 +118,7 @@ public class DirMutOptStrategies implements Serializable {
         private static final long serialVersionUID = (long) 20140526;
         
         @Override
-        public PointOptStrategy clone() {
+        public PointOptStrategy copy() {
             return new FullOptimization();
         }
 
@@ -153,7 +155,7 @@ public class DirMutOptStrategies implements Serializable {
         }
         
         @Override
-        public PointOptStrategy clone() {
+        public PointOptStrategy copy() {
             return new EulerOnlyOptimization(this.bobConf, this.collDetect.clone(), this.blowColl, this.fullyRelaxed);
         }
 
@@ -206,11 +208,11 @@ public class DirMutOptStrategies implements Serializable {
             
             if (currBestE >= FixedValues.NONCONVERGEDENERGY) {
                 System.out.println("INFO: Could not find any place that was collision free and had a reasonable energy. Complaining.");
-                return new Tuple<>(FixedValues.NONCONVERGEDENERGY, geom.clone());
+                return new Tuple<>(FixedValues.NONCONVERGEDENERGY, geom.copy());
             }
 
             // work is already setup properly, except for the energy :-)
-            final Geometry res = adap.getCurrentGeom().clone();
+            final Geometry res = adap.getCurrentGeom().copy();
             res.setFitness(currBestE);
             
             return new Tuple<>(res.getFitness(),res);
@@ -239,7 +241,7 @@ public class DirMutOptStrategies implements Serializable {
         }
 
         @Override
-        public PointOptStrategy clone() {
+        public PointOptStrategy copy() {
             return new RigidBodyOptimization(this.halfDiff, this.bobConf,
                 this.collDetect.clone(), this.blowColl, this.fullyRelaxed);
         }
@@ -312,11 +314,11 @@ public class DirMutOptStrategies implements Serializable {
             
             if (currBestE >= FixedValues.NONCONVERGEDENERGY) {
                 System.out.println("INFO: Could not find any place that was collision free and had a reasonable energy. Complaining.");
-                return new Tuple<>(FixedValues.NONCONVERGEDENERGY, geom.clone());
+                return new Tuple<>(FixedValues.NONCONVERGEDENERGY, geom.copy());
             }
 
             // work is already setup properly, except for the energy :-)
-            final Geometry res = adap.getCurrentGeom().clone();
+            final Geometry res = adap.getCurrentGeom().copy();
             res.setFitness(currBestE);
             
             return new Tuple<>(res.getFitness(),res);
@@ -400,7 +402,7 @@ public class DirMutOptStrategies implements Serializable {
                 
                 return e;
             } else {
-                final double[] coords = back.getActiveCoordinates(work.clone());
+                final double[] coords = back.getActiveCoordinates(work.copy());
                 final double e = back.fitness(coords, cIter);
                 if(DEBUG){System.out.println("DEBUG: new energy is " + e);}
                 
@@ -430,7 +432,7 @@ public class DirMutOptStrategies implements Serializable {
         }
 
         @Override
-        public PointOptStrategy clone() {
+        public PointOptStrategy copy() {
             return new EnergyOnlyEvaluator();
         }
 
@@ -461,7 +463,7 @@ public class DirMutOptStrategies implements Serializable {
                     }
                     
                     // clone() is necessary as object is potentially mutable
-                    final double[] currCoords = back.getActiveCoordinates(geom.clone());
+                    final double[] currCoords = back.getActiveCoordinates(geom.copy());
                     coordsCache = currCoords;
                     evalCounter++;
                     final double e = back.fitness(currCoords, evalCounter);

--- a/src/org/ogolem/core/FoehrGeometryMutation.java
+++ b/src/org/ogolem/core/FoehrGeometryMutation.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,11 +46,11 @@ import org.ogolem.random.RandomUtils;
 /**
  * A orientation-based mutation.
  * @author Johannes Dieterich
- * @version 2016-12-18
+ * @version 2020-04-29
  */
 public class FoehrGeometryMutation implements GenericMutation<Molecule,Geometry> {
     
-    private static final long serialVersionUID = (long) 20150217;
+    private static final long serialVersionUID = (long) 20200429;
 
     public static enum MODUS {INCREMENT,FULLYRANDOM};
     public static enum HOWMANY {SINGLE, MULTIPLE, MULTIPLEGAUSS, ALL};
@@ -108,7 +108,7 @@ public class FoehrGeometryMutation implements GenericMutation<Molecule,Geometry>
         }
         
         
-        final Geometry mutated = orig.clone();
+        final Geometry mutated = orig.copy();
         for(final int mutMol : mutations){
             
             final Molecule mol = mutated.getMoleculeAtPosition(mutMol);

--- a/src/org/ogolem/core/FoehrGeometryXOver.java
+++ b/src/org/ogolem/core/FoehrGeometryXOver.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2015, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,11 +46,11 @@ import org.ogolem.random.RandomUtils;
 /**
  * A genotype crossover only taking the molecular orientations into account.
  * @author Johannes Dieterich
- * @version 2016-12-18
+ * @version 2020-04-29
  */
 public class FoehrGeometryXOver implements GenericCrossover<Molecule,Geometry>{
     
-    private static final long serialVersionUID = (long) 20150217;
+    private static final long serialVersionUID = (long) 20200429;
     
     private final int noCuts;
     
@@ -88,8 +88,8 @@ public class FoehrGeometryXOver implements GenericCrossover<Molecule,Geometry>{
         // get cutting points
         final List<Integer> cutPoints = RandomUtils.listOfPoints(noCuts, mother.getNumberOfIndieParticles());
         
-        final Geometry gChild1 = mother.clone();
-        final Geometry gChild2 = father.clone();
+        final Geometry gChild1 = mother.copy();
+        final Geometry gChild2 = father.copy();
         gChild1.setID(futureID);
         gChild2.setID(futureID);
                 

--- a/src/org/ogolem/core/FullyCartesianCoordinates.java
+++ b/src/org/ogolem/core/FullyCartesianCoordinates.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2012-2014, J. M. Dieterich
-                2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +43,11 @@ import org.ogolem.generic.stats.GenericDetailStatistics;
 /**
  * A simple adapter for the geometry to gradient/energy provider.
  * @author Johannes Dieterich
- * @version 2015-11-17
+ * @version 2020-04-29
  */
 public class FullyCartesianCoordinates implements GenericBackend<Molecule,Geometry> {
     
-    private static final long serialVersionUID = (long) 20150104;
+    private static final long serialVersionUID = (long) 20200429;
     
     public static final double MAXINCREMENTBOUNDS = 10.0; // in bohr
     
@@ -72,7 +72,7 @@ public class FullyCartesianCoordinates implements GenericBackend<Molecule,Geomet
     }
     
     @Override
-    public FullyCartesianCoordinates clone(){
+    public FullyCartesianCoordinates copy(){
         return new FullyCartesianCoordinates(this);
     }
     

--- a/src/org/ogolem/core/GenericGeometryDarwin.java
+++ b/src/org/ogolem/core/GenericGeometryDarwin.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,11 +48,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * A generified (or de-generified?) Darwin implementation based off GenericAbstractDarwin.
  * @author Johannes Dieterich
- * @version 2014-03-29
+ * @version 2020-04-29
  */
 public class GenericGeometryDarwin extends GenericAbstractDarwin<Molecule,Geometry> {
     
-    private static final long serialVersionUID = (long) 20140329;
+    private static final long serialVersionUID = (long) 20200429;
     private final GenericCrossover<Double,Molecule> molXOver;
     private final GenericMutation<Double,Molecule> molMutation;
     private final double molXOverProb;
@@ -81,7 +82,7 @@ public class GenericGeometryDarwin extends GenericAbstractDarwin<Molecule,Geomet
     }
     
     @Override
-    public GenericGeometryDarwin clone() {
+    public GenericGeometryDarwin copy() {
         return new GenericGeometryDarwin(this);
     }
 

--- a/src/org/ogolem/core/Geometry.java
+++ b/src/org/ogolem/core/Geometry.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ import org.ogolem.random.Lottery;
  * It needs to provide a lot of states, getters and setters
  * as well as methods.
  * @author Johannes Dieterich
- * @version 2016-12-18
+ * @version 2020-04-29
  */
 public class Geometry extends ContinuousProblem<Molecule> {
 	
@@ -61,7 +61,7 @@ public class Geometry extends ContinuousProblem<Molecule> {
      * Whenever something changes in this class, increment the serialVersionUID field.
      * AND: Nasty errors when sucking in old serialized objects may follow otherwise.
      */
-    private static final long serialVersionUID = (long) 20140402;
+    private static final long serialVersionUID = (long) 20200429;
 
     // a boolean saying whether or not it is already locally optimized
     private boolean isLocOptimized = false;
@@ -176,7 +176,7 @@ public class Geometry extends ContinuousProblem<Molecule> {
     }
     
     @Override
-    public Geometry clone(){
+    public Geometry copy(){
         return new Geometry(this);
     }
 
@@ -1045,7 +1045,7 @@ public class Geometry extends ContinuousProblem<Molecule> {
         
         final Molecule[] mols = new Molecule[noOfIndieParticles];
         for(int i = 0; i < molecules.size(); i++){
-            mols[i] = molecules.get(i).clone();
+            mols[i] = molecules.get(i).copy();
         }
         
         return mols;

--- a/src/org/ogolem/core/GeometryInitializationToGenericAdaptor.java
+++ b/src/org/ogolem/core/GeometryInitializationToGenericAdaptor.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +43,11 @@ import org.ogolem.generic.GenericInitializer;
 /**
  * An adaptor from the old interface to the generic one. Hopefully temporary...
  * @author Johannes Dieterich
- * @version 2015-04-28
+ * @version 2020-04-29
  */
 public class GeometryInitializationToGenericAdaptor implements GenericInitializer<Molecule, Geometry> {
     
-    private static final long serialVersionUID = (long) 20140330;
+    private static final long serialVersionUID = (long) 20200429;
     private final GenericFitnessFunction<Molecule,Geometry> fitness;
     private final GeometryInitialization init;
     private final CollisionDetection.CDTYPE whichCollDetect;
@@ -81,11 +81,11 @@ public class GeometryInitializationToGenericAdaptor implements GenericInitialize
         this.molecularCD = orig.molecularCD;
         this.whichCollDetect = orig.whichCollDetect;
         this.whichDissDetect = orig.whichDissDetect;
-        this.fitness = orig.fitness.clone();
+        this.fitness = orig.fitness.copy();
     }
     
     @Override
-    public GenericInitializer<Molecule, Geometry> clone() {
+    public GenericInitializer<Molecule, Geometry> copy() {
         return new GeometryInitializationToGenericAdaptor(this);
     }
 

--- a/src/org/ogolem/core/GeometryReader.java
+++ b/src/org/ogolem/core/GeometryReader.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,15 +44,15 @@ import org.ogolem.io.InputPrimitives;
 /**
  * Individual reader implementation for geometries.
  * @author Johannes Dieterich
- * @version 2016-09-03
+ * @version 2020-04-29
  */
 public class GeometryReader implements IndividualReader<Geometry>{
 
-    private static final long serialVersionUID = (long) 20140403;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     
     @Override
-    public GeometryReader clone() {
+    public GeometryReader copy() {
         return new GeometryReader();
     }
 

--- a/src/org/ogolem/core/GlobalConfig.java
+++ b/src/org/ogolem/core/GlobalConfig.java
@@ -67,7 +67,7 @@ import org.ogolem.random.Lottery;
  * All configuration data needed for the program to run is in this class. It is
  * reusable for the "constructor madness". Default values are provided.
  * @author Johannes Dieterich
- * @version 2020-04-25
+ * @version 2020-04-29
  */
 public class GlobalConfig implements Configuration<Molecule,Geometry> {
 
@@ -991,7 +991,7 @@ public class GlobalConfig implements Configuration<Molecule,Geometry> {
     public Newton getRefNewton() {
         
         try{
-            final Newton newton = LocOptFactory.translateLocalOpt(refNewton.clone());
+            final Newton newton = LocOptFactory.translateLocalOpt(refNewton.copy());
             return newton;
         } catch(Exception e){
             e.printStackTrace(System.err);

--- a/src/org/ogolem/core/HydrogenBondNicheComp.java
+++ b/src/org/ogolem/core/HydrogenBondNicheComp.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2012-2014, J. M. Dieterich
-              2015-2019, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,11 +47,11 @@ import org.ogolem.generic.genericpool.NicheComputer;
  * based on water molecules where atoms are defined as OHH in the input.
  * Ignores other building blocks/molecules.
  * @author Johannes Dieterich
- * @version 2019-12-29
+ * @version 2020-04-29
  */
 public class HydrogenBondNicheComp implements NicheComputer<Molecule,Geometry>{
     
-    private static final long serialVersionUID = (long) 20140107;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     private final double maxDistOH;
     private final double maxDistOO;
@@ -70,7 +70,7 @@ public class HydrogenBondNicheComp implements NicheComputer<Molecule,Geometry>{
     }
     
     @Override
-    public HydrogenBondNicheComp clone(){
+    public HydrogenBondNicheComp copy(){
         return new HydrogenBondNicheComp(this);
     }
     

--- a/src/org/ogolem/core/InteriorMoleculeNicheComp.java
+++ b/src/org/ogolem/core/InteriorMoleculeNicheComp.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +43,11 @@ import org.ogolem.generic.genericpool.NicheComputer;
 /**
  * Nicher working based on the number of interior molecules
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  */
 class InteriorMoleculeNicheComp implements NicheComputer<Molecule,Geometry>{
     
-    private static final long serialVersionUID = (long) 20140107;
+    private static final long serialVersionUID = (long) 20200429;
     private final static boolean DEBUG = true;
     private final SurfaceDetectionEngine surfer;
     
@@ -60,7 +60,7 @@ class InteriorMoleculeNicheComp implements NicheComputer<Molecule,Geometry>{
     }
     
     @Override
-    public InteriorMoleculeNicheComp clone(){
+    public InteriorMoleculeNicheComp copy(){
         return new InteriorMoleculeNicheComp(this);
     }
     

--- a/src/org/ogolem/core/InverseNewtonAdapter.java
+++ b/src/org/ogolem/core/InverseNewtonAdapter.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2015, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,11 +46,11 @@ import org.ogolem.generic.GenericLocOpt;
  * Translates a generic fitness function based local optimization to the Newton
  * interface.
  * @author Johannes Dieterich
- * @version 2016-09-03
+ * @version 2020-04-29
  */
 public class InverseNewtonAdapter implements Newton {
 
-    private static final long serialVersionUID = (long) 20150104;
+    private static final long serialVersionUID = (long) 20200429;
     
     private final GenericLocOpt<Molecule,Geometry> locopt;
     private long countGeomOpts = 0l;
@@ -61,7 +61,7 @@ public class InverseNewtonAdapter implements Newton {
     }
     
     InverseNewtonAdapter(final InverseNewtonAdapter orig){
-        this.locopt = orig.locopt.clone();
+        this.locopt = orig.locopt.copy();
     }
     
     @Override

--- a/src/org/ogolem/core/LJNeighborNicheComp.java
+++ b/src/org/ogolem/core/LJNeighborNicheComp.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
-              2015-2019, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -52,11 +52,11 @@ import org.ogolem.helpers.IndexSort;
  * icosahedral, decahedral, tetrahedral, and fcc,
  * based on the neighborhoods of selected or all atoms
  * @author Bernd Hartke
- * @version 2019-12-29
+ * @version 2020-04-29
  */
 class LJNeighborNicheComp implements NicheComputer<Molecule,Geometry> {
     
-    private static final long serialVersionUID = (long) 20140107;
+    private static final long serialVersionUID = (long) 20200429;
     public static final int defWidth = 20;
     public static final String defMode = "StandardTypes";
     
@@ -76,7 +76,7 @@ class LJNeighborNicheComp implements NicheComputer<Molecule,Geometry> {
     }
     
     @Override
-    public LJNeighborNicheComp clone(){
+    public LJNeighborNicheComp copy(){
         return new LJNeighborNicheComp(this);
     }
     

--- a/src/org/ogolem/core/LJProjNicheComp.java
+++ b/src/org/ogolem/core/LJProjNicheComp.java
@@ -46,7 +46,7 @@ import org.ogolem.generic.genericpool.NicheComputer;
  * most likely not useful for much else (according to BXH).
  * @author Johannes Dieterich
  * @author Bernd Hartke
- * @version 2020-02-09
+ * @version 2020-04-29
  */
 class LJProjNicheComp implements NicheComputer<Molecule,Geometry> {
     
@@ -90,7 +90,7 @@ class LJProjNicheComp implements NicheComputer<Molecule,Geometry> {
     }
     
     @Override
-    public LJProjNicheComp clone(){
+    public LJProjNicheComp copy(){
         return new LJProjNicheComp(this);
     }
     

--- a/src/org/ogolem/core/Molecule.java
+++ b/src/org/ogolem/core/Molecule.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This describes a full molecules consisting of atoms and further information.
  * @author Johannes Dieterich
- * @version 2020-04-25
+ * @version 2020-04-29
  */
 public class Molecule extends ContinuousProblem<Double> {
 
@@ -249,7 +249,7 @@ public class Molecule extends ContinuousProblem<Double> {
     }
     
     @Override
-    public Molecule clone(){
+    public Molecule copy(){
         return new Molecule(this);
     }
 

--- a/src/org/ogolem/core/NewtonAdaptor.java
+++ b/src/org/ogolem/core/NewtonAdaptor.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014-2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,11 +45,11 @@ import org.ogolem.generic.stats.GenericDetailStatistics;
 /**
  * An adaptor to fit the old Newton interface into the new generic world.
  * @author Johannes Dieterich
- * @version 2015-01-04
+ * @version 2020-04-29
  */
 public class NewtonAdaptor implements GenericLocOpt<Molecule,Geometry> {
     
-    private static final long serialVersionUID = (long) 20140328;
+    private static final long serialVersionUID = (long) 20200429;
     private final Newton newton;
     private int count = 0;
 
@@ -61,7 +62,7 @@ public class NewtonAdaptor implements GenericLocOpt<Molecule,Geometry> {
     }
     
     @Override
-    public NewtonAdaptor clone() {
+    public NewtonAdaptor copy() {
         return new NewtonAdaptor(this);
     }
 

--- a/src/org/ogolem/core/PluggableDirMut.java
+++ b/src/org/ogolem/core/PluggableDirMut.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014-2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,11 +49,11 @@ import org.ogolem.helpers.Tuple;
  * Essentially a stripped down version of the AdvGDM so far. Eventually, this will
  * though implement AdvGDM.
  * @author Johannes Dieterich
- * @version 2015-07-19
+ * @version 2020-04-29
  */
 public class PluggableDirMut implements GenericMutation<Molecule,Geometry>{
     
-    private static final long serialVersionUID = (long) 20140614;
+    private static final long serialVersionUID = (long) 20200429;
 
     private final boolean DEBUG;
     private final double blowBonds;
@@ -116,15 +117,15 @@ public class PluggableDirMut implements GenericMutation<Molecule,Geometry>{
         this.blowBonds = orig.blowBonds;
         this.collDetect = orig.collDetect.clone();
         this.blowColl = orig.blowColl;
-        this.back = orig.back.clone();
-        this.locopt = orig.locopt.clone();
+        this.back = orig.back.copy();
+        this.locopt = orig.locopt.copy();
         this.realCD = orig.realCD;
         this.realDD = orig.realDD;
         this.doLocOpt = orig.doLocOpt;
         this.fullyRelaxed = orig.fullyRelaxed;
         this.doCDFirst = orig.doCDFirst;
         this.pointProv = orig.pointProv.clone();
-        this.pointOpt = orig.pointOpt.clone();
+        this.pointOpt = orig.pointOpt.copy();
         this.markMovedMolsUnmovable = orig.markMovedMolsUnmovable;
         this.noMoved = orig.noMoved;
         this.doCDForEveryTrial = orig.doCDForEveryTrial;
@@ -161,7 +162,7 @@ public class PluggableDirMut implements GenericMutation<Molecule,Geometry>{
         final BondInfo bonds = work.getBondInfo();
         
         // get the energy before we manipulate
-        final double[] currCoords = back.getActiveCoordinates(work.clone());
+        final double[] currCoords = back.getActiveCoordinates(work.copy());
         final double eBefore = back.fitness(currCoords, 42);
         final double[] eparts = new double[work.getNumberOfIndieParticles()];
         
@@ -193,13 +194,13 @@ public class PluggableDirMut implements GenericMutation<Molecule,Geometry>{
                         moved, -1);
                 if(bestFoundGeom == null){
                     if(DEBUG){System.out.println("DEBUG: Unconditionally making this best found.");}
-                    bestFoundGeom = res.getObject2().clone();
+                    bestFoundGeom = res.getObject2().copy();
                     bestFoundFitness = res.getObject1();
                     continue;
                 }
                 if(res.getObject1() < bestFoundFitness){
                     if(DEBUG){System.out.println("DEBUG: Conditionally making this best found.");}
-                    bestFoundGeom = res.getObject2().clone();
+                    bestFoundGeom = res.getObject2().copy();
                     bestFoundFitness = res.getObject1();
                 }
             }
@@ -209,7 +210,7 @@ public class PluggableDirMut implements GenericMutation<Molecule,Geometry>{
             if(bestFoundGeom != null){
             
                 // well, just continue with the best we found :-)
-                final Geometry mutationResult = bestFoundGeom.clone();
+                final Geometry mutationResult = bestFoundGeom.copy();
                 mutationResult.setFitness(bestFoundFitness);
             
                 work = mutationResult;

--- a/src/org/ogolem/core/RigidBodyCoordinates.java
+++ b/src/org/ogolem/core/RigidBodyCoordinates.java
@@ -44,7 +44,7 @@ import org.ogolem.generic.GenericBackend;
 /**
  * A coordinate set for rigid body optimizations.
  * @author Johannes Dieterich
- * @version 2020-02-09
+ * @version 2020-04-29
  */
 public class RigidBodyCoordinates implements CoordinateRepresentation {
     
@@ -52,7 +52,7 @@ public class RigidBodyCoordinates implements CoordinateRepresentation {
     
     public static final double MAXMOVECOMCOORD = 10.0; // in bohr
     
-    private static final long serialVersionUID = (long) 20200209;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
 
     private final RigidBodyBackend backend;
@@ -81,7 +81,7 @@ public class RigidBodyCoordinates implements CoordinateRepresentation {
     }
     
     @Override
-    public GenericBackend<Molecule, Geometry> clone() {
+    public GenericBackend<Molecule, Geometry> copy() {
         return new RigidBodyCoordinates(this);
     }
     
@@ -109,7 +109,7 @@ public class RigidBodyCoordinates implements CoordinateRepresentation {
     public double[] getActiveCoordinates(final Geometry individual) {
         
         final int mols = individual.getNumberOfIndieParticles();
-        this.cache = individual;//.clone();
+        this.cache = individual;//.copy();
         this.coms = new double[mols][3];
         this.comDisplacementCache = new double[mols][];
         this.cartesBackup = new ArrayList<>(individual.getNumberOfIndieParticles());
@@ -240,7 +240,7 @@ public class RigidBodyCoordinates implements CoordinateRepresentation {
     public double fitness(final double[] currCoords, final int iteration) {
         
         if(DEBUG){
-            final Geometry scr = cache.clone();
+            final Geometry scr = cache.copy();
             updateActiveCoordinates(scr,currCoords);
             final String[] cart = scr.makePrintableAbsoluteCoord(true);
             System.out.println("DEBUG: AT ENERGY EVALUTION " + iteration);
@@ -256,7 +256,7 @@ public class RigidBodyCoordinates implements CoordinateRepresentation {
     @Override
     public Geometry fitness(final Geometry individual, final boolean forceOneEval) {
         
-        final double[] optCoord = getActiveCoordinates(individual.clone());
+        final double[] optCoord = getActiveCoordinates(individual.copy());
         final double e = fitness(optCoord, 0);
         
         individual.setFitness(e);
@@ -273,7 +273,7 @@ public class RigidBodyCoordinates implements CoordinateRepresentation {
         }
         
         if(DEBUG){
-            final Geometry scr = cache.clone();
+            final Geometry scr = cache.copy();
             updateActiveCoordinates(scr,currCoords);
             final String[] cart = scr.makePrintableAbsoluteCoord(true);
             System.out.println("DEBUG: AT GRADIENT EVALUTION " + iteration);

--- a/src/org/ogolem/core/ScaTTM3FBackend.java
+++ b/src/org/ogolem/core/ScaTTM3FBackend.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2012-2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,7 +39,6 @@ package org.ogolem.core;
 
 import java.io.File;
 import java.util.Locale;
-import org.apache.commons.math3.util.FastMath;
 import static org.ogolem.core.Constants.*;
 import org.ogolem.io.OutputPrimitives;
 import org.ogolem.properties.DipoleMoment;
@@ -48,7 +47,7 @@ import org.ogolem.scaTTM3F.TTM3F;
 /**
  * Calls the Scala-TTM3F force field for highly exact water clusters.
  * @author Johannes Dieterich
- * @version 2015-03-27
+ * @version 2020-04-29
  */
 public class ScaTTM3FBackend implements CartesianFullBackend {
     
@@ -194,7 +193,7 @@ public class ScaTTM3FBackend implements CartesianFullBackend {
                         anythingFound = true;
                         
                         // increase energy
-                        final double distInv = FastMath.sqrt(distSq)-CUTDIST;
+                        final double distInv = Math.sqrt(distSq)-CUTDIST;
                         final double divProdX = dX * distInv;
                         final double divProdY = dY * distInv;
                         final double divProdZ = dZ * distInv;
@@ -306,7 +305,7 @@ public class ScaTTM3FBackend implements CartesianFullBackend {
                     
                     if(distSq <= CUTDISTSQ){
                         // increase energy
-                        final double distInv = FastMath.sqrt(distSq)-CUTDIST;
+                        final double distInv = Math.sqrt(distSq)-CUTDIST;
                         e += CUTENERGY*distInv*distInv;
                     }
                 }

--- a/src/org/ogolem/core/SingleGeomSpectralFitnessFunction.java
+++ b/src/org/ogolem/core/SingleGeomSpectralFitnessFunction.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -64,7 +64,7 @@ import org.ogolem.spectral.FullSpectrum;
  * A fitness function to locopt a geometry and subsequently obtain the fitness
  * value from a spectral fit against a reference.
  * @author Johannes Dieterich
- * @version 2015-04-28
+ * @version 2020-04-29
  */
 public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction<Molecule,Geometry>{
 
@@ -74,7 +74,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
      */
     private final static double PREFAC = Math.PI*2*2.99792458E-2;
     
-    private static final long serialVersionUID = (long) 20150227;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     
     private final GenericFitnessFunction<Molecule,Geometry> opter;
@@ -162,7 +162,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
     }
     
     SingleGeomSpectralFitnessFunction(final SingleGeomSpectralFitnessFunction orig){
-        this.opter = orig.opter.clone();
+        this.opter = orig.opter.copy();
         this.corrFrames = orig.corrFrames;
         this.corrFramesPerBlock = orig.corrFramesPerBlock;
         this.corrGap = orig.corrGap;
@@ -192,7 +192,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
     }
     
     @Override
-    public GenericFitnessFunction<Molecule, Geometry> clone() {
+    public GenericFitnessFunction<Molecule, Geometry> copy() {
         return new SingleGeomSpectralFitnessFunction(this);
     }
 
@@ -360,7 +360,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
     
     private static class Coefficient extends ContinuousProblem<Double>{
 
-        private static final long serialVersionUID = (long) 20150227;
+        private static final long serialVersionUID = (long) 20200429;
         private double coefficient;
         
         Coefficient(){
@@ -372,7 +372,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
         }
         
         @Override
-        public ContinuousProblem<Double> clone() {
+        public ContinuousProblem<Double> copy() {
             return new Coefficient(this);
         }
 
@@ -398,7 +398,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
     
     private static class FitnessFunction implements GenericBackend<Double,Coefficient>{
         
-        private static final long serialVersionUID = (long) 20150227;
+        private static final long serialVersionUID = (long) 20200429;
         
         private final FullSpectrum ref;
         private final FullSpectrum fit;
@@ -417,7 +417,7 @@ public class SingleGeomSpectralFitnessFunction implements GenericFitnessFunction
         }
 
         @Override
-        public GenericBackend<Double, Coefficient> clone() {
+        public GenericBackend<Double, Coefficient> copy() {
             return new FitnessFunction(this);
         }
 

--- a/src/org/ogolem/core/SnaefellsjoekullGeometryXOver.java
+++ b/src/org/ogolem/core/SnaefellsjoekullGeometryXOver.java
@@ -42,7 +42,6 @@ import contrib.bobyqa.BOBYQAOptimizer;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.commons.math3.util.FastMath;
 import static org.ogolem.core.GlobOptAtomics.assignMolecularTypes;
 import static org.ogolem.core.GlobOptAtomics.findOptimalSphereRadius;
 import static org.ogolem.core.GlobOptAtomics.randomRotation;
@@ -54,7 +53,7 @@ import org.ogolem.random.RandomUtils;
 /**
  * A sphere-based phenotype cut.
  * @author Johannes Dieterich
- * @version 2020-02-09
+ * @version 2020-04-29
  */
 public class SnaefellsjoekullGeometryXOver implements GenericCrossover<Molecule,Geometry> {
 
@@ -157,8 +156,8 @@ public class SnaefellsjoekullGeometryXOver implements GenericCrossover<Molecule,
         /*
          * create work geometries and rotate them
          */
-        final Geometry gChild2 = mother.clone();
-        final Geometry gChild1 = father.clone();
+        final Geometry gChild2 = mother.copy();
+        final Geometry gChild1 = father.copy();
         final CartesianCoordinates cartesMother = gChild2.getCartesians();
         final CartesianCoordinates cartesFather = gChild1.getCartesians();
 
@@ -234,8 +233,8 @@ public class SnaefellsjoekullGeometryXOver implements GenericCrossover<Molecule,
                 fatherCOMs[j][i] = tmpF[j];
             }
             
-            motherCOMDists[i] = FastMath.sqrt(tmpM[0]*tmpM[0]+tmpM[1]*tmpM[1]+tmpM[2]*tmpM[2]);
-            fatherCOMDists[i] = FastMath.sqrt(tmpF[0]*tmpF[0]+tmpF[1]*tmpF[1]+tmpF[2]*tmpF[2]);
+            motherCOMDists[i] = Math.sqrt(tmpM[0]*tmpM[0]+tmpM[1]*tmpM[1]+tmpM[2]*tmpM[2]);
+            fatherCOMDists[i] = Math.sqrt(tmpF[0]*tmpF[0]+tmpF[1]*tmpF[1]+tmpF[2]*tmpF[2]);
             maxCOMDistMom = Math.max(maxCOMDistMom, motherCOMDists[i]);
         }
         
@@ -498,7 +497,7 @@ public class SnaefellsjoekullGeometryXOver implements GenericCrossover<Molecule,
             for(int j = 0; j < 3; j++){
                 motherCOMs[j][i] = tmp1[j];
             }
-            motherCOMDists[i] = FastMath.sqrt(tmp1[0]*tmp1[0]+tmp1[1]*tmp1[1]+tmp1[2]*tmp1[2]);
+            motherCOMDists[i] = Math.sqrt(tmp1[0]*tmp1[0]+tmp1[1]*tmp1[1]+tmp1[2]*tmp1[2]);
         }
 
         // first always null the ArrayLists

--- a/src/org/ogolem/core/WaterAngleNicheComp.java
+++ b/src/org/ogolem/core/WaterAngleNicheComp.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2012-2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,11 +45,11 @@ import org.ogolem.generic.genericpool.NicheComputer;
  * clusters. Routine similar to the one implemented in Phenix and described in
  * B. Hartke, Z. Phys. Chem., 214, 1251 (2000).
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  */
 public class WaterAngleNicheComp implements NicheComputer<Molecule,Geometry> {
 
-    private static final long serialVersionUID = (long) 20140107;
+    private static final long serialVersionUID = (long) 20200429;
     private final static double ANGLOW = Math.toRadians(80.0);
     private final static double ANGHIGH = Math.toRadians(100.0);
     private final static double PLOW = 50.0;
@@ -68,7 +68,7 @@ public class WaterAngleNicheComp implements NicheComputer<Molecule,Geometry> {
     }
     
     @Override
-    public WaterAngleNicheComp clone(){
+    public WaterAngleNicheComp copy(){
         return new WaterAngleNicheComp(this);
     }
     

--- a/src/org/ogolem/dimerizer/DimerizerCore.java
+++ b/src/org/ogolem/dimerizer/DimerizerCore.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The actual working core of the dimerizer.
  * @author Johannes Dieterich
- * @version 2015-04-28
+ * @version 2020-04-29
  */
 class DimerizerCore {
     
@@ -62,7 +62,7 @@ class DimerizerCore {
         final CollisionDetectionEngine cd = new CollisionDetection(CollisionDetection.CDTYPE.SIMPLEPAIRWISE);
         
         // setup XYZ constraints on the first atom of each of the molecules.
-        final Geometry work = geom.clone();
+        final Geometry work = geom.copy();
         final boolean[][] constr1 = work.getMoleculeAtPosition(0).getConstraints();
         constr1[0][0] = true;
         constr1[1][0] = true;
@@ -99,7 +99,7 @@ class DimerizerCore {
             final CollisionDetectionEngine cd, final double blowFac, final long counter){
             
         // create one just for us
-        final Geometry ggg = geom.clone();
+        final Geometry ggg = geom.copy();
         
         // rotate, translate
         final double[] com2 = ggg.getCOM(1);

--- a/src/org/ogolem/generic/AbstractDefaultConfig.java
+++ b/src/org/ogolem/generic/AbstractDefaultConfig.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -49,13 +49,13 @@ import org.ogolem.generic.threading.TaskFactory;
  * An abstract default config. Essentially, a bare-bones starting point if you
  * want to solve your own optimization problem using the ogolem kernels.
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  * @param <E> the optimizable quantity, e.g., Double or Molecule
  * @param <T> the actual optimizable class
  */
 public abstract class AbstractDefaultConfig<E,T extends Optimizable<E>> implements Configuration<E,T>{
     
-    private static final long serialVersionUID = (long) 20140830;
+    private static final long serialVersionUID = (long) 20200429;
     
     /**
      * where to find the seeding individuals. Also works as an identifier whether
@@ -181,7 +181,7 @@ public abstract class AbstractDefaultConfig<E,T extends Optimizable<E>> implemen
     @SuppressWarnings("unchecked")
     @Override
     public T getExample() throws Exception {
-        return (T) example.clone();
+        return (T) example.copy();
     }
 
     @Override

--- a/src/org/ogolem/generic/AbstractProblem.java
+++ b/src/org/ogolem/generic/AbstractProblem.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.core.FixedValues;
 /**
  * An abstract simple implementation of optimizable.
  * @author Johannes Dieterich
- * @version 2014-05-02
+ * @version 2020-04-29
  */
 public abstract class AbstractProblem<E> implements Optimizable<E> {
     
-    private static final long serialVersionUID = (long) 20140401;
+    private static final long serialVersionUID = (long) 20200429;
     protected long myID = -1;
     protected long fatherID = -1;
     protected long motherID = -1;
@@ -62,7 +63,7 @@ public abstract class AbstractProblem<E> implements Optimizable<E> {
     }
     
     @Override
-    public abstract AbstractProblem<E> clone();
+    public abstract AbstractProblem<E> copy();
 
     @Override
     public long getID(){

--- a/src/org/ogolem/generic/BoundedGenericMutation.java
+++ b/src/org/ogolem/generic/BoundedGenericMutation.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich and B. Hartke
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,14 +44,14 @@ import org.ogolem.random.RandomUtils;
 /**
  * A bounded generic mutation.
  * @author Johannes Dieterich
- * @version 2013-12-04
+ * @version 2020-04-29
  */
 public class BoundedGenericMutation<T extends Optimizable<Double>> implements GenericMutation<Double,T>{
     
     public static final int SINGLEMUT = 0;
     public static final int MULTIMUT = 1;
     
-    private static final long serialVersionUID = (long) 20131201;
+    private static final long serialVersionUID = (long) 20200429;
     private final Lottery r;
     private final int mode;
     private final double[] upper;
@@ -84,7 +85,7 @@ public class BoundedGenericMutation<T extends Optimizable<Double>> implements Ge
     public T mutate(final T orig) {
         
         @SuppressWarnings("unchecked")
-        final T mut = (T) orig.clone();
+        final T mut = (T) orig.copy();
         
         final Double[] params = mut.getGenomeCopy();
         final int dims = params.length;

--- a/src/org/ogolem/generic/BoundedInitializer.java
+++ b/src/org/ogolem/generic/BoundedInitializer.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich and B. Hartke
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.random.Lottery;
 /**
  * A bounded initializer for continuous problems.
  * @author Johannes Dieterich
- * @version 2013-12-01
+ * @version 2020-04-29
  */
 public class BoundedInitializer<T extends Optimizable<Double>> implements GenericInitializer<Double,T> {
     
-    private static final long serialVersionUID = (long) 20131201;
+    private static final long serialVersionUID = (long) 20200429;
     private final GenericFitnessFunction<Double,T> fitness;
     private final Lottery r;
     private final double[] upper;
@@ -63,11 +64,11 @@ public class BoundedInitializer<T extends Optimizable<Double>> implements Generi
         this.lower = orig.lower;
         this.upper = orig.upper;
         this.r = Lottery.getInstance();
-        this.fitness = orig.fitness.clone();
+        this.fitness = orig.fitness.copy();
     }
 
     @Override
-    public BoundedInitializer<T> clone() {
+    public BoundedInitializer<T> copy() {
         return new BoundedInitializer<>(this);
     }
 
@@ -75,7 +76,7 @@ public class BoundedInitializer<T extends Optimizable<Double>> implements Generi
     public T initialize(final T ref, final long futureID) {
         
         @SuppressWarnings("unchecked")
-        final T init = (T) ref.clone();
+        final T init = (T) ref.copy();
         
         final Double[] params = init.getGenomeCopy();
         final int dims = params.length;

--- a/src/org/ogolem/generic/ContinuousProblem.java
+++ b/src/org/ogolem/generic/ContinuousProblem.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2010, J. M. Dieterich and B. Hartke
               2012-2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40,11 +41,11 @@ package org.ogolem.generic;
 /**
  * An abstract implementation of a continuous problem.
  * @author Johannes Dieterich
- * @version 2014-05-02
+ * @version 2020-04-29
  */
 public abstract class ContinuousProblem<E> extends AbstractProblem<E> {
     
-    private static final long serialVersionUID = (long) 20140401;
+    private static final long serialVersionUID = (long) 20200429;
     
     public ContinuousProblem(){
     }
@@ -54,7 +55,7 @@ public abstract class ContinuousProblem<E> extends AbstractProblem<E> {
     }
     
     @Override
-    public abstract ContinuousProblem<E> clone();
+    public abstract ContinuousProblem<E> copy();
     
     @Override
     public final boolean isDiscreteProblem(){

--- a/src/org/ogolem/generic/Copyable.java
+++ b/src/org/ogolem/generic/Copyable.java
@@ -1,6 +1,5 @@
 /**
-Copyright (c) 2013, J. M. Dieterich
-              2020, J. M. Dieterich and B. Hartke
+Copyright (c) 2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,45 +37,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.generic;
 
 /**
- * A simple generic darwin implementation.
+ * Mark an object as copyable without descending into the hell of special clone behavior.
  * @author Johannes Dieterich
  * @version 2020-04-29
  */
-public class SimpleGenericDarwin<E,T extends Optimizable<E>> extends GenericAbstractDarwin<E,T>{
-    
-    private static final long serialVersionUID = (long) 20200429;
-    
-    public SimpleGenericDarwin(final GenericCrossover<E,T> cross, final GenericMutation<E,T> mut,
-            final GenericSanityCheck<E,T> sanity, final GenericFitnessFunction<E,T> fitness,
-            final IndividualWriter<T> writer, final double crossPoss, final double mutPoss,
-            final boolean printBeforeFitness, final int noOfTries){
-        super(cross, mut, sanity, fitness, writer, crossPoss, mutPoss,
-            printBeforeFitness, noOfTries);
-    }
-    
-    public SimpleGenericDarwin(final SimpleGenericDarwin<E,T> orig){
-        super(orig);
-    }
-    
-    @Override
-    public SimpleGenericDarwin<E,T> copy(){
-        return new SimpleGenericDarwin<>(this);
-    }
-    
-    @Override
-    public String getMyID(){
-        return "simple darwin using: "
-                + "\n\txover    " + xover.getMyID()
-                + "\n\tmutation " + mutation.getMyID()
-                + "\n\tfitness  " + fitness.getMyID();
-    }
-    
-    @Override
-    public void postXOver(final T individual1, final T individual2, final long futureID){}
-    
-    @Override
-    public void postMutation(final T individual){}
-    
-    @Override
-    public void runAfterEachTry(){}
+public interface Copyable {
+	
+	/**
+	 * Returns a copy of itself. Must not throw Exceptions unless catastrophic condition exists.
+	 * Is assumed to complete.
+	 * @return a copy of itself, depth of it dictated by object needs
+	 */
+	Copyable copy();
 }

--- a/src/org/ogolem/generic/DiscreteProblem.java
+++ b/src/org/ogolem/generic/DiscreteProblem.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2010, J. M. Dieterich and B. Hartke
               2012-2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40,14 +41,14 @@ package org.ogolem.generic;
 /**
  * An abstract implementation of a discrete problem.
  * @author Johannes Dieterich
- * @version 2013-11-22
+ * @version 2020-04-29
  */
 public abstract class DiscreteProblem<E> extends AbstractProblem<E> {
     
-    private static final long serialVersionUID = (long) 20140327;
+    private static final long serialVersionUID = (long) 20200429;
     
     @Override
-    public abstract DiscreteProblem<E> clone();
+    public abstract DiscreteProblem<E> copy();
     
     @Override
     public final boolean isDiscreteProblem(){

--- a/src/org/ogolem/generic/DummyIndividualReader.java
+++ b/src/org/ogolem/generic/DummyIndividualReader.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,14 +40,14 @@ package org.ogolem.generic;
 /**
  * A dummy for the individualreader. Doesn't do anything.
  * @author Johannes Dieterich
- * @version 2014-04-02
+ * @version 2020-04-29
  */
 public class DummyIndividualReader<T> implements IndividualReader<T> {
     
-    private static final long serialVersionUID = (long) 20140403;
+    private static final long serialVersionUID = (long) 20200429;
 
     @Override
-    public IndividualReader<T> clone() {
+    public IndividualReader<T> copy() {
         return new DummyIndividualReader<>();
     }
 

--- a/src/org/ogolem/generic/GenericAbsolutePrescreeningLocOpt.java
+++ b/src/org/ogolem/generic/GenericAbsolutePrescreeningLocOpt.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-                2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +43,11 @@ import org.slf4j.LoggerFactory;
 /**
  * A prescreening local optimization.
  * @author Johannes Dieterich
- * @version 2014-12-14
+ * @version 2020-04-29
  */
 public class GenericAbsolutePrescreeningLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E,T> {
     
-    private static final long serialVersionUID = (long) 20131124;
+    private static final long serialVersionUID = (long) 20200429;
     private static final Logger l = LoggerFactory.getLogger(GenericAbsolutePrescreeningLocOpt.class);
     protected final GenericLocOpt<E,T> locopt;
     protected final double maxFitness;
@@ -61,12 +61,12 @@ public class GenericAbsolutePrescreeningLocOpt <E,T extends ContinuousProblem<E>
     
  public GenericAbsolutePrescreeningLocOpt(final GenericAbsolutePrescreeningLocOpt<E,T> orig){
         super(orig);
-        this.locopt = orig.locopt.clone();
+        this.locopt = orig.locopt.copy();
         this.maxFitness = orig.maxFitness;
     }
     
     @Override
-    public GenericAbstractLocOpt<E, T> clone() {
+    public GenericAbstractLocOpt<E, T> copy() {
         return new GenericAbsolutePrescreeningLocOpt<>(this);
     }
 
@@ -75,7 +75,7 @@ public class GenericAbsolutePrescreeningLocOpt <E,T extends ContinuousProblem<E>
         
         // one shot
         @SuppressWarnings("unchecked")
-        final double[] genome = back.getActiveCoordinates((T) individual.clone());
+        final double[] genome = back.getActiveCoordinates((T) individual.copy());
         final double e = back.fitness(genome, 0);
         
         l.debug("Fitness of one shot is " + e + " compared to " + maxFitness);

--- a/src/org/ogolem/generic/GenericAbstractGradFreeLocOpt.java
+++ b/src/org/ogolem/generic/GenericAbstractGradFreeLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,11 +43,11 @@ import org.ogolem.generic.stats.GenericDetailStatistics;
  * An abstract implementation for a local optimization for continuous problems
  * for gradient-free local optimizations.
  * @author Johannes Dieterich
- * @version 2014-12-15
+ * @version 2020-04-29
  */
 public abstract class GenericAbstractGradFreeLocOpt<E,T extends ContinuousProblem<E>> implements GenericLocOpt<E,T>{
     
-    private static final long serialVersionUID = (long) 20131124;
+    private static final long serialVersionUID = (long) 20200429;
     protected final GenericFitnessBackend<E,T> back;
     
     public GenericAbstractGradFreeLocOpt(final GenericFitnessBackend<E,T> back){
@@ -54,11 +55,11 @@ public abstract class GenericAbstractGradFreeLocOpt<E,T extends ContinuousProble
     }
     
     protected GenericAbstractGradFreeLocOpt(final GenericAbstractGradFreeLocOpt<E,T> orig){
-        this.back = orig.back.clone();
+        this.back = orig.back.copy();
     }
     
     @Override
-    public abstract GenericAbstractGradFreeLocOpt<E,T> clone();
+    public abstract GenericAbstractGradFreeLocOpt<E,T> copy();
     
     @Override
     public T fitness(final T individual, final boolean forceOneEval){     

--- a/src/org/ogolem/generic/GenericAbstractLocOpt.java
+++ b/src/org/ogolem/generic/GenericAbstractLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013-2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.generic.stats.GenericDetailStatistics;
 /**
  * An abstract implementation for a local optimization for continuous problems.
  * @author Johannes Dieterich
- * @version 2015-01-04
+ * @version 2020-04-29
  */
 public abstract class GenericAbstractLocOpt<E,T extends ContinuousProblem<E>> implements GenericLocOpt<E,T>{
     
-    private static final long serialVersionUID = (long) 20131124;
+    private static final long serialVersionUID = (long) 20200429;
     protected final GenericBackend<E,T> back;
     
     public GenericAbstractLocOpt(final GenericBackend<E,T> back){
@@ -53,11 +54,11 @@ public abstract class GenericAbstractLocOpt<E,T extends ContinuousProblem<E>> im
     }
     
     protected GenericAbstractLocOpt(final GenericAbstractLocOpt<E,T> orig){
-        this.back = orig.back.clone();
+        this.back = orig.back.copy();
     }
     
     @Override
-    public abstract GenericAbstractLocOpt<E,T> clone();
+    public abstract GenericAbstractLocOpt<E,T> copy();
     
     @Override
     public T fitness(final T individual, final boolean forceOneEval){     

--- a/src/org/ogolem/generic/GenericBackend.java
+++ b/src/org/ogolem/generic/GenericBackend.java
@@ -1,5 +1,6 @@
 /**
-Copyright (c) 2013-2020, J. M. Dieterich
+Copyright (c) 2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,12 +42,12 @@ package org.ogolem.generic;
  * continuous problem.
  * @author Johannes Dieterich
  * @author Dominik Behrens
- * @version 2020-04-22
+ * @version 2020-04-29
  */
 public interface GenericBackend<E,T extends ContinuousProblem<E>> extends GenericFitnessBackend<E,T>{
     
     @Override
-    public GenericBackend<E,T> clone();
+    public GenericBackend<E,T> copy();
         
     /**
      * Calculates the fitness and gradient of this individual. getActiveCoordinates(T) must be called prior the first call to this routine!

--- a/src/org/ogolem/generic/GenericChainedFitnessFunc.java
+++ b/src/org/ogolem/generic/GenericChainedFitnessFunc.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,11 +43,11 @@ import java.util.List;
 /**
  * A generic chain of fitness functions.
  * @author Johannes Dieterich
- * @version 2014-12-20
+ * @version 2020-04-29
  */
 public class GenericChainedFitnessFunc<E,T extends Optimizable<E>> implements GenericFitnessFunction<E,T> {
     
-    private static final long serialVersionUID = (long) 20141220;
+    private static final long serialVersionUID = (long) 20200429;
 
     private final List<GenericFitnessFunction<E,T>> functions;
     private final double cutoff;
@@ -61,13 +62,13 @@ public class GenericChainedFitnessFunc<E,T extends Optimizable<E>> implements Ge
         if(orig.functions.isEmpty()){throw new RuntimeException("Wrong input for chained fitness function.");}
         this.functions = new ArrayList<>();
         orig.functions.forEach((function) -> {
-            this.functions.add(function.clone());
+            this.functions.add(function.copy());
         });
         this.cutoff = orig.cutoff;
     }
     
     @Override
-    public GenericChainedFitnessFunc<E, T> clone() {
+    public GenericChainedFitnessFunc<E, T> copy() {
         return new GenericChainedFitnessFunc<>(this);
     }
 

--- a/src/org/ogolem/generic/GenericChainedMutation.java
+++ b/src/org/ogolem/generic/GenericChainedMutation.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +44,11 @@ import org.ogolem.random.Lottery;
 /**
  * A chain of mutation operators.
  * @author Johannes Dieterich
- * @version 2014-05-04
+ * @version 2020-04-29
  */
 public class GenericChainedMutation<E, T extends Optimizable<E>> implements GenericMutation<E,T> {
 
-    private static final long serialVersionUID = (long) 2014054;
+    private static final long serialVersionUID = (long) 20200429;
     private final List<GenericMutation<E,T>> mutations;
     private final List<Double> probs;
     private final Lottery r;
@@ -94,7 +95,7 @@ public class GenericChainedMutation<E, T extends Optimizable<E>> implements Gene
     public T mutate(final T orig) {
         
         assert(mutations.size() == probs.size());
-        T mutated = (T) orig.clone();
+        T mutated = (T) orig.copy();
         for(int i = 0; i < mutations.size(); i++){
             if(r.nextDouble() < probs.get(i)){
                 mutated = mutations.get(i).mutate(mutated);

--- a/src/org/ogolem/generic/GenericChainedXOver.java
+++ b/src/org/ogolem/generic/GenericChainedXOver.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,11 +45,11 @@ import org.ogolem.random.Lottery;
 /**
  * A chain of crossover operators.
  * @author Johannes Dieterich
- * @version 2014-05-04
+ * @version 2020-04-29
  */
 public class GenericChainedXOver<E,T extends Optimizable<E>> implements GenericCrossover<E,T> {
     
-    private static final long serialVersionUID = (long) 2014054;
+    private static final long serialVersionUID = (long) 20200429;
     private final List<GenericCrossover<E,T>> xovers;
     private final List<Double> probs;
     private final Lottery r;
@@ -95,7 +96,7 @@ public class GenericChainedXOver<E,T extends Optimizable<E>> implements GenericC
     public Tuple<T, T> crossover(final T mother, final T father, final long futureID) {
         
         assert(xovers.size() == probs.size());
-        Tuple<T,T> children = new Tuple<>((T) mother.clone(), (T)father.clone());
+        Tuple<T,T> children = new Tuple<>((T) mother.copy(), (T)father.copy());
         for(int  i = 0; i < xovers.size(); i++){
             if(r.nextDouble() < probs.get(i)){
                 children = xovers.get(i).crossover(children.getObject1(), children.getObject2(), futureID);

--- a/src/org/ogolem/generic/GenericFitnessBackend.java
+++ b/src/org/ogolem/generic/GenericFitnessBackend.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,14 +43,14 @@ package org.ogolem.generic;
  * nature yet, we strongly suspect this to be the case and may change this in
  * the future.
  * @author Johannes Dieterich
- * @version 2015-03-27
+ * @version 2020-04-29
  */
 public interface GenericFitnessBackend<E,T extends Optimizable<E>> extends GenericFitnessFunction<E,T> {
     
     public enum BOUNDSTYPE{NONE, SOME, ALL};
     
     @Override
-    public GenericFitnessBackend<E,T> clone();
+    public GenericFitnessBackend<E,T> copy();
     
     /**
      * Returns the number of active, i.e., to be optimized, coordinates in this

--- a/src/org/ogolem/generic/GenericFitnessFunction.java
+++ b/src/org/ogolem/generic/GenericFitnessFunction.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,12 @@ import java.io.Serializable;
 /**
  * An interface for generic fitness functions.
  * @author Johannes Dieterich
- * @version 2013-11-22
+ * @version 2020-04-29
  */
-public interface GenericFitnessFunction<E,T extends Optimizable<E>> extends Serializable, Cloneable {
+public interface GenericFitnessFunction<E,T extends Optimizable<E>> extends Serializable, Copyable {
     
-    public GenericFitnessFunction<E,T> clone();
+	@Override
+    GenericFitnessFunction<E,T> copy();
     
     String getMyID();
     

--- a/src/org/ogolem/generic/GenericFitnessFunctionBackendWrapper.java
+++ b/src/org/ogolem/generic/GenericFitnessFunctionBackendWrapper.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-                2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,11 @@ package org.ogolem.generic;
 /**
  * A basic wrapper for interface translation
  * @author Johannes Dieterich
- * @version 2015-03-28
+ * @version 2020-04-29
  */
 public class GenericFitnessFunctionBackendWrapper<T extends Optimizable<Double>> implements GenericFitnessBackend<Double,T> {
 
-    private static final long serialVersionUID = (long) 20141217;
+    private static final long serialVersionUID = (long) 20200429;
     private final GenericFitnessFunction<Double,T> func;
     private final double[] lower;
     private final double[] upper;
@@ -63,13 +63,13 @@ public class GenericFitnessFunctionBackendWrapper<T extends Optimizable<Double>>
     }
     
     public GenericFitnessFunctionBackendWrapper(final GenericFitnessFunctionBackendWrapper<T> orig){
-        this.func = orig.func.clone();
+        this.func = orig.func.copy();
         this.lower = (orig.lower == null) ? null : orig.lower.clone();
         this.upper = (orig.upper == null) ? null : orig.upper.clone();
     }
     
     @Override
-    public GenericFitnessFunctionBackendWrapper<T> clone() {
+    public GenericFitnessFunctionBackendWrapper<T> copy() {
         return new GenericFitnessFunctionBackendWrapper<>(this);
     }
 

--- a/src/org/ogolem/generic/GenericGermanyCrossover.java
+++ b/src/org/ogolem/generic/GenericGermanyCrossover.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich and B. Hartke
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +44,11 @@ import org.ogolem.helpers.Tuple;
  * A generic genotype crossover using real numbers (you can't get much easier
  * than that).
  * @author Johannes Dieterich
- * @version 2014-03-27
+ * @version 2020-04-29
  */
 public class GenericGermanyCrossover <E,T extends Optimizable<E>> implements GenericCrossover<E,T>{
     
-    private static final long serialVersionUID = (long) 20131122;
+    private static final long serialVersionUID = (long) 20200429;
     private final double gaussWidth;
     
     public GenericGermanyCrossover(final double gaussWidth){
@@ -68,9 +69,9 @@ public class GenericGermanyCrossover <E,T extends Optimizable<E>> implements Gen
     public Tuple<T,T> crossover(final T mother, final T father, final long futureID){
         
         @SuppressWarnings("unchecked")
-        final T child1 = (T) mother.clone();
+        final T child1 = (T) mother.copy();
         @SuppressWarnings("unchecked")
-        final T child2 = (T) father.clone();
+        final T child2 = (T) father.copy();
         final E[] genomeChild1 = child1.getGenomeCopy();
         final E[] genomeChild2 = child2.getGenomeCopy();
         

--- a/src/org/ogolem/generic/GenericGlobalOptimization.java
+++ b/src/org/ogolem/generic/GenericGlobalOptimization.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,12 @@ import java.io.Serializable;
 /**
  * Interface for all (generic) global optimizations.
  * @author Johannes Dieterich
- * @version 2013-11-22
+ * @version 2020-04-29
  */
-public interface GenericGlobalOptimization<E,T extends Optimizable<E>> extends Serializable, Cloneable {
+public interface GenericGlobalOptimization<E,T extends Optimizable<E>> extends Serializable, Copyable {
     
-    public GenericGlobalOptimization<E,T> clone();
+	@Override
+    GenericGlobalOptimization<E,T> copy();
     
     String getMyID();
     

--- a/src/org/ogolem/generic/GenericHollandCrossover.java
+++ b/src/org/ogolem/generic/GenericHollandCrossover.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * A not-crossing crossover.
  * @author Johannes Dieterich
- * @version 2013-11-24
+ * @version 2020-04-29
  */
 public class GenericHollandCrossover <E,T extends Optimizable<E>> implements GenericCrossover<E,T>{
     
-    private static final long serialVersionUID = (long) 20131124;
+    private static final long serialVersionUID = (long) 20200429;
 
     @Override
     public GenericHollandCrossover<E,T> clone(){
@@ -61,8 +62,8 @@ public class GenericHollandCrossover <E,T extends Optimizable<E>> implements Gen
     @Override
     public Tuple<T,T> crossover(final T mother, final T father, final long futureID){
         
-        final T t1 = (T)mother.clone();
-        final T t2 = (T)father.clone();
+        final T t1 = (T)mother.copy();
+        final T t2 = (T)father.copy();
         t1.setID(futureID);
         t2.setID(futureID);
         

--- a/src/org/ogolem/generic/GenericInitializer.java
+++ b/src/org/ogolem/generic/GenericInitializer.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,12 @@ import java.io.Serializable;
 /**
  * Interface for a generic initializer.
  * @author Johannes Dieterich
- * @version 2013-11-23
+ * @version 2020-04-29
  */
-public interface GenericInitializer<E,T extends Optimizable<E>> extends Serializable, Cloneable{
+public interface GenericInitializer<E,T extends Optimizable<E>> extends Serializable, Copyable{
    
-    GenericInitializer<E,T> clone();
+	@Override
+    GenericInitializer<E,T> copy();
     
     T initialize(final T ref, final long futureID);
     

--- a/src/org/ogolem/generic/GenericLocOpt.java
+++ b/src/org/ogolem/generic/GenericLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,7 +45,7 @@ package org.ogolem.generic;
 public interface GenericLocOpt<E,T extends ContinuousProblem<E>> extends GenericFitnessFunction<E,T>{
     
     @Override
-    public GenericLocOpt<E,T> clone();
+    public GenericLocOpt<E,T> copy();
     
     public GenericFitnessBackend<E,T> getFitnessBackend();
     

--- a/src/org/ogolem/generic/GenericMultipleGlobOpt.java
+++ b/src/org/ogolem/generic/GenericMultipleGlobOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +44,11 @@ import org.ogolem.random.Lottery;
 /**
  * Multiple GLOBAL OPTIMIZATIONS wrapped nicely.
  * @author Johannes Dieterich
- * @version 2014-05-18
+ * @version 2020-04-29
  */
 public class GenericMultipleGlobOpt<E,T extends Optimizable<E>> implements GenericGlobalOptimization<E,T> {
 
-    private static final long serialVersionUID = (long) 20140518;
+    private static final long serialVersionUID = (long) 20200429;
     private final Lottery random = Lottery.getInstance();
     private final List<GenericGlobalOptimization<E,T>> globopts;
     private final double[] probabilities;
@@ -75,12 +76,12 @@ public class GenericMultipleGlobOpt<E,T extends Optimizable<E>> implements Gener
         this.probabilities = orig.probabilities.clone();
         this.globopts = new ArrayList<>(orig.globopts.size());
         orig.globopts.forEach((opt) -> {
-            this.globopts.add(opt.clone());
+            this.globopts.add(opt.copy());
         });
     }
     
     @Override
-    public GenericGlobalOptimization<E, T> clone() {
+    public GenericGlobalOptimization<E, T> copy() {
         return new GenericMultipleGlobOpt<>(this);
     }
 

--- a/src/org/ogolem/generic/GenericMutationAsXOver.java
+++ b/src/org/ogolem/generic/GenericMutationAsXOver.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * Adaptor to translate turn a mutation into a crossover.
  * @author Johannes Dieterich
- * @version 2014-04-01
+ * @version 2020-04-29
  */
 public class GenericMutationAsXOver<E, T extends Optimizable<E>> implements GenericCrossover<E,T> {
 
-    private static final long serialVersionUID = (long) 20140401;
+    private static final long serialVersionUID = (long) 20200429;
     private final GenericMutation<E,T> mutation;
     
     public GenericMutationAsXOver(final GenericMutation<E,T> mut){
@@ -70,9 +71,9 @@ public class GenericMutationAsXOver<E, T extends Optimizable<E>> implements Gene
     @Override
     public Tuple<T, T> crossover(final T mother, final T father, final long futureID) {
         
-        final T work1 = (T) mother.clone();
+        final T work1 = (T) mother.copy();
         work1.setID(futureID);
-        final T work2 = (T) father.clone();
+        final T work2 = (T) father.copy();
         work2.setID(futureID);
         
         final T child1 = mutation.mutate(work1);

--- a/src/org/ogolem/generic/GenericNoLocOpt.java
+++ b/src/org/ogolem/generic/GenericNoLocOpt.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,11 +39,11 @@ package org.ogolem.generic;
 /**
  * A non-locopt local optimization, i.e., a single point.
  * @author Johannes Dieterich
- * @version 2015-04-04
+ * @version 2020-04-29
  */
 public class GenericNoLocOpt<E,T extends ContinuousProblem<E>> implements GenericLocOpt<E,T> {
 
-    private static final long serialVersionUID = (long) 20150404;
+    private static final long serialVersionUID = (long) 20200429;
 
     private final GenericFitnessBackend<E,T> backend;
     
@@ -52,11 +52,11 @@ public class GenericNoLocOpt<E,T extends ContinuousProblem<E>> implements Generi
     }
     
     GenericNoLocOpt(final GenericNoLocOpt<E,T> orig){
-        this.backend = orig.backend.clone();
+        this.backend = orig.backend.copy();
     }
     
     @Override
-    public GenericLocOpt<E, T> clone() {
+    public GenericLocOpt<E, T> copy() {
         return new GenericNoLocOpt<>(this);
     }
     

--- a/src/org/ogolem/generic/GenericPortugalCrossover.java
+++ b/src/org/ogolem/generic/GenericPortugalCrossover.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich and B. Hartke
+              2013, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +44,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * An n-point, generic genotype, real-number based crossover operator.
  * @author Johannes Dieterich
- * @version 2013-11-22
+ * @version 2020-04-29
  */
 public class GenericPortugalCrossover <E,T extends Optimizable<E>> implements GenericCrossover<E,T>{
     
-    private static final long serialVersionUID = (long) 20131122;
+    private static final long serialVersionUID = (long) 20200429;
     private final int noCrosses;
     
     public GenericPortugalCrossover(final int noCrosses){
@@ -68,9 +69,9 @@ public class GenericPortugalCrossover <E,T extends Optimizable<E>> implements Ge
     public Tuple<T,T> crossover(final T mother, final T father, final long futureID){
         
         @SuppressWarnings("unchecked")
-        final T child1 = (T) mother.clone();
+        final T child1 = (T) mother.copy();
         @SuppressWarnings("unchecked")
-        final T child2 = (T) father.clone();
+        final T child2 = (T) father.copy();
         final E[] genomeChild1 = child1.getGenomeCopy();
         final E[] genomeChild2 = child2.getGenomeCopy();
         

--- a/src/org/ogolem/generic/GenericRelativePrescreeningLocOpt.java
+++ b/src/org/ogolem/generic/GenericRelativePrescreeningLocOpt.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,11 +47,11 @@ import org.slf4j.LoggerFactory;
  * environments or b) in environments where the pool is being propagated to the clients
  * (regularly).
  * @author Johannes Dieterich
- * @version 2016-01-14
+ * @version 2020-04-29
  */
 public class GenericRelativePrescreeningLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E,T>{
     
-    private static final long serialVersionUID = (long) 20131124;
+    private static final long serialVersionUID = (long) 20200429;
     private static final Logger l = LoggerFactory.getLogger(GenericRelativePrescreeningLocOpt.class);
     protected final GenericAbstractLocOpt<E,T> locopt;
     protected final GenericPool<E,T> pool;
@@ -68,13 +68,13 @@ public class GenericRelativePrescreeningLocOpt <E,T extends ContinuousProblem<E>
     
     public GenericRelativePrescreeningLocOpt(final GenericRelativePrescreeningLocOpt<E,T> orig){
         super(orig);
-        this.locopt = orig.locopt.clone();
+        this.locopt = orig.locopt.copy();
         this.maxPerc = orig.maxPerc;
         this.pool = orig.pool; // is a singleton!
     }
     
     @Override
-    public GenericRelativePrescreeningLocOpt<E,T> clone(){
+    public GenericRelativePrescreeningLocOpt<E,T> copy(){
         return new GenericRelativePrescreeningLocOpt<>(this);
     }
     
@@ -88,7 +88,7 @@ public class GenericRelativePrescreeningLocOpt <E,T extends ContinuousProblem<E>
         
         // one shot
         @SuppressWarnings("unchecked")
-        final double[] genome = back.getActiveCoordinates((T) individual.clone());
+        final double[] genome = back.getActiveCoordinates((T) individual.copy());
         final double e = back.fitness(genome, 0);
         
         final double currBest = pool.getFitnessOfIndividualAtPos(0);

--- a/src/org/ogolem/generic/IndividualReader.java
+++ b/src/org/ogolem/generic/IndividualReader.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,12 @@ import java.io.Serializable;
 /**
  * An interface for reading stuff from a file.
  * @author Johannes Dieterich
- * @version 2014-04-02
+ * @version 2020-04-29
  */
-public interface IndividualReader<T> extends Serializable, Cloneable {
-    
-    IndividualReader<T> clone();
+public interface IndividualReader<T> extends Serializable, Cloneable, Copyable {
+
+	@Override
+    IndividualReader<T> copy();
     
     void populateIndividualFromFile(final T individual, final String file) throws Exception;
     

--- a/src/org/ogolem/generic/NoCrossover.java
+++ b/src/org/ogolem/generic/NoCrossover.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * A no crossover, essentially a double copy machine.
  * @author Johannes Dieterich
- * @version 2014-03-29
+ * @version 2020-04-29
  */
 public class NoCrossover<E, T extends Optimizable<E>> implements GenericCrossover<E,T> {
 
-    private static final long serialVersionUID = (long) 20140401;
+    private static final long serialVersionUID = (long) 20200429;
     
     @Override
     public GenericCrossover<E, T> clone() {
@@ -61,9 +62,9 @@ public class NoCrossover<E, T extends Optimizable<E>> implements GenericCrossove
     @SuppressWarnings("unchecked")
     public Tuple<T, T> crossover(final T mother, final T father, final long futureID) {
         
-        final T child1 = (T) mother.clone();
+        final T child1 = (T) mother.copy();
         child1.setID(futureID);
-        final T child2 = (T) father.clone();
+        final T child2 = (T) father.copy();
         child2.setID(futureID);
         return new Tuple<>(child1,child2);
     }

--- a/src/org/ogolem/generic/NoMutation.java
+++ b/src/org/ogolem/generic/NoMutation.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,11 +40,11 @@ package org.ogolem.generic;
 /**
  * A not-mutation. Essentially just a copy machine.
  * @author Johannes Dieterich
- * @version 2014-03-29
+ * @version 2020-04-29
  */
 public class NoMutation<E, T extends Optimizable<E>> implements GenericMutation<E,T>{
 
-    private static final long serialVersionUID = (long) 20140401;
+    private static final long serialVersionUID = (long) 20200429;
     
     @Override
     public GenericMutation<E, T> clone() {
@@ -59,7 +60,7 @@ public class NoMutation<E, T extends Optimizable<E>> implements GenericMutation<
     @Override
     public T mutate(final T orig) {
         
-        final T copy = (T) orig.clone();
+        final T copy = (T) orig.copy();
         return copy;
     }
     

--- a/src/org/ogolem/generic/Optimizable.java
+++ b/src/org/ogolem/generic/Optimizable.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2010, J. M. Dieterich and B. Hartke
               2012-2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,11 +43,11 @@ import java.io.Serializable;
 /**
  * Defined to unify all possible optimizable problems.
  * @author Johannes Dieterich
- * @version 2013-11-22
+ * @version 2020-04-29
  */
-public interface Optimizable<T extends Object> extends Serializable, Cloneable {
+public interface Optimizable<T extends Object> extends Serializable, Copyable {
 
-    Optimizable<T> clone();
+    Optimizable<T> copy();
     
     boolean isDiscreteProblem();
     

--- a/src/org/ogolem/generic/genericpool/GenericParentSelectors.java
+++ b/src/org/ogolem/generic/genericpool/GenericParentSelectors.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2012-2014, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ import org.ogolem.random.RandomUtils;
  * A collection of some simple parent selection algorithms.
  * @author Johannes Dieterich
  * @author Bernd Hartke
- * @version 2016-01-14
+ * @version 2020-04-29
  */
 public class GenericParentSelectors {
     
@@ -156,8 +156,8 @@ public class GenericParentSelectors {
             final int index2 = r.nextInt((int) Math.round(stepAt2 * poolSize));
             
             final List<T> parents = new LinkedList<>();
-            parents.add((T) pool.getIndividualAtPosition(index1).clone());
-            parents.add((T) pool.getIndividualAtPosition(index2).clone());
+            parents.add((T) pool.getIndividualAtPosition(index1).copy());
+            parents.add((T) pool.getIndividualAtPosition(index2).copy());
             
             return parents;
         }
@@ -205,8 +205,8 @@ public class GenericParentSelectors {
                     if(niche == null){
                         System.err.println("ERROR: No niche info for individual at pool position " + i + ". Returning position 0 twice as parent.");
                         final List<T> parents = new LinkedList<>();
-                        parents.add((T) pool.getIndividualAtPosition(0).clone());
-                        parents.add((T) pool.getIndividualAtPosition(0).clone());
+                        parents.add((T) pool.getIndividualAtPosition(0).copy());
+                        parents.add((T) pool.getIndividualAtPosition(0).copy());
                         
                         return parents;
                     }
@@ -260,11 +260,11 @@ public class GenericParentSelectors {
             
             final List<T> parents = new LinkedList<>();
             if(perNiche){
-                parents.add((T) pool.getIndividualAtPosition(listNicheMemberPositions.get(niche1).get(index1)).clone());
-                parents.add((T) pool.getIndividualAtPosition(listNicheMemberPositions.get(niche2).get(index2)).clone());
+                parents.add((T) pool.getIndividualAtPosition(listNicheMemberPositions.get(niche1).get(index1)).copy());
+                parents.add((T) pool.getIndividualAtPosition(listNicheMemberPositions.get(niche2).get(index2)).copy());
             }else{
-                parents.add((T) pool.getIndividualAtPosition(index1).clone());
-                parents.add((T) pool.getIndividualAtPosition(index2).clone());
+                parents.add((T) pool.getIndividualAtPosition(index1).copy());
+                parents.add((T) pool.getIndividualAtPosition(index2).copy());
             }
             
             return parents;
@@ -344,8 +344,8 @@ public class GenericParentSelectors {
             assert(index2 < poolSize && index2 >= 0);
             
             final List<T> parents = new LinkedList<>();
-            parents.add((T) pool.getIndividualAtPosition(index1).clone());
-            parents.add((T) pool.getIndividualAtPosition(index2).clone());
+            parents.add((T) pool.getIndividualAtPosition(index1).copy());
+            parents.add((T) pool.getIndividualAtPosition(index2).copy());
             
             return parents;
         }

--- a/src/org/ogolem/generic/genericpool/GenericPool.java
+++ b/src/org/ogolem/generic/genericpool/GenericPool.java
@@ -53,7 +53,7 @@ import org.ogolem.io.OutputPrimitives;
 /**
  * A generic genetic pool.
  * @author Johannes Dieterich
- * @version 2020-04-13
+ * @version 2020-04-29
  */
 public class GenericPool<E,T extends Optimizable<E>> implements Serializable, Iterable<GenericPoolEntry<E,T>> {
     
@@ -607,7 +607,7 @@ public class GenericPool<E,T extends Optimizable<E>> implements Serializable, It
                 final double posFit = entry.getFitness();
                 if(fitness < posFit){
                 
-                    final GenericPoolEntry<E,T> addEntry = newEntry.clone();
+                    final GenericPoolEntry<E,T> addEntry = newEntry.copy();
                     geneticPool.add(pos, addEntry);
                     
                     nicher.report(niche);
@@ -664,7 +664,7 @@ public class GenericPool<E,T extends Optimizable<E>> implements Serializable, It
                     final boolean divBack = diversity.areDiverse(newEntry, entry);
                     if(!divBack){
                         // not enough diversity compared to the previous pos individual -> "replace" the other individual, thereby keeping the pool size constant
-                        final GenericPoolEntry<E,T> addEntry = newEntry.clone();
+                        final GenericPoolEntry<E,T> addEntry = newEntry.copy();
                         geneticPool.set(pos, addEntry);
                         // ensure pool size
                         ensureSize(poolSize);
@@ -674,7 +674,7 @@ public class GenericPool<E,T extends Optimizable<E>> implements Serializable, It
                     }
                     
                     // both diversity to the front AND to the back. just add in between.
-                    final GenericPoolEntry<E,T> addEntry = newEntry.clone();
+                    final GenericPoolEntry<E,T> addEntry = newEntry.copy();
                     geneticPool.add(pos, addEntry);
                     
                     // ensure pool size

--- a/src/org/ogolem/generic/genericpool/GenericPoolEntry.java
+++ b/src/org/ogolem/generic/genericpool/GenericPoolEntry.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2012, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,14 +38,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.generic.genericpool;
 
 import java.io.Serializable;
+import org.ogolem.generic.Copyable;
 import org.ogolem.generic.Optimizable;
 
 /**
  * An individual for the generic pool
  * @author Johannes Dieterich
- * @version 2012-02-15
+ * @version 2020-04-29
  */
-public class GenericPoolEntry<E,T extends Optimizable<E>> implements Serializable, Cloneable {
+public class GenericPoolEntry<E,T extends Optimizable<E>> implements Serializable, Copyable {
     
     private static final long serialVersionUID = (long) 20120215;
     
@@ -69,12 +71,12 @@ public class GenericPoolEntry<E,T extends Optimizable<E>> implements Serializabl
     @SuppressWarnings("unchecked")
     GenericPoolEntry(final GenericPoolEntry<E,T> orig){
         this.fitness = orig.fitness;
-        this.individual = (orig.individual == null) ? null : (T) orig.individual.clone();
+        this.individual = (orig.individual == null) ? null : (T) orig.individual.copy();
         this.niche = (orig.niche == null) ? null : orig.niche.clone();
     }
     
     @Override
-    public GenericPoolEntry<E,T> clone(){
+    public GenericPoolEntry<E,T> copy(){
         return new GenericPoolEntry<>(this);
     }
     

--- a/src/org/ogolem/generic/genericpool/NicheComputer.java
+++ b/src/org/ogolem/generic/genericpool/NicheComputer.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2010, J. M. Dieterich and B. Hartke
               2012, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -39,16 +39,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.generic.genericpool;
 
 import java.io.Serializable;
+import org.ogolem.generic.Copyable;
 import org.ogolem.generic.Optimizable;
 
 /**
  * Computes a niche.
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  */
-public interface NicheComputer<E,T extends Optimizable<E>> extends Serializable, Cloneable {
+public interface NicheComputer<E,T extends Optimizable<E>> extends Serializable, Copyable {
     
-    NicheComputer<E,T> clone();
+	@Override
+    NicheComputer<E,T> copy();
     
     Niche computeNiche(final T individual);
 }

--- a/src/org/ogolem/generic/threading/GenericGlobOptTask.java
+++ b/src/org/ogolem/generic/threading/GenericGlobOptTask.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A generic implementation of a global optimization task.
  * @author Johannes Dieterich
- * @version 2020-04-24
+ * @version 2020-04-29
  */
 public class GenericGlobOptTask <E,T extends Optimizable<E>,V extends GenericGlobalOptimization<E,T>> implements TaskFactory<E,T,V>{
     
@@ -87,12 +87,12 @@ public class GenericGlobOptTask <E,T extends Optimizable<E>,V extends GenericGlo
                     }
                 } else if(!useCache && !DEBUG){
                     l.debug("Trying to use new object as helper for global opt...");
-                    final V helpers = (V) cache.getOriginalEntry().clone();
+                    final V helpers = (V) cache.getOriginalEntry().copy();
                     runme(helpers,pool,history,taskID);
                 } else{
                     try{
                         l.debug("Trying to use new object as helper for global opt (try/catch)...");
-                        final V helpers = (V) cache.getOriginalEntry().clone();
+                        final V helpers = (V) cache.getOriginalEntry().copy();
                         runme(helpers,pool,history,taskID);
                     } catch(Throwable t){
                         t.printStackTrace(System.err);

--- a/src/org/ogolem/generic/threading/GenericInitTask.java
+++ b/src/org/ogolem/generic/threading/GenericInitTask.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A generic implementation of an initialization task.
  * @author Johannes Dieterich
- * @version 2016-10-26
+ * @version 2020-04-29
  */
 public class GenericInitTask<E,T extends Optimizable<E>,V extends GenericInitializer<E,T>> implements TaskFactory<E,T,V>{
     
@@ -85,12 +85,12 @@ public class GenericInitTask<E,T extends Optimizable<E>,V extends GenericInitial
                     stuff.setObject1(false);
                 } else if(!useCache && !DEBUG){
                     l.debug("Trying to use new object as helper for initializing...");
-                    final V helpers = (V) cache.getOriginalEntry().clone();
+                    final V helpers = (V) cache.getOriginalEntry().copy();
                     runme(helpers,pool,taskID);
                 } else{
                     try{
                         l.debug("Trying to use new object as helper for initializing (try/catch)...");
-                        final V helpers = (V) cache.getOriginalEntry().clone();
+                        final V helpers = (V) cache.getOriginalEntry().copy();
                         runme(helpers,pool,taskID);
                     } catch(Throwable t){
                         t.printStackTrace(System.err);

--- a/src/org/ogolem/generic/threading/GenericOGOLEMOptimization.java
+++ b/src/org/ogolem/generic/threading/GenericOGOLEMOptimization.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -56,6 +56,7 @@ import org.ogolem.generic.IndividualWriter;
 import org.ogolem.generic.genericpool.NicheComputer;
 import org.ogolem.generic.stats.GenericDetailStatistics;
 import org.ogolem.helpers.Fortune;
+import org.ogolem.helpers.CopyableTuple;
 import org.ogolem.helpers.Tuple;
 import org.ogolem.io.OutputPrimitives;
 import org.slf4j.Logger;
@@ -64,7 +65,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A fully generic, shared-memory global optimization manager.
  * @author Johannes Dieterich
- * @version 2016-10-26
+ * @version 2020-04-29
  */
 public class GenericOGOLEMOptimization<E,T extends Optimizable<E>> {
     
@@ -134,7 +135,7 @@ public class GenericOGOLEMOptimization<E,T extends Optimizable<E>> {
         final GenericGlobalOptimization<E,T> globopt;
         ObjectCache<GenericInitializer<E,T>> initCache = null;
         ObjectCache<GenericGlobalOptimization<E,T>> globCache = null;
-        ObjectCache<Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> fitFuncCache = null;
+        ObjectCache<CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> fitFuncCache = null;
         TaskFactory<E,T,GenericInitializer<E,T>> initTasks = null;
         TaskFactory<E,T,GenericGlobalOptimization<E,T>> globTasks = null;
         int noGlobSteps = -1;
@@ -149,7 +150,7 @@ public class GenericOGOLEMOptimization<E,T extends Optimizable<E>> {
             fitness = config.getFitnessFunction();
             initCache = new ObjectCache<>(noThreads,initializer);
             globCache = new ObjectCache<>(noThreads,globopt);
-            final Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>> tup = new Tuple<>(reader,fitness);
+            final CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>> tup = new CopyableTuple<>(reader,fitness);
             fitFuncCache = new ObjectCache<>(noThreads,tup);
             enableDetailedStats = config.wantsDetailedStats();
         } catch(final Exception e){
@@ -177,7 +178,7 @@ public class GenericOGOLEMOptimization<E,T extends Optimizable<E>> {
         int noSeeded = 0;
         if(seedFolder != null && !seedFolder.isEmpty()){
             // apparently we do want to use them
-            TaskFactory<E,T,Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> seedTasks = null;
+            TaskFactory<E,T,CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> seedTasks = null;
             try{
                 seedTasks = new GenericSeedTask<>(seedFolder);
             } catch(Exception e){
@@ -186,7 +187,7 @@ public class GenericOGOLEMOptimization<E,T extends Optimizable<E>> {
                 System.exit(-20);
             }
             assert(seedTasks != null);
-            final GenericThreadDispatcher<E,T,Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> initSMPPool
+            final GenericThreadDispatcher<E,T,CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> initSMPPool
                     = new GenericThreadDispatcher<>(noThreads, pool,history,fitFuncCache,0,Math.min(GenericSeedTask.getNoOfSeeds(),
                             poolConfig.getPoolSize()),seedTasks,subsToWait,doNiching,nicheComp);
             initSMPPool.doAllTasks();

--- a/src/org/ogolem/generic/threading/GenericSeedTask.java
+++ b/src/org/ogolem/generic/threading/GenericSeedTask.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,6 +50,7 @@ import org.ogolem.generic.generichistory.GenericHistory;
 import org.ogolem.generic.genericpool.GenericPool;
 import org.ogolem.generic.genericpool.Niche;
 import org.ogolem.generic.genericpool.NicheComputer;
+import org.ogolem.helpers.CopyableTuple;
 import org.ogolem.helpers.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,9 +58,9 @@ import org.slf4j.LoggerFactory;
 /**
  * A generic implementation of an initialization task.
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  */
-public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<E,T,Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>>>{
+public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<E,T,CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>>>{
     
     private static final Logger l = LoggerFactory.getLogger(GenericSeedTask.class);
     private final boolean DEBUG = (GlobalConfig.DEBUGLEVEL > 0);
@@ -85,8 +86,8 @@ public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<
     @SuppressWarnings("unchecked")
     @Override
     public Runnable createTask(final GenericPool<E,T> pool, final GenericHistory<E,T> history,
-            final Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>> refStuff, final boolean useCache,
-            final ObjectCache<Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> cache, 
+            final CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>> refStuff, final boolean useCache,
+            final ObjectCache<CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> cache, 
             final boolean doNiching, final NicheComputer<E,T> nicheComp,
             final ObjectCache<NicheComputer<E,T>> nicheCompCache, final long taskID) {
     
@@ -99,7 +100,7 @@ public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<
                 
                 if(useCache && !DEBUG){
                     l.debug("Trying to use cached object as helper for initializing...");
-                    final Tuple<Boolean,Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> stuff = cache.getUnusedEntry();
+                    final Tuple<Boolean,CopyableTuple<IndividualReader<T>,GenericFitnessFunction<E,T>>> stuff = cache.getUnusedEntry();
                     final Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>> cached = stuff.getObject2();
                     runme(cached,pool,taskID);
                     l.debug("Returning helper for initializing to cache...");
@@ -108,7 +109,7 @@ public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<
                     l.debug("Trying to use new object as helper for initializing...");
                     Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>> helpers = null;
                     try{
-                        helpers = cache.getOriginalEntry().clone();
+                        helpers = cache.getOriginalEntry().copy();
                     } catch(Exception e){
                         System.err.println("Exception in cloneing reader and fitness function.");
                         e.printStackTrace(System.err);
@@ -119,7 +120,7 @@ public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<
                 } else{
                     try{
                         l.debug("Trying to use new object as helper for initializing (try/catch)...");
-                        final Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>> helpers = cache.getOriginalEntry().clone();
+                        final Tuple<IndividualReader<T>,GenericFitnessFunction<E,T>> helpers = cache.getOriginalEntry().copy();
                         runme(helpers,pool,taskID);
                     } catch(Throwable t){
                         t.printStackTrace(System.err);
@@ -143,7 +144,7 @@ public class GenericSeedTask<E,T extends Optimizable<E>> implements TaskFactory<
                 l.info("Seed " + thisSeed + " used for individual " + taskID);
                 
                 // read
-                final T work = (T) pool.getExample().clone();
+                final T work = (T) pool.getExample().copy();
                 try{
                     helper.getObject1().populateIndividualFromFile(work, thisSeed);
                 } catch(Exception e){

--- a/src/org/ogolem/generic/threading/GenericThreadDispatcher.java
+++ b/src/org/ogolem/generic/threading/GenericThreadDispatcher.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich
               2015, J. M. Dieterich and B. Hartke
-              2017, J. M. Dieterich and B. Hartke
+              2017-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.ogolem.generic.Copyable;
 import org.ogolem.generic.Optimizable;
 import org.ogolem.generic.generichistory.GenericHistory;
 import org.ogolem.generic.genericpool.GenericPool;
@@ -55,9 +56,9 @@ import org.slf4j.LoggerFactory;
 /**
  * A generic thread dispatcher.
  * @author Johannes Dieterich
- * @version 2017-03-18
+ * @version 2020-04-29
  */
-public class GenericThreadDispatcher<E,T extends Optimizable<E>,V extends Cloneable> {
+public class GenericThreadDispatcher<E,T extends Optimizable<E>,V extends Copyable> {
     
     private static final Logger l = LoggerFactory.getLogger(GenericThreadDispatcher.class);
     private final int threads;

--- a/src/org/ogolem/generic/threading/ObjectCache.java
+++ b/src/org/ogolem/generic/threading/ObjectCache.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,19 +37,19 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.generic.threading;
 
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.ogolem.generic.Copyable;
 import org.ogolem.helpers.Tuple;
 
 /**
  * A generic object cache. Thread-safe (well, that is the purpose of it).
  * @author Johannes Dieterich
- * @version 2013-11-23
- * @param <T> must be an implementation of Cloneable
+ * @version 2020-04-29
+ * @param <T> must be an implementation of Copyable
  */
-public class ObjectCache<T extends Cloneable> {
+public class ObjectCache<T extends Copyable> {
     
     private static final int MAXTRIES = 1000;
     private final T ref;
@@ -89,10 +90,7 @@ public class ObjectCache<T extends Cloneable> {
     @SuppressWarnings("unchecked")
     private T dirtyClone(final T orig) throws Exception {
         
-        final Class<?> cl = orig.getClass();
-        final Method method = cl.getDeclaredMethod("clone");
-        method.setAccessible(true);
-        final T rtn = (T) method.invoke(orig);
+    	final T rtn = (T) orig.copy();
 
         return rtn;
     }

--- a/src/org/ogolem/generic/threading/TaskFactory.java
+++ b/src/org/ogolem/generic/threading/TaskFactory.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich
-              2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.generic.threading;
 
+import org.ogolem.generic.Copyable;
 import org.ogolem.generic.Optimizable;
 import org.ogolem.generic.generichistory.GenericHistory;
 import org.ogolem.generic.genericpool.GenericPool;
@@ -45,9 +46,9 @@ import org.ogolem.generic.genericpool.NicheComputer;
 /**
  * An interface describing how we want to create more tasks.
  * @author Johannes Dieterich
- * @version 2015-05-26
+ * @version 2020-04-29
  */
-public interface TaskFactory<E,T extends Optimizable<E>,V extends Cloneable> {
+public interface TaskFactory<E,T extends Optimizable<E>,V extends Copyable> {
     
     Runnable createTask(final GenericPool<E,T> pool, final GenericHistory<E,T> history,
             final V refStuff, final boolean useCache, final ObjectCache<V> cache,

--- a/src/org/ogolem/helpers/CopyableTuple.java
+++ b/src/org/ogolem/helpers/CopyableTuple.java
@@ -1,6 +1,6 @@
 /**
-Copyright (c) 2013, J. M. Dieterich
-              2020, J. M. Dieterich and B. Hartke
+Copyright (c) 2010     , J. M. Dieterich and B. Hartke
+              2010-2014, J. M. Dieterich
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,49 +34,22 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-package org.ogolem.generic;
-
-/**
- * A simple generic darwin implementation.
- * @author Johannes Dieterich
- * @version 2020-04-29
  */
-public class SimpleGenericDarwin<E,T extends Optimizable<E>> extends GenericAbstractDarwin<E,T>{
-    
-    private static final long serialVersionUID = (long) 20200429;
-    
-    public SimpleGenericDarwin(final GenericCrossover<E,T> cross, final GenericMutation<E,T> mut,
-            final GenericSanityCheck<E,T> sanity, final GenericFitnessFunction<E,T> fitness,
-            final IndividualWriter<T> writer, final double crossPoss, final double mutPoss,
-            final boolean printBeforeFitness, final int noOfTries){
-        super(cross, mut, sanity, fitness, writer, crossPoss, mutPoss,
-            printBeforeFitness, noOfTries);
-    }
-    
-    public SimpleGenericDarwin(final SimpleGenericDarwin<E,T> orig){
-        super(orig);
-    }
-    
-    @Override
-    public SimpleGenericDarwin<E,T> copy(){
-        return new SimpleGenericDarwin<>(this);
-    }
-    
-    @Override
-    public String getMyID(){
-        return "simple darwin using: "
-                + "\n\txover    " + xover.getMyID()
-                + "\n\tmutation " + mutation.getMyID()
-                + "\n\tfitness  " + fitness.getMyID();
-    }
-    
-    @Override
-    public void postXOver(final T individual1, final T individual2, final long futureID){}
-    
-    @Override
-    public void postMutation(final T individual){}
-    
-    @Override
-    public void runAfterEachTry(){}
+package org.ogolem.helpers;
+
+import org.ogolem.generic.Copyable;
+
+public class CopyableTuple<T extends Copyable, V extends Copyable> extends Tuple<T,V> implements Copyable {
+
+	private static final long serialVersionUID = (long) 20200429;
+	
+	public CopyableTuple(T obj1, V obj2){
+		super(obj1, obj2);
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Override
+	public CopyableTuple<T,V> copy(){
+		return new CopyableTuple<T,V>((T) object1.copy(), (V) object2.copy());
+	}
 }

--- a/src/org/ogolem/helpers/Tuple.java
+++ b/src/org/ogolem/helpers/Tuple.java
@@ -1,6 +1,7 @@
 /**
-Copyright (c) 2010     , J. M. Dieterich and B. Hartke
+Copyright (c) 2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,16 +39,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.helpers;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
 
 /**
  * A 2D Tupel.
  * @author Johannes Dieterich
- * @version 2014-07-09
+ * @version 2020-04-29
  */
-public class Tuple<E,T> implements Serializable, Cloneable {
+public class Tuple<E,T> implements Serializable {
 
-    private static final long serialVersionUID = (long) 20110314;
+    private static final long serialVersionUID = (long) 20200429;
     
     protected E object1;
     protected T object2;
@@ -57,24 +57,6 @@ public class Tuple<E,T> implements Serializable, Cloneable {
         object2 = ob2;
     }
     
-    @SuppressWarnings("unchecked")
-    @Override
-    public Tuple<E,T> clone() throws CloneNotSupportedException{
-        try {
-            final Class<?> cE = object1.getClass();
-	    final Method cloneE = cE.getDeclaredMethod("clone");
-	    final Object clE = cloneE.invoke(object1, new Object[]{});
-            
-            final Class<?> cT = object2.getClass();
-	    final Method cloneT = cT.getDeclaredMethod("clone");
-	    final Object clT = cloneT.invoke(object2, new Object[]{});
-            
-            return new Tuple<>((E) clE, (T) clT);
-        } catch (Throwable t){
-            throw new CloneNotSupportedException(t.toString());
-        }
-    }
-
     public E getObject1(){
         return object1;
     }

--- a/src/org/ogolem/helpers/Tuple3D.java
+++ b/src/org/ogolem/helpers/Tuple3D.java
@@ -1,6 +1,7 @@
 /**
-Copyright (c) 2010     , J. M. Dieterich and B. Hartke
+Copyright (c) 2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,16 +39,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.helpers;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
 
 /**
  * A 3D Tupel.
  * @author Johannes Dieterich
- * @version 2014-07-10
+ * @version 2020-04-29
  */
-public class Tuple3D<E,T,V> extends Tuple<E,T> implements Serializable, Cloneable {
+public class Tuple3D<E,T,V> extends Tuple<E,T> implements Serializable {
 
-    private static final long serialVersionUID = (long) 20110314;
+    private static final long serialVersionUID = (long) 20200429;
 
     protected V object3;
 
@@ -56,29 +56,6 @@ public class Tuple3D<E,T,V> extends Tuple<E,T> implements Serializable, Cloneabl
         object3 = ob3;
     }
     
-    @SuppressWarnings("unchecked")
-    @Override
-    public Tuple3D<E,T,V> clone() throws CloneNotSupportedException {
-        
-        try {
-            final Class<?> cE = object1.getClass();
-	    final Method cloneE = cE.getDeclaredMethod("clone");
-	    final Object clE = cloneE.invoke(object1, new Object[]{});
-            
-            final Class<?> cT = object2.getClass();
-	    final Method cloneT = cT.getDeclaredMethod("clone");
-	    final Object clT = cloneT.invoke(object2, new Object[]{});
-            
-            final Class<?> cV = object3.getClass();
-	    final Method cloneV = cV.getDeclaredMethod("clone");
-	    final Object clV = cloneV.invoke(object3, new Object[]{});
-            
-            return new Tuple3D<>((E) clE, (T) clT, (V) clV);
-        } catch (Throwable t){
-            throw new CloneNotSupportedException(t.toString());
-        }
-    }
-
     public V getObject3(){
         return object3;
     }

--- a/src/org/ogolem/helpers/Tuple4D.java
+++ b/src/org/ogolem/helpers/Tuple4D.java
@@ -37,16 +37,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.helpers;
 
 import java.io.Serializable;
-import java.lang.reflect.Method;
 
 /**
  * A 4D tuple.
  * @author Johannes Dieterich
- * @version 2020-01-04
+ * @version 2020-04-29
  */
-public class Tuple4D<E,T,V,W> extends Tuple3D<E,T,V> implements Serializable, Cloneable {
+public class Tuple4D<E,T,V,W> extends Tuple3D<E,T,V> implements Serializable {
     
-    private static final long serialVersionUID = (long) 20140727;
+    private static final long serialVersionUID = (long) 20200429;
 
     private W object4;
 
@@ -55,33 +54,6 @@ public class Tuple4D<E,T,V,W> extends Tuple3D<E,T,V> implements Serializable, Cl
         object4 = ob4;
     }
     
-    @SuppressWarnings("unchecked")
-    @Override
-    public Tuple4D<E,T,V,W> clone() throws CloneNotSupportedException {
-        
-        try {
-            final Class<?> cE = object1.getClass();
-	    final Method cloneE = cE.getDeclaredMethod("clone");
-	    final Object clE = cloneE.invoke(object1, new Object[]{});
-            
-            final Class<?> cT = object2.getClass();
-	    final Method cloneT = cT.getDeclaredMethod("clone");
-	    final Object clT = cloneT.invoke(object2, new Object[]{});
-            
-            final Class<?> cV = object3.getClass();
-	    final Method cloneV = cV.getDeclaredMethod("clone");
-	    final Object clV = cloneV.invoke(object3, new Object[]{});
-                        
-            final Class<?> cW = object4.getClass();
-	    final Method cloneW = cW.getDeclaredMethod("clone");
-	    final Object clW = cloneW.invoke(object4, new Object[]{});
-            
-            return new Tuple4D<>((E) clE, (T) clT, (V) clV, (W) clW);
-        } catch (Throwable t){
-            throw new CloneNotSupportedException(t.toString());
-        }
-    }
-
     public W getObject4(){
         return object4;
     }

--- a/src/org/ogolem/locopt/BOBYQALocOpt.java
+++ b/src/org/ogolem/locopt/BOBYQALocOpt.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich
-                2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -50,11 +50,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * A generic BOBYQA interface.
  * @author Johannes Dieterich
- * @version 2014-03-28
+ * @version 2020-04-29
  */
 public class BOBYQALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstractGradFreeLocOpt<E,T> {
     
-    private static final long serialVersionUID = (long) 20150328;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     private final int maxIter;
     private final double initialTrustRadius;
@@ -85,7 +85,7 @@ public class BOBYQALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
     }
     
     @Override
-    public BOBYQALocOpt<E,T> clone() {
+    public BOBYQALocOpt<E,T> copy() {
         return new BOBYQALocOpt<>(this);
     }
 
@@ -98,7 +98,7 @@ public class BOBYQALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
     protected T optimize(final T individual) {
         
         @SuppressWarnings("unchecked")
-        final T clone = (T) individual.clone();
+        final T clone = (T) individual.copy();
         
         // first build the Adapter
         final double[] optCoords = back.getActiveCoordinates(clone);
@@ -129,7 +129,7 @@ public class BOBYQALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
         adap.denormalizeToBounds(borders, t.getObject2(), g);
         
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         res.setFitness(t.getObject1());
         back.updateActiveCoordinates(res, g);
         

--- a/src/org/ogolem/locopt/CGLocOpt.java
+++ b/src/org/ogolem/locopt/CGLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014-2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -56,11 +57,11 @@ import org.ogolem.locopt.apachehelpers.MultivariateToGradientProvider;
 /**
  * Interface to apache commons implementation of CG.
  * @author Johannes Dieterich
- * @version 2015-01-11
+ * @version 2020-04-29
  */
 public class CGLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E,T> {
 
-    private static final long serialVersionUID = (long) 20140907;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     private final boolean useFletcherReevesUpdate;
     private final double absThresh;
@@ -89,7 +90,7 @@ public class CGLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstract
     }
     
     @Override
-    public CGLocOpt<E,T> clone() {
+    public CGLocOpt<E,T> copy() {
         return new CGLocOpt<>(this);
     }
 
@@ -102,7 +103,7 @@ public class CGLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstract
     protected T optimize(final T individual) {
 
         @SuppressWarnings("unchecked")
-        final T work = (T) individual.clone();
+        final T work = (T) individual.copy();
         final MultivariateToEnergyProvider<E,T> provE = new MultivariateToEnergyProvider<>(back, work);
         final MultivariateToGradientProvider<E,T> provG = new MultivariateToGradientProvider<>(back, work);
         
@@ -139,12 +140,12 @@ public class CGLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstract
             // apparently it likes to set this to null internally, nice one...
             if(currP == null){
                 @SuppressWarnings("unchecked")
-                final T res = (T) individual.clone();
+                final T res = (T) individual.copy();
                 res.setFitness(FixedValues.NONCONVERGEDENERGY);
                 return res;
             } else {
                 @SuppressWarnings("unchecked")
-                final T res = (T) individual.clone();
+                final T res = (T) individual.copy();
                 res.setFitness(currE);
                 back.updateActiveCoordinates(res, currP);
                 
@@ -160,7 +161,7 @@ public class CGLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstract
         final double[] p = result.getPoint();
                 
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         res.setFitness(e);
         back.updateActiveCoordinates(res, p);
         

--- a/src/org/ogolem/locopt/FIRELocOpt.java
+++ b/src/org/ogolem/locopt/FIRELocOpt.java
@@ -65,13 +65,13 @@ import org.ogolem.generic.GenericBackend;
  *
  * @author Mark Dittner
  * @author Dominik Behrens
- * @version 2020-04-27
+ * @version 2020-04-29
  */
 public class FIRELocOpt<E, T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E, T> {
 
     private final static boolean DEBUG = false;
 
-    private static final long serialVersionUID = (long) 20200427;
+    private static final long serialVersionUID = (long) 20200429;
 
     // FIRE parameters
     final private double dt;
@@ -142,7 +142,7 @@ public class FIRELocOpt<E, T extends ContinuousProblem<E>> extends GenericAbstra
     }
 
     @Override
-    public FIRELocOpt<E, T> clone() {
+    public FIRELocOpt<E, T> copy() {
         return new FIRELocOpt<>(this);
     }
 
@@ -153,7 +153,7 @@ public class FIRELocOpt<E, T extends ContinuousProblem<E>> extends GenericAbstra
 
     @Override
     protected T optimize(T individual) {
-        @SuppressWarnings("unchecked") final T work = (T) individual.clone();
+        @SuppressWarnings("unchecked") final T work = (T) individual.copy();
         final int dims = back.numberOfActiveCoordinates(work);
         final double[] p = back.getActiveCoordinates(work).clone();
 
@@ -299,7 +299,7 @@ public class FIRELocOpt<E, T extends ContinuousProblem<E>> extends GenericAbstra
                         + ". Best measure: " + currentBest.currentQualityMeasure + " of iteration: " +
                         currentBest.iteration);
 
-                @SuppressWarnings("unchecked") final T res = (T) individual.clone();
+                @SuppressWarnings("unchecked") final T res = (T) individual.copy();
                 res.setFitness(currentBest.dEnergy);
                 back.historyGetBestPoint(res);
 
@@ -309,7 +309,7 @@ public class FIRELocOpt<E, T extends ContinuousProblem<E>> extends GenericAbstra
             }
         }
 
-        @SuppressWarnings("unchecked") final T res = (T) individual.clone();
+        @SuppressWarnings("unchecked") final T res = (T) individual.copy();
         res.setFitness(lastE);
         back.updateActiveCoordinates(res, p);
 

--- a/src/org/ogolem/locopt/FleminLocOpt.java
+++ b/src/org/ogolem/locopt/FleminLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2013-2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,11 +49,11 @@ import org.ogolem.locopt.numalhelpers.NumalGradientWrapper;
 /**
  * An adapter to Flemin from the NUMAL package.
  * @author Johannes Dieterich
- * @version 2014-12-15
+ * @version 2020-04-29
  */
 public class FleminLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E,T> {
     
-    private static final long serialVersionUID = (long) 20141215;
+    private static final long serialVersionUID = (long) 20200429;
     private final double machPrec;
     private final int maxIter;
     private final double convThresh;
@@ -83,7 +84,7 @@ public class FleminLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
     }
     
     @Override
-    public FleminLocOpt<E,T> clone() {
+    public FleminLocOpt<E,T> copy() {
         return new FleminLocOpt<>(this);
     }
 
@@ -96,7 +97,7 @@ public class FleminLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
     protected T optimize(final T individual) {
         
         @SuppressWarnings("unchecked")
-        final T work = (T) individual.clone();
+        final T work = (T) individual.copy();
         final int dims = back.numberOfActiveCoordinates(work);
         final double[] start = back.getActiveCoordinates(work).clone();
         
@@ -140,7 +141,7 @@ public class FleminLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
         System.arraycopy(numalParams, 1, start, 0, dims);
         
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         res.setFitness(fitness);
         back.updateActiveCoordinates(res, start);
         

--- a/src/org/ogolem/locopt/GenericChainedLocalOpt.java
+++ b/src/org/ogolem/locopt/GenericChainedLocalOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014-2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,11 +44,11 @@ import java.util.List;
 /**
  * A generic chain of fitness functions.
  * @author Johannes Dieterich
- * @version 2015-01-10
+ * @version 2020-04-29
  */
 public class GenericChainedLocalOpt<E,T extends ContinuousProblem<E>> implements GenericLocOpt<E,T> {
     
-    private static final long serialVersionUID = (long) 20141220;
+    private static final long serialVersionUID = (long) 20200429;
 
     private final List<GenericLocOpt<E,T>> functions;
     private final double cutoff;
@@ -62,13 +63,13 @@ public class GenericChainedLocalOpt<E,T extends ContinuousProblem<E>> implements
         if(orig.functions.isEmpty()){throw new RuntimeException("Wrong input for chained fitness function.");}
         this.functions = new ArrayList<>();
         orig.functions.forEach((function) -> {
-            this.functions.add(function.clone());
+            this.functions.add(function.copy());
         });
         this.cutoff = orig.cutoff;
     }
     
     @Override
-    public GenericChainedLocalOpt<E, T> clone() {
+    public GenericChainedLocalOpt<E, T> copy() {
         return new GenericChainedLocalOpt<>(this);
     }
 

--- a/src/org/ogolem/locopt/LBFGSLocOpt.java
+++ b/src/org/ogolem/locopt/LBFGSLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2012-2015, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,11 +48,11 @@ import org.ogolem.helpers.Machine;
  * An interface to the slightly adjusted version of the L-BFGS implementation
  * from RISO.
  * @author Johannes Dieterich
- * @version 2015-01-07
+ * @version 2020-04-29
  */
 public class LBFGSLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E,T> {
     
-    private static final long serialVersionUID = (long) 20141216;
+    private static final long serialVersionUID = (long) 20200429;
     private static final boolean DEBUG = false;
     
     private final int maxSteps;
@@ -96,7 +97,7 @@ public class LBFGSLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstr
     }
     
     @Override
-    public LBFGSLocOpt<E, T> clone() {
+    public LBFGSLocOpt<E, T> copy() {
         return new LBFGSLocOpt<>(this);
     }
     
@@ -109,7 +110,7 @@ public class LBFGSLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstr
     protected T optimize(final T individual) {
         
         @SuppressWarnings("unchecked")
-        final T work = (T) individual.clone();
+        final T work = (T) individual.copy();
         final int dims = back.numberOfActiveCoordinates(work);
         final double[] p = back.getActiveCoordinates(work).clone();
         
@@ -194,7 +195,7 @@ public class LBFGSLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstr
         }
 
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         res.setFitness(lastE);
         back.updateActiveCoordinates(res, p);
         

--- a/src/org/ogolem/locopt/NEWUOALocOpt.java
+++ b/src/org/ogolem/locopt/NEWUOALocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,11 +48,11 @@ import org.ogolem.helpers.Tuple;
 /**
  * A generic interface to the NEWUOA local optimization.
  * @author Johannes Dieterich
- * @version 2014-12-15
+ * @version 2020-04-29
  */
 public class NEWUOALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstractGradFreeLocOpt<E,T> {
 
-    private static final long serialVersionUID = (long) 20141215;
+    private static final long serialVersionUID = (long) 20200429;
     private final NEWUOAOptimizer opt;
 
     /**
@@ -73,7 +74,7 @@ public class NEWUOALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
     }
     
     @Override
-    public NEWUOALocOpt<E,T> clone() {
+    public NEWUOALocOpt<E,T> copy() {
         return new NEWUOALocOpt<>(this);
     }
     
@@ -89,7 +90,7 @@ public class NEWUOALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
         // first build the Adapter
         final int dims = back.numberOfActiveCoordinates(individual);
         @SuppressWarnings("unchecked")
-        final T work = (T) individual.clone();
+        final T work = (T) individual.copy();
         final double[] guess = back.getActiveCoordinates(work);
         final NEWUOALocOpt.Adapter<E,T> adap = new NEWUOALocOpt.Adapter<>(back);
         
@@ -97,7 +98,7 @@ public class NEWUOALocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstr
         final Tuple<Double,double[]> t = opt.doOptimize(dims,guess, adap);        
 
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         res.setFitness(t.getObject1());
         back.updateActiveCoordinates(res, guess);
         

--- a/src/org/ogolem/locopt/PraxisLocOpt.java
+++ b/src/org/ogolem/locopt/PraxisLocOpt.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -49,11 +49,11 @@ import org.ogolem.locopt.numalhelpers.NumalFitnessWrapper;
 /**
  * An interface to NUMAL's gradient-free Praxis local optimization implementation.
  * @author Johannes Dieterich
- * @version 2016-03-15
+ * @version 2020-04-29
  */
 public class PraxisLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbstractGradFreeLocOpt<E,T> {
     
-    private static final long serialVersionUID = (long) 20141215;
+    private static final long serialVersionUID = (long) 20200429;
     private final double machPrec;
     private final int maxIter;
     private final double convThresh;
@@ -88,7 +88,7 @@ public class PraxisLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbst
     }
     
     @Override
-    public PraxisLocOpt<E,T> clone() {
+    public PraxisLocOpt<E,T> copy() {
         return new PraxisLocOpt<>(this);
     }
 
@@ -101,7 +101,7 @@ public class PraxisLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbst
     protected T optimize(final T individual) {
         
         @SuppressWarnings("unchecked")
-        final T work = (T) individual.clone();
+        final T work = (T) individual.copy();
         final int dims = back.numberOfActiveCoordinates(work);
         final double[] start = back.getActiveCoordinates(work).clone();
         
@@ -153,7 +153,7 @@ public class PraxisLocOpt <E,T extends ContinuousProblem<E>> extends GenericAbst
 
         // put the fitness in
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         final double fitness = out[2];
         res.setFitness(fitness);
         back.updateActiveCoordinates(res, start);

--- a/src/org/ogolem/locopt/RNK1MinLocOpt.java
+++ b/src/org/ogolem/locopt/RNK1MinLocOpt.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,11 +49,11 @@ import org.ogolem.locopt.numalhelpers.NumalGradientWrapper;
 /**
  * An interface to NUMAL's RNK1Min algorithm.
  * @author Johannes Dieterich
- * @version 2014-12-16
+ * @version 2020-04-29
  */
 public class RNK1MinLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbstractLocOpt<E,T> {
 
-    private static final long serialVersionUID = (long) 20141215;
+    private static final long serialVersionUID = (long) 20200429;
     private final double machPrec;
     private final int maxIter;
     private final double convThresh;
@@ -79,7 +80,7 @@ public class RNK1MinLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbst
     }
     
     @Override
-    public RNK1MinLocOpt<E, T> clone() {
+    public RNK1MinLocOpt<E, T> copy() {
         return new RNK1MinLocOpt<>(this);
     }
     
@@ -92,7 +93,7 @@ public class RNK1MinLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbst
     protected T optimize(final T individual) {
         
         @SuppressWarnings("unchecked")
-        final T work = (T) individual.clone();
+        final T work = (T) individual.copy();
         final int dims = back.numberOfActiveCoordinates(work);
         final double[] start = back.getActiveCoordinates(work).clone();
         
@@ -136,7 +137,7 @@ public class RNK1MinLocOpt<E,T extends ContinuousProblem<E>> extends GenericAbst
         System.arraycopy(numalParams, 1, start, 0, dims);
         
         @SuppressWarnings("unchecked")
-        final T res = (T) individual.clone();
+        final T res = (T) individual.copy();
         res.setFitness(fitness);
         back.updateActiveCoordinates(res, start);
         

--- a/src/org/ogolem/rmi/GenericInitTask.java
+++ b/src/org/ogolem/rmi/GenericInitTask.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,11 +45,11 @@ import org.ogolem.generic.Optimizable;
 /**
  * A generic init task.
  * @author Johannes Dieterich
- * @version 2014-04-02
+ * @version 2020-04-29
  */
 public class GenericInitTask<E, T extends Optimizable<E>> implements Task<T>{
     
-    private static final long serialVersionUID = (long) 20140402;
+    private static final long serialVersionUID = (long) 20200429;
     private final GenericInitializer<E,T> initer;
     private final long newID;
     private final T start;
@@ -76,7 +77,7 @@ public class GenericInitTask<E, T extends Optimizable<E>> implements Task<T>{
     @Override
     public Result<T> getDummyAnswer(final int onClient) {
         
-        final T clone = (T) start.clone();
+        final T clone = (T) start.copy();
         clone.setFitness(FixedValues.NONCONVERGEDENERGY);
         clone.setID(newID);
         

--- a/src/org/ogolem/rmi/GenericSeedTask.java
+++ b/src/org/ogolem/rmi/GenericSeedTask.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -44,7 +45,7 @@ import org.ogolem.generic.Optimizable;
 /**
  * A generic seeding task.
  * @author Johannes Dieterich
- * @version 2014-04-02
+ * @version 2020-04-29
  */
 public class GenericSeedTask <E, T extends Optimizable<E>> implements Task<T>{
     
@@ -85,7 +86,7 @@ public class GenericSeedTask <E, T extends Optimizable<E>> implements Task<T>{
     @Override
     public Result<T> getDummyAnswer(final int onClient) {
         
-        final T clone = (T) start.clone();
+        final T clone = (T) start.copy();
         clone.setFitness(FixedValues.NONCONVERGEDENERGY);
         clone.setID(newID);
         

--- a/src/org/ogolem/rmi/GenericThreadingClientBackend.java
+++ b/src/org/ogolem/rmi/GenericThreadingClientBackend.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2016, J. M. Dieterich and B. Hartke
+Copyright (c) 2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -43,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.ogolem.generic.Configuration;
+import org.ogolem.generic.Copyable;
 import org.ogolem.generic.GenericGlobalOptimization;
 import org.ogolem.generic.GenericInitializer;
 import org.ogolem.generic.Optimizable;
@@ -63,7 +64,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The actual backend for the threading RMI client.
  * @author Johannes Dieterich
- * @version 2016-04-14
+ * @version 2020-04-29
  */
 class GenericThreadingClientBackend<E,T extends Optimizable<E>> {
     
@@ -361,7 +362,7 @@ class GenericThreadingClientBackend<E,T extends Optimizable<E>> {
         return false;
     }
     
-    private <V extends Cloneable> void doXXX(final int threads, final TaskFactory<E,T,V> tasker, final ObjectCache<V> cache,
+    private <V extends Copyable> void doXXX(final int threads, final TaskFactory<E,T,V> tasker, final ObjectCache<V> cache,
             final List<Task<T>> initTasks){
 
         // start thread pool
@@ -398,7 +399,7 @@ class GenericThreadingClientBackend<E,T extends Optimizable<E>> {
         }
     }
     
-    private <V extends Cloneable> void doXXX(final int threads, final TaskFactory<E,T,V> tasker, final ObjectCache<V> cache,
+    private <V extends Copyable> void doXXX(final int threads, final TaskFactory<E,T,V> tasker, final ObjectCache<V> cache,
             final int offset, final int chunkSize){
 
         assert(chunkSize > 0);
@@ -463,12 +464,12 @@ class GenericThreadingClientBackend<E,T extends Optimizable<E>> {
                     }
                 } else if(!useCache && !DEBUG){
                     l.debug("Trying to use new object as helper for global opt...");
-                    final GenericGlobalOptimization<U,W> helpers = cache.getOriginalEntry().clone();
+                    final GenericGlobalOptimization<U,W> helpers = cache.getOriginalEntry().copy();
                     runme(helpers,pool,history,taskID, isInit);
                 } else{
                     try{
                         l.debug("Trying to use new object as helper for global opt (try/catch)...");
-                        final GenericGlobalOptimization<U,W> helpers = cache.getOriginalEntry().clone();
+                        final GenericGlobalOptimization<U,W> helpers = cache.getOriginalEntry().copy();
                         runme(helpers,pool,history,taskID, isInit);
                     } catch(Throwable t){
                         t.printStackTrace(System.err);

--- a/src/org/ogolem/switches/Switch.java
+++ b/src/org/ogolem/switches/Switch.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2012, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -45,7 +46,7 @@ import org.ogolem.generic.DiscreteProblem;
 /**
  * The actual switch.
  * @author Johannes Dieterich
- * @version 2013-11-22
+ * @version 2020-04-29
  */
 public class Switch extends DiscreteProblem<Color> {
 
@@ -103,7 +104,7 @@ public class Switch extends DiscreteProblem<Color> {
     }
     
     @Override
-    public Switch clone(){
+    public Switch copy(){
         return new Switch(this);
     }
     

--- a/tests/org/ogolem/core/RigidBodyCoordinatesTest.java
+++ b/tests/org/ogolem/core/RigidBodyCoordinatesTest.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014-2015, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,7 @@ import static org.ogolem.core.Constants.ANGTOBOHR;
 /**
  *
  * @author Johannes Dieterich
- * @version 2016-09-03
+ * @version 2020-04-29
  */
 public class RigidBodyCoordinatesTest {
     
@@ -194,8 +194,8 @@ public class RigidBodyCoordinatesTest {
         System.out.println("fitness");
 
         // make sure that w2 and w20 have the right energy
-        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.clone());
-        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.clone());
+        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
+        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
         
         final double e2 = rigidW2TIP4P.fitness(extCoord2, 0);
         final double e20 = rigidW20TIP4P.fitness(extCoord20, 0);
@@ -217,8 +217,8 @@ public class RigidBodyCoordinatesTest {
         
         // make sure that w2 and w20 have the right energy
 
-        final double e2 = rigidW2TIP4P.fitness(gWater2.clone(), true).getFitness();
-        final double e20 = rigidW20TIP4P.fitness(gWater20.clone(), true).getFitness();
+        final double e2 = rigidW2TIP4P.fitness(gWater2.copy(), true).getFitness();
+        final double e20 = rigidW20TIP4P.fitness(gWater20.copy(), true).getFitness();
         
         // from DJW
         final double expResult2 = -0.009936231756023471;
@@ -236,9 +236,9 @@ public class RigidBodyCoordinatesTest {
         System.out.println("gradient");
 
         // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.clone());
-        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.clone());
-        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.clone());
+        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
+        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
+        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
         
         final double[] grad2W = new double[6*2];
         final double[] grad2WDis = new double[6*2];
@@ -295,9 +295,9 @@ public class RigidBodyCoordinatesTest {
         System.out.println("numerical gradients");
 
         // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.clone());
-        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.clone());
-        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.clone());
+        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
+        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
+        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
         
         final double[] grad2W = new double[6*2];
         final double[] grad2WDis = new double[6*2];
@@ -395,7 +395,7 @@ public class RigidBodyCoordinatesTest {
         System.out.println("numerical gradients (stepped)");
 
         // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.clone());
+        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
         
         final double[] grad2WDis = new double[6*2];
         final double[] grad2WDisAna = new double[6*2];
@@ -597,7 +597,7 @@ public class RigidBodyCoordinatesTest {
         System.out.println("numerical gradients TIP3P (stepped)");
 
         // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2Dis = rigidW2DisTIP3P.getActiveCoordinates(gWater2Distorted.clone());
+        final double[] extCoord2Dis = rigidW2DisTIP3P.getActiveCoordinates(gWater2Distorted.copy());
         
         final double[] grad2WDis = new double[6*2];
         final double[] grad2WDisAna = new double[6*2];

--- a/tests/org/ogolem/locopt/BasicOptimizableType.java
+++ b/tests/org/ogolem/locopt/BasicOptimizableType.java
@@ -1,5 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -41,11 +42,11 @@ import org.ogolem.generic.ContinuousProblem;
 /**
  * A basic optimizable type. Basically a wrapper for a double[].
  * @author Johannes Dieterich
- * @version 2014-12-15
+ * @version 2020-04-29
  */
 public class BasicOptimizableType extends ContinuousProblem<Double>{
     
-    private static final long serialVersionUID = (long) 20141215;
+    private static final long serialVersionUID = (long) 20200429;
     private double[] genome;
 
     BasicOptimizableType(final double[] genome){
@@ -53,7 +54,7 @@ public class BasicOptimizableType extends ContinuousProblem<Double>{
     }
     
     @Override
-    public ContinuousProblem<Double> clone() {
+    public ContinuousProblem<Double> copy() {
         return new BasicOptimizableType(genome.clone());
     }
 

--- a/tests/org/ogolem/locopt/HarmonicFunction.java
+++ b/tests/org/ogolem/locopt/HarmonicFunction.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-                2015, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -42,11 +42,11 @@ import org.ogolem.generic.GenericBackend;
 /**
  * A basic harmonic function, y = a*(x-x0)**2 + b
  * @author Johannes Dieterich
- * @version 2015-03-28
+ * @version 2020-04-29
  */
 public class HarmonicFunction implements GenericBackend<Double,BasicOptimizableType>{
     
-    private static final long serialVersionUID = (long) 20150328;
+    private static final long serialVersionUID = (long) 20200429;
     private final double x0;
     private final double a;
     private final double b;
@@ -71,7 +71,7 @@ public class HarmonicFunction implements GenericBackend<Double,BasicOptimizableT
     }
     
     @Override
-    public HarmonicFunction clone() {
+    public HarmonicFunction copy() {
         return new HarmonicFunction(a,x0,b,boundUp,boundLow);
     }
 
@@ -122,7 +122,7 @@ public class HarmonicFunction implements GenericBackend<Double,BasicOptimizableT
 
     @Override
     public BasicOptimizableType fitness(BasicOptimizableType individual, boolean forceOneEval) {
-        final double[] actCoord = getActiveCoordinates((BasicOptimizableType) individual.clone());
+        final double[] actCoord = getActiveCoordinates((BasicOptimizableType) individual.copy());
         final double fitness = fitness(actCoord,1);
         
         individual.setFitness(fitness);


### PR DESCRIPTION
* Major refactor to switch to Copyable versus using Cloneable.

Reasons:
* gets rid of Cloneable pitfalls (we are also overriding it wrongly)
* gets rid of reflection magic
* hence gets us a step closer to be able to run on GraalVM

* Switch GA ops over to Lists.