### PR TITLE
Improve XTB example stability

### DIFF
--- a/examples/clusteropt/au10/au10_gfn1_xtb.ogo
+++ b/examples/clusteropt/au10/au10_gfn1_xtb.ogo
@@ -8,11 +8,11 @@ Au;0.0;0.0;0.0
 </GEOMETRY>
 CellSize=60;60;60
 NumberOfGlobIterations=99900
-PoolSize=100
+PoolSize=32
 GeneticRecordsToSerial=1000000
 GeometriesToSerial=100000
 AcceptableFitness=-39.8054548
-BlowBondDetect=1.8
+BlowBondDetect=0.9
 BlowFacDissoc=4.0
-LocOptAlgo=xtb:method=gfn1-xtb, optlevel=normal
+LocOptAlgo=xtb:method=gfn1-xtb,optlevel=normal
 GlobOptAlgo=cluster{xover(multiple:75%sweden:cutstyle=2|25%sweden:cutstyle=1)mutation(multiple:75%montecarlo:mode=some|25%montecarlo:mode=one)}

--- a/src/org/ogolem/interfaces/XTBCaller.java
+++ b/src/org/ogolem/interfaces/XTBCaller.java
@@ -204,7 +204,6 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
             final Map<String, String> envMap = pb.environment();
             envMap.put("OMP_NUM_THREADS", "1");
             envMap.put("OMP_MAX_ACTIVE_LEVELS", "1");
-            envMap.put("MKL_NUM_THREADS", "1");
         }
 
         final Process proc = pb.start();


### PR DESCRIPTION
* Removed the MKL parallelization flag (it caused unwanted additional threading)
* Lowered the BlowBondDetect in the au10 example to 0.9, which should now be small enough to let reasonable individuals pass.
* Lowered the initial pool size.