### PR TITLE
XTB as backend (energy only)

### DIFF
--- a/cluster-macrobenchs.csv
+++ b/cluster-macrobenchs.csv
@@ -13,6 +13,6 @@ examples/clusteropt/w7 , w7_tip4p.ogo , -0.0927719842 , globmin_tip4p.xyz , 1e-6
 # H2O 7 - TTM3F
 examples/clusteropt/w7 , w7_ttm3f.ogo , -0.091194191 , globmin_ttm3f.xyz , 1e-6 , 1e-4
 # Au 10 - GFN1-XTB
-examples/clusteropt/au10 , au10_gfn1_xtb.ogo , -39.8054548 , globmin_gfn1xtb.xyz, 1e-6, 1e-4
+examples/clusteropt/au10 , au10_gfn1_xtb.ogo , -39.8054548 , globmin_gfn1xtb.xyz, 1e-5, 1e-4
 # Si6 - SWGFF
 examples/clusteropt/si6_swg , si6.ogo  , -1.025728, globmin.xyz , 1e-6 , 1e-4

--- a/src/org/ogolem/interfaces/XTBCaller.java
+++ b/src/org/ogolem/interfaces/XTBCaller.java
@@ -41,28 +41,34 @@ package org.ogolem.interfaces;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.ogolem.core.AbstractLocOpt;
 import org.ogolem.core.BondInfo;
 import org.ogolem.core.CartesianCoordinates;
+import org.ogolem.core.CartesianFullBackend;
 import org.ogolem.core.Constants;
+import static org.ogolem.core.Constants.BOHRTOANG;
 import org.ogolem.core.FixedValues;
 import org.ogolem.core.GlobalConfig;
+import org.ogolem.core.Gradient;
 import org.ogolem.core.StreamGobbler;
 import org.ogolem.io.InputPrimitives;
 import org.ogolem.io.ManipulationPrimitives;
 import org.ogolem.io.OutputPrimitives;
 
 /**
- * Calls Stefan Grimme's xtb program for local geometry optimization
+ * Calls Stefan Grimme's xtb program for local geometry optimization. Has partial
+ * support as a CartesianFullBackend (energy evaluation) which is why it is not
+ * being exposed.
  * @author Bernd Hartke
  * @author Johannes Dieterich
- * @version 2020-07-03
+ * @version 2020-07-04
  */
-public class XTBCaller extends AbstractLocOpt {
+public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     
-    private static final long serialVersionUID = (long) 20200703;
+    private static final long serialVersionUID = (long) 20200704;
     
     public static enum METHOD {GFNFF, GFN0XTB, GFN1XTB, GFN2XTB};
     public static enum OPTLEVEL {CRUDE, SLOPPY, LOOSE, NORMAL, TIGHT, VERYTIGHT};
@@ -133,6 +139,16 @@ public class XTBCaller extends AbstractLocOpt {
     @Override
     public String myIDandMethod() {
         return "Grimme xtb " + xtbMeth.name();
+    }
+
+    @Override
+    public String getMethodID() {
+        return "Grimme xtb " + xtbMeth.name();
+    }
+
+    @Override
+    public CartesianFullBackend getBackend(){
+        return new XTBCaller(this);
     }
 
     @Override
@@ -256,5 +272,157 @@ public class XTBCaller extends AbstractLocOpt {
         ManipulationPrimitives.remove(dirName);
         
         return res;
+    }
+
+    @Override
+    public void gradientCalculation(long lID, int iIteration, double[] xyz1D, String[] saAtomTypes,
+            short[] atomNos, int[] atsPerMol, double[] energyparts, int iNoOfAtoms, float[] faCharges,
+            short[] spins, final BondInfo bonds, final Gradient grad, final boolean hasRigidEnvironment) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
+    @Override
+    public double energyCalculation(long lID, int iIteration, double[] xyz1D, String[] saAtomTypes,
+            short[] atomNos, int[] atsPerMol, double[] energyparts, int iNoOfAtoms, float[] faCharges,
+            short[] spins, final BondInfo bonds, final boolean hasRigidEnvironment){
+
+        // create a directory
+        final String dirName = "xtbenergy-" + lID + "_" + System.currentTimeMillis();
+        final String xyzFile = dirName + File.separator + "input.xyz";
+        try{
+            OutputPrimitives.createAFolder(dirName);
+        } catch(Exception e){
+            System.err.println("Failure to create subdirectory in XTBCaller.energyCalculation");
+            e.printStackTrace(System.err);
+            return FixedValues.NONCONVERGEDENERGY;
+        }
+
+        // put the xyz info there
+        final String[] printXYZ = new String[iNoOfAtoms + 2];
+
+        printXYZ[0] = Integer.toString(iNoOfAtoms);
+        printXYZ[1] = " created by OGOLEM";
+
+        for (int i = 2; i < iNoOfAtoms + 2; i++) {
+            final double dXValue = xyz1D[(i-2)] * BOHRTOANG;
+            final double dYValue = xyz1D[iNoOfAtoms+(i-2)] * BOHRTOANG;
+            final double dZValue = xyz1D[2*iNoOfAtoms+(i-2)] * BOHRTOANG;
+            printXYZ[i] = saAtomTypes[i - 2] + "   " + String.format(Locale.US, "%20.7f", dXValue) + "   " 
+                          + String.format(Locale.US, "%20.7f", dYValue) + "   " + String.format(Locale.US, "%20.7f", dZValue);
+        }
+
+        try {
+            OutputPrimitives.writeOut(xyzFile, printXYZ, false);
+        } catch (Exception e) {
+            System.err.println("Failure to write xyz file in XTBCaller.energyCalculation");
+            e.printStackTrace(System.err);
+            return FixedValues.NONCONVERGEDENERGY;
+
+        }
+
+        // get charge/spin
+        float totCharge = 0.0f;
+        for(int i = 0; i < faCharges.length; i++){
+            totCharge += faCharges[i];
+        }
+        final int charge = Math.round(totCharge);
+        int spin = 0;
+        for(int i = 0; i < spins.length; i++){
+            spin += spins[i];
+        }
+
+        final List<String> cmdList = new ArrayList<>();
+        cmdList.add(xtbCmd);
+        cmdList.add(xtbMethod[0]);
+        if(!xtbMethod[1].isEmpty()) cmdList.add(xtbMethod[1]);
+        if(charge != 0){
+            cmdList.add("--chrg");
+            cmdList.add("" + charge);
+        }
+        if(spin != 0){
+            cmdList.add("--uhf");
+            cmdList.add("" + spin);
+        }
+
+        if(xControlFileOrig != null) {
+            // copy the xcontrol file
+            try {
+                OutputPrimitives.copyFile(xControlFileOrig, dirName + File.separator + "xtb.inp");
+            } catch (Exception e){
+                System.err.println("Failure to copy xtb input file in XTBCaller.energyCalculation");
+                e.printStackTrace(System.err);
+                return FixedValues.NONCONVERGEDENERGY;
+            }
+            cmdList.add("--input");
+            cmdList.add("xtb.inp");
+        }
+
+        if(xtbOtherOptions != null){
+            for(final String s : xtbOtherOptions) cmdList.add(s);
+        }
+
+        cmdList.add("input.xyz");
+
+        final ProcessBuilder pb = new ProcessBuilder(cmdList);
+        pb.directory(new File(dirName));
+        if(setEnvironment) {
+            // ensure that xtb is only running with one thread
+            final Map<String, String> envMap = pb.environment();
+            envMap.put("OMP_NUM_THREADS", "1"); 
+            envMap.put("OMP_MAX_ACTIVE_LEVELS", "1");
+            envMap.put("MKL_NUM_THREADS", "1");
+        }
+
+        String[] xtbOut = null;
+        try {
+            final Process proc = pb.start();
+            
+            // any error message?
+            final StreamGobbler errorGobbler = new StreamGobbler(proc.getErrorStream(), "ERROR");
+
+            // any output?
+            final StreamGobbler outputGobbler = new StreamGobbler(proc.getInputStream(), "OUTPUT");
+
+            // kick them off
+            errorGobbler.start();
+            outputGobbler.start();
+
+            // any error???
+            if (proc.waitFor() != 0) {
+                throw new Exception("xtb returns non-zero return value (energy calculation).");
+            }
+            xtbOut = outputGobbler.getData(); 
+        } catch (Exception e) {
+            System.err.println("Failure in cmd execution in XTBCaller.energyCalculation");
+            e.printStackTrace(System.err);
+            return FixedValues.NONCONVERGEDENERGY;
+        }
+
+        double energy = FixedValues.NONCONVERGEDENERGY;
+        try{
+            // find the total energy in the output
+            double totalE = FixedValues.NONCONVERGEDENERGY;
+            for(int i = xtbOut.length - 1; i >= 0; i--) {
+                if(xtbOut[i].contains("TOTAL ENERGY")) {
+                    final String[] line = xtbOut[i].trim().split("\\s+");
+                    energy = Double.parseDouble(line[3]);
+                    break;
+                }
+            }
+        } catch(Exception e){
+            System.err.println("Failure in reading energy in XTBCaller.energyCalculation");
+            e.printStackTrace(System.err);
+            return FixedValues.NONCONVERGEDENERGY;
+        }
+
+        //cleanup
+        try {
+            ManipulationPrimitives.remove(dirName);
+        } catch (Exception e) {
+            System.err.println("failure to remove subdir in XTBCaller.energyCalculation");
+            e.printStackTrace(System.err);
+        }
+
+        return energy;
     }
 }


### PR DESCRIPTION
Add support for energy evalutation to XTB, i.e., formally make it a CartesianFullBackend. However, due to the lack of a gradient implementation, this functionality will not be exposed but only used from operators that may need energies.

While there, adjust the precision for the XTB macrobenchmark to better match the opt normal setting.