### PR TITLE
input option to auto-delete xtblocopt subdirs even in case of failure…

### DIFF
--- a/src/org/ogolem/core/LocOptFactory.java
+++ b/src/org/ogolem/core/LocOptFactory.java
@@ -230,7 +230,8 @@ public class LocOptFactory extends AbstractLocOptFactory<Molecule, Geometry> {
       XTBCaller.METHOD meth = XTBCaller.METHOD.GFN2XTB;
       XTBCaller.OPTLEVEL opt = XTBCaller.OPTLEVEL.NORMAL;
       boolean setEnvironment = true;
-      String xControlFile = null;
+      String xControlFileName = null;
+      boolean forceDelete = false;
 
       final String[] spl = inputOpts.split("\\,");
       for (final String s : spl) {
@@ -268,13 +269,20 @@ public class LocOptFactory extends AbstractLocOptFactory<Molecule, Geometry> {
           setEnvironment = false;
         } else if (s.trim().startsWith("xcontrol=")) {
           final String x = s.trim().substring("xcontrol=".length()).trim();
-          xControlFile = x;
+          xControlFileName = x;
+          final File xControlFile = new File(xControlFileName);
+          if (!xControlFile.isFile() || !xControlFile.canRead()) {
+            throw new RuntimeException(
+                "xcontrol file " + xControlFileName + " not found by XTB caller");
+          }
+        } else if (s.trim().equalsIgnoreCase("forcedelete")) {
+          forceDelete = true;
         } else {
           throw new RuntimeException("Illegal XTB option " + s);
         }
       }
 
-      newton = new XTBCaller(config, meth, opt, setEnvironment, xControlFile);
+      newton = new XTBCaller(config, meth, opt, setEnvironment, xControlFileName, forceDelete);
     } else if (locOptString.startsWith("molpro:")) {
       String sTemp3 = locOptString.substring(7).trim();
       if (sTemp3.equalsIgnoreCase("am1/vdz") || sTemp3.equalsIgnoreCase("am1")) {

--- a/src/org/ogolem/core/LocOptFactory.java
+++ b/src/org/ogolem/core/LocOptFactory.java
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
+import java.io.File
 import java.util.HashMap;
 import org.ogolem.adaptive.AdaptiveParameters;
 import org.ogolem.generic.GenericBackend;

--- a/src/org/ogolem/core/LocOptFactory.java
+++ b/src/org/ogolem/core/LocOptFactory.java
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
-import java.io.File
+import java.io.File;
 import java.util.HashMap;
 import org.ogolem.adaptive.AdaptiveParameters;
 import org.ogolem.generic.GenericBackend;

--- a/src/org/ogolem/interfaces/XTBCaller.java
+++ b/src/org/ogolem/interfaces/XTBCaller.java
@@ -93,13 +93,15 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
   private final String[] xtbOtherOptions;
   private final boolean setEnvironment;
   private final String xControlFileOrig;
+  private final boolean forceDelete;
 
   public XTBCaller(
       final GlobalConfig globconf,
       final METHOD method,
       final OPTLEVEL level,
       final boolean setEnvironment,
-      final String xControlFileOrig)
+      final String xControlFileOrig,
+      final boolean forceDelete)
       throws Exception {
     super(globconf);
 
@@ -161,6 +163,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     this.xtbOtherOptions = (otherOpts == null) ? null : otherOpts.split("\\s+");
     this.setEnvironment = setEnvironment;
     this.xControlFileOrig = xControlFileOrig;
+    this.forceDelete = forceDelete;
   }
 
   private XTBCaller(final XTBCaller orig) {
@@ -172,6 +175,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     this.xtbOtherOptions = orig.xtbOtherOptions;
     this.setEnvironment = orig.setEnvironment;
     this.xControlFileOrig = orig.xControlFileOrig;
+    this.forceDelete = orig.forceDelete;
   }
 
   @Override
@@ -274,10 +278,18 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     // any error???
     final int errCode = proc.waitFor();
     if (errCode != 0) {
+      if (forceDelete) {
+        ManipulationPrimitives.remove(dirName);
+        System.err.println("WARNING in XTB caller: removing subdir despite nonzero return code");
+      }
       throw new Exception(
           "xtb returns non-zero return value (local optimization). Error code " + errCode);
     }
     if (!new File(dirName + File.separator + ".xtboptok").isFile()) {
+      if (forceDelete) {
+        ManipulationPrimitives.remove(dirName);
+        System.err.println("WARNING in XTB caller: removing subdir despite non-converged locopt");
+      }
       throw new Exception("xtb locopt had problems.");
     }
     // cmd should(!) have completed normally...


### PR DESCRIPTION
When XTB locopts fail occasionally due to too outlandish starting geometries, longer production runs can accumulate lots of xtblocopt-XYZ subdirectories which the user will delete right away w/o examination b/c all is known to be well This gives the user the option to do this automagically -- only upon request, of course = the default is to keep these fail-subdirs for later examination.

I had a weird conflict locally (which I fixed, I think), so I hope that I am not screwing things up here...
