### PR TITLE
Clarify some mixed nomenclature between the RMI and MPI parallelization approaches.

### DIFF
--- a/src/org/ogolem/core/MainOGOLEM.java
+++ b/src/org/ogolem/core/MainOGOLEM.java
@@ -1,6 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
+              2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -52,7 +53,7 @@ import org.ogolem.rmi.GenericGlobOptJob;
  * The entry point for any batch-mode, massively parallel usage of the OGOLEM
  * program suite in cluster global optimization mode.
  * @author Johannes Dieterich
- * @version 2014-04-06
+ * @version 2020-06-23
  */
 public class MainOGOLEM {
 
@@ -122,7 +123,7 @@ public class MainOGOLEM {
         }
 
         if (myRank == 0) {
-            // MPI master
+            // MPI rank 0 == the queen
 			/*
              * "Serial" parts: Setup
              */
@@ -253,9 +254,9 @@ public class MainOGOLEM {
                 final GenericGlobOptJob<Molecule,Geometry> job = new GenericGlobOptJob<>(globConf,
                     pool,history, globConf.getReader(),globConf.getWriter(globConf.outputFolder),
                     globConf.outputFolder,globConf.outputFile);
-                GenericMPIOptimization.runAsMaster(job);
+                GenericMPIOptimization.runAsQueen(job);
             } catch(Exception e){
-                System.err.println("Couldn't run master part of the job.");
+                System.err.println("Couldn't run queen part of the job.");
                 e.printStackTrace(System.err);
                 try {
                     MPI.COMM_WORLD.Abort(42);
@@ -311,9 +312,9 @@ public class MainOGOLEM {
             final long timeout = 30000; // 30 s timeout
 
             try {
-                GenericMPIOptimization.runAsSlave(timeout);
+                GenericMPIOptimization.runAsDrone(timeout);
             } catch (Exception e) {
-                System.err.println("Exception in slave process " + myRank);
+                System.err.println("Exception in drone process " + myRank);
                 e.printStackTrace(System.err);
                 try {
                     MPI.COMM_WORLD.Abort(99);

--- a/src/org/ogolem/rmi/ClientList.java
+++ b/src/org/ogolem/rmi/ClientList.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2011-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -51,7 +51,7 @@ import org.ogolem.helpers.Tuple3D;
 /**
  * A list of clients, their state and the work they are supposed to do.
  * @author Johannes Dieterich
- * @version 2016-04-05
+ * @version 2020-06-23
  */
 final class ClientList<T>{
 
@@ -181,7 +181,7 @@ final class ClientList<T>{
                             rmi.returnResultForced(dummy);
                         }
                     } catch(Exception e){
-                        System.err.println("ERROR: Couldn't return dummy result to master. This is a serious problem! " + e.toString());
+                        System.err.println("ERROR: Couldn't return dummy result to server. This is a serious problem! " + e.toString());
                         e.printStackTrace(System.err);
                     }
                 }

--- a/src/org/ogolem/rmi/GenericProxyJob.java
+++ b/src/org/ogolem/rmi/GenericProxyJob.java
@@ -1,6 +1,6 @@
 /**
 Copyright (c) 2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ import org.ogolem.rmi.RMICodes.JOBSTATE;
 /**
  * A generic global optimization job.
  * @author Johannes Dieterich
- * @version 2016-01-21
+ * @version 2020-06-23
  */
 public class GenericProxyJob<E, T extends Optimizable<E>> implements Job<T>{
 
@@ -140,7 +140,7 @@ public class GenericProxyJob<E, T extends Optimizable<E>> implements Job<T>{
                 if(DEBUG){System.out.println("DEBUG: Initial chunk request: " + initTasks.size());}
                 initTasksGotten = initTasks.size();
             } catch(Exception e){
-                System.err.println("ERROR: Exception in initial proxy to master communication.");
+                System.err.println("ERROR: Exception in initial proxy to server communication.");
                 e.printStackTrace(System.err);
                 System.exit(28);
             } finally {
@@ -355,7 +355,7 @@ public class GenericProxyJob<E, T extends Optimizable<E>> implements Job<T>{
                         final List<T> myPool = new ArrayList<>();
                         int c = 0;
                         int offset = 0;
-                        // always synchronize our top, NEW individuals with the master
+                        // always synchronize our top, NEW individuals with the server
                         while(c < maxStructsExchange && pool.getCurrentPoolSize() > 0 && offset < pool.getCurrentPoolSize()){
                             final T ind = pool.getIndividualAtPosition(offset); // we remove from the top (ignoring known IDs)
                             final long id = ind.getID();
@@ -486,7 +486,7 @@ public class GenericProxyJob<E, T extends Optimizable<E>> implements Job<T>{
                     if(doMaxStructsExchange){
                         final List<T> myPool = new ArrayList<>();
                         int c = 0;
-                        // always synchronize our top individuals with the master
+                        // always synchronize our top individuals with the server
                         for(final GenericPoolEntry<E,T> entry : pool.getAllIndividuals()){
                             myPool.add(entry.getIndividual());
                             pool.removeIndividualAtPos(c);

--- a/src/org/ogolem/rmi/GenericThreadingClientBackend.java
+++ b/src/org/ogolem/rmi/GenericThreadingClientBackend.java
@@ -238,7 +238,7 @@ class GenericThreadingClientBackend<E,T extends Optimizable<E>> {
             final List<T> myPool = new ArrayList<>();
             int c = 0;
             int offset = 0;
-            // always synchronize our top, NEW individuals with the master            
+            // always synchronize our top, NEW individuals with the server
             while(c < indsToMerge && pool.getCurrentPoolSize() > 0 && offset < pool.getCurrentPoolSize()){
                 final T ind = pool.getIndividualAtPosition(offset); // we remove from the top (ignoring known IDs)
                 final long id = ind.getID();

--- a/src/org/ogolem/rmi/MainRMIClient.java
+++ b/src/org/ogolem/rmi/MainRMIClient.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2011, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,7 +46,7 @@ import static org.ogolem.rmi.RMICodes.JOBSTATE.*;
 /**
  * The entry to the client part of OGOLEM's RMI.
  * @author Johannes Dieterich
- * @version 2016-04-05
+ * @version 2020-06-23
  */
 public class MainRMIClient {
 
@@ -101,7 +101,7 @@ public class MainRMIClient {
         
         final String key = "Client speaking, I am here. " + keySuffix;
 
-        // first we try to connect to our master and exchange keys
+        // first we try to connect to our server and exchange keys
         final long waittimeClientMS = 2000; // two seconds.
         RMICommunication<?> comm = null;
         int myID = -1;
@@ -123,10 +123,10 @@ public class MainRMIClient {
                 }
             
                 // exchange keys
-                final Tuple<String,Integer> answer = comm.registerWithMaster(key);
-                if(!answer.getObject1().equalsIgnoreCase("Master speaking, everything fine. " + keySuffix)){
+                final Tuple<String,Integer> answer = comm.registerWithServer(key);
+                if(!answer.getObject1().equalsIgnoreCase("Server speaking, everything fine. " + keySuffix)){
                     // not good, exit (we want to avoid double registration...)
-                    System.err.println("ERROR: Wrong answer from master. Aborting client. Server was " + server + ". Answer was " + answer.getObject1());
+                    System.err.println("ERROR: Wrong answer from server. Aborting client. Server was " + server + ". Answer was " + answer.getObject1());
                     System.exit(27);
                 } else{
                     myID = answer.getObject2();

--- a/src/org/ogolem/rmi/MainRMIProxy.java
+++ b/src/org/ogolem/rmi/MainRMIProxy.java
@@ -50,7 +50,7 @@ import org.ogolem.io.OutputPrimitives;
 /**
  * Proxy function for the RMI parallelization.
  * @author Johannes Dieterich
- * @version 2020-04-28
+ * @version 2020-06-23
  */
 public class MainRMIProxy {
 
@@ -152,7 +152,7 @@ public class MainRMIProxy {
         
         final String key = "Client speaking, I am here. " + keySuffix;
         
-        // first we try to connect to our master and exchange keys
+        // first we try to connect to our server and exchange keys
         final long waittimeClientMS = 2000; // two seconds.
         RMICommunication<?> serverComm = null;
         int myID = -1;
@@ -174,10 +174,10 @@ public class MainRMIProxy {
                 }
             
                 // exchange keys
-                final Tuple<String,Integer> answer = serverComm.registerWithMaster(key);
-                if(!answer.getObject1().equalsIgnoreCase("Master speaking, everything fine. " + keySuffix)){
+                final Tuple<String,Integer> answer = serverComm.registerWithServer(key);
+                if(!answer.getObject1().equalsIgnoreCase("Server speaking, everything fine. " + keySuffix)){
                     // not good, exit (we want to avoid double registration...)
-                    System.err.println("ERROR: Wrong answer from master.s Aborting client. Server was " + serverName + ". Answer was " + answer.getObject1());
+                    System.err.println("ERROR: Wrong answer from server. Aborting client. Server was " + serverName + ". Answer was " + answer.getObject1());
                     System.exit(27);
                 } else{
                     myID = answer.getObject2();

--- a/src/org/ogolem/rmi/MainRMIThreader.java
+++ b/src/org/ogolem/rmi/MainRMIThreader.java
@@ -1,5 +1,5 @@
 /**
-Copyright (c) 2016, J. M. Dieterich and B. Hartke
+Copyright (c) 2016-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,7 @@ import org.ogolem.io.OutputPrimitives;
 /**
  * A threading client for the RMI setup.
  * @author Johannes Dieterich
- * @version 2016-04-14
+ * @version 2020-06-23
  */
 public class MainRMIThreader {
    
@@ -122,7 +122,7 @@ public class MainRMIThreader {
                 
         final String key = "Client speaking, I am here. " + keySuffix;
         
-        // first we try to connect to our master and exchange keys
+        // first we try to connect to our server and exchange keys
         final long waittimeClientMS = 2000; // two seconds.
         RMICommunication<?> serverComm = null;
         int myID = -1;
@@ -144,10 +144,10 @@ public class MainRMIThreader {
                 }
             
                 // exchange keys
-                final Tuple<String,Integer> answer = serverComm.registerWithMaster(key);
-                if(!answer.getObject1().equalsIgnoreCase("Master speaking, everything fine. " + keySuffix)){
+                final Tuple<String,Integer> answer = serverComm.registerWithServer(key);
+                if(!answer.getObject1().equalsIgnoreCase("Server speaking, everything fine. " + keySuffix)){
                     // not good, exit (we want to avoid double registration...)
-                    System.err.println("ERROR: Wrong answer from master.s Aborting client. Server was " + server + ". Answer was " + answer.getObject1());
+                    System.err.println("ERROR: Wrong answer from server. Aborting client. Server was " + server + ". Answer was " + answer.getObject1());
                     System.exit(27);
                 } else{
                     myID = answer.getObject2();

--- a/src/org/ogolem/rmi/RMICommImpl.java
+++ b/src/org/ogolem/rmi/RMICommImpl.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ import org.ogolem.rmi.RMICodes.JOBSTATE;
 /**
  * Implements our RMI communication interface.
  * @author Johannes Dieterich
- * @version 2016-01-25
+ * @version 2020-06-23
  */
 public class RMICommImpl<T> implements RMICommunication<T>{
 
@@ -88,7 +88,7 @@ public class RMICommImpl<T> implements RMICommunication<T>{
     }
 
     @Override
-    public Tuple<String,Integer> registerWithMaster(final String key) throws RemoteException{
+    public Tuple<String,Integer> registerWithServer(final String key) throws RemoteException{
 
         if(anyProblem){
             throw new RemoteException("Configuration problem.");
@@ -96,11 +96,11 @@ public class RMICommImpl<T> implements RMICommunication<T>{
         
         // we use the key mainly to make sure that we do not mess up with any other program
         if(key.equalsIgnoreCase("Client speaking, I am here. " + keySuffix)){
-            return new Tuple<>("Master speaking, everything fine. " + keySuffix, list.newClient());
+            return new Tuple<>("Server speaking, everything fine. " + keySuffix, list.newClient());
         } else if(key.startsWith("Client speaking, I am here. ") && !key.equalsIgnoreCase("Client speaking, I am here. " + keySuffix)){
-            return new Tuple<>("Master speaking, you are contacting the wrong server. Contacted server: " + keySuffix,-1);
+            return new Tuple<>("Server speaking, you are contacting the wrong server. Contacted server: " + keySuffix,-1);
         } else {
-            return new Tuple<>("Master speaking, absolutely wrong key.",-1);
+            return new Tuple<>("Server speaking, absolutely wrong key.",-1);
         }
     }
 

--- a/src/org/ogolem/rmi/RMICommunication.java
+++ b/src/org/ogolem/rmi/RMICommunication.java
@@ -1,7 +1,7 @@
 /**
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2016, J. M. Dieterich and B. Hartke
+              2015-2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -47,7 +47,7 @@ import org.ogolem.helpers.Tuple3D;
 /**
  * Defines all client-server communication using RMI.
  * @author Johannes Dieterich
- * @version 2016-01-25
+ * @version 2020-06-23
  * @param <T> typically an optimizable
  */
 public interface RMICommunication<T> extends Remote {
@@ -58,7 +58,7 @@ public interface RMICommunication<T> extends Remote {
      * @return A string and an ID for the client.
      * @throws RemoteException
      */
-    public Tuple<String,Integer> registerWithMaster(String sKey) throws RemoteException;
+    public Tuple<String,Integer> registerWithServer(String sKey) throws RemoteException;
 
     /**
      * Get a task. If it doesn't contain anything,


### PR DESCRIPTION
This now consistently uses server/client for the RMI approach in line with the RMI
behavior and queen/drone for the MPI approach to signify the difference between
starting ogolem with different options (RMI) vs figuring the differences out at
runtime through MPI-API.