### PR TITLE
keep subdirs mv rand ini

### DIFF
--- a/src/org/ogolem/core/Input.java
+++ b/src/org/ogolem/core/Input.java
@@ -1176,6 +1176,28 @@ public final class Input {
     }
 
     /*
+     * INITIALIZE THE RANDOM NUMBER GENERATOR here,
+     * since environments refer to it
+     */
+    RNGenerator rng = null;
+    if (rngString.equalsIgnoreCase("javarng:autoseed")) {
+      // get seed first
+      final Random r = new Random();
+      final long seed = r.nextLong();
+      rng = new StandardRNG(seed);
+    } else if (rngString.startsWith("javarng:seed=")) {
+      final String s = rngString.substring("javarng:seed=".length()).trim();
+      final long seed = Long.parseLong(s);
+      rng = new StandardRNG(seed);
+    } else {
+      throw new RuntimeException("Illegal RNG configured: " + rngString);
+    }
+
+    System.out.println("INFO: RNG initialized: " + rng.getInformation());
+
+    Lottery.setGenerator(rng);
+
+    /*
      * work on environment tags
      */
     if (hasEnvTag) {
@@ -1539,27 +1561,6 @@ public final class Input {
 
       globConf.backendDefs = backendDefs;
     }
-
-    /*
-     * SECOND TO LAST THING: INITIALIZE THE RANDOM NUMBER GENERATOR
-     */
-    RNGenerator rng = null;
-    if (rngString.equalsIgnoreCase("javarng:autoseed")) {
-      // get seed first
-      final Random r = new Random();
-      final long seed = r.nextLong();
-      rng = new StandardRNG(seed);
-    } else if (rngString.startsWith("javarng:seed=")) {
-      final String s = rngString.substring("javarng:seed=".length()).trim();
-      final long seed = Long.parseLong(s);
-      rng = new StandardRNG(seed);
-    } else {
-      throw new RuntimeException("Illegal RNG configured: " + rngString);
-    }
-
-    System.out.println("INFO: RNG initialized: " + rng.getInformation());
-
-    Lottery.setGenerator(rng);
 
     /*
      * LAST THINGS: BUILD LOCOPT AND GLOBOPT OBJECTS

--- a/src/org/ogolem/core/LocOptFactory.java
+++ b/src/org/ogolem/core/LocOptFactory.java
@@ -232,7 +232,7 @@ public class LocOptFactory extends AbstractLocOptFactory<Molecule, Geometry> {
       XTBCaller.OPTLEVEL opt = XTBCaller.OPTLEVEL.NORMAL;
       boolean setEnvironment = true;
       String xControlFileName = null;
-      boolean forceDelete = false;
+      XTBCaller.SUBDIRS subdirs = XTBCaller.SUBDIRS.NORMAL;
 
       final String[] spl = inputOpts.split("\\,");
       for (final String s : spl) {
@@ -276,14 +276,23 @@ public class LocOptFactory extends AbstractLocOptFactory<Molecule, Geometry> {
             throw new RuntimeException(
                 "xcontrol file " + xControlFileName + " not found by XTB caller");
           }
-        } else if (s.trim().equalsIgnoreCase("forcedelete")) {
-          forceDelete = true;
+        } else if (s.trim().startsWith("subdirs=")) {
+          final String d = s.trim().substring("subdirs=".length()).trim();
+          if (d.equalsIgnoreCase("forcedelete")) {
+            subdirs = XTBCaller.SUBDIRS.FORCEDELETE;
+          } else if (d.equalsIgnoreCase("keepall")) {
+            subdirs = XTBCaller.SUBDIRS.KEEPALL;
+          } else if (d.equalsIgnoreCase("normal")) {
+            subdirs = XTBCaller.SUBDIRS.NORMAL;
+          } else {
+            throw new RuntimeException("Illegal subdir treatment " + d + " for XTB caller");
+          }
         } else {
           throw new RuntimeException("Illegal XTB option " + s);
         }
       }
 
-      newton = new XTBCaller(config, meth, opt, setEnvironment, xControlFileName, forceDelete);
+      newton = new XTBCaller(config, meth, opt, setEnvironment, xControlFileName, subdirs);
     } else if (locOptString.startsWith("molpro:")) {
       String sTemp3 = locOptString.substring(7).trim();
       if (sTemp3.equalsIgnoreCase("am1/vdz") || sTemp3.equalsIgnoreCase("am1")) {

--- a/src/org/ogolem/interfaces/XTBCaller.java
+++ b/src/org/ogolem/interfaces/XTBCaller.java
@@ -86,6 +86,12 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     VERYTIGHT
   };
 
+  public static enum SUBDIRS {
+    NORMAL,
+    FORCEDELETE,
+    KEEPALL
+  };
+
   private final String xtbCmd;
   private final METHOD xtbMeth;
   private final String[] xtbMethod;
@@ -93,7 +99,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
   private final String[] xtbOtherOptions;
   private final boolean setEnvironment;
   private final String xControlFileOrig;
-  private final boolean forceDelete;
+  private final SUBDIRS subdirs;
 
   public XTBCaller(
       final GlobalConfig globconf,
@@ -101,7 +107,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
       final OPTLEVEL level,
       final boolean setEnvironment,
       final String xControlFileOrig,
-      final boolean forceDelete)
+      final SUBDIRS subdirs)
       throws Exception {
     super(globconf);
 
@@ -163,7 +169,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     this.xtbOtherOptions = (otherOpts == null) ? null : otherOpts.split("\\s+");
     this.setEnvironment = setEnvironment;
     this.xControlFileOrig = xControlFileOrig;
-    this.forceDelete = forceDelete;
+    this.subdirs = subdirs;
   }
 
   private XTBCaller(final XTBCaller orig) {
@@ -175,7 +181,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     this.xtbOtherOptions = orig.xtbOtherOptions;
     this.setEnvironment = orig.setEnvironment;
     this.xControlFileOrig = orig.xControlFileOrig;
-    this.forceDelete = orig.forceDelete;
+    this.subdirs = orig.subdirs;
   }
 
   @Override
@@ -278,7 +284,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     // any error???
     final int errCode = proc.waitFor();
     if (errCode != 0) {
-      if (forceDelete) {
+      if (subdirs == SUBDIRS.FORCEDELETE) {
         ManipulationPrimitives.remove(dirName);
         System.err.println("WARNING in XTB caller: removing subdir despite nonzero return code");
       }
@@ -286,7 +292,7 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
           "xtb returns non-zero return value (local optimization). Error code " + errCode);
     }
     if (!new File(dirName + File.separator + ".xtboptok").isFile()) {
-      if (forceDelete) {
+      if (subdirs == SUBDIRS.FORCEDELETE) {
         ManipulationPrimitives.remove(dirName);
         System.err.println("WARNING in XTB caller: removing subdir despite non-converged locopt");
       }
@@ -333,7 +339,9 @@ public class XTBCaller extends AbstractLocOpt implements CartesianFullBackend {
     }
 
     // cleanup
-    ManipulationPrimitives.remove(dirName);
+    if (subdirs != SUBDIRS.KEEPALL) {
+      ManipulationPrimitives.remove(dirName);
+    }
 
     return res;
   }


### PR DESCRIPTION
This is for 2 little things that are too small for a PR of their own:
1) adding a "keep-all" option for XTB subdirs (the opposite of "forcedelete")
2) moving the Lottery initiation to before the environment initiation in Input, to enable environments to refer to the already initiated Lottery (instead of triggering their own, which is ugly and potentially breaks reproducibility)

Co-authored-by: iotamudelta <dieterich@ogolem.org>