### PR TITLE
Upgrade Java requirement to Java16

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         stage('Build') {
             steps {
                 echo 'Building ogolem and running unit tests'
-                sh 'gradle build -i'
+                sh 'gradle build -i -Dorg.gradle.java.home=/usr/local/openjdk16'
             }
         }
         stage('Build ogolem manual') {
@@ -17,19 +17,19 @@ pipeline {
         stage('Microbenchmark') {
             steps {
 	        echo 'Running ogolem internal microbenchmarks'
-                sh 'java -jar build/libs/ogolem-snapshot.jar --microbenchmarks'
+                sh '/usr/local/openjdk16/bin/java --add-modules jdk.incubator.vector -jar build/libs/ogolem-snapshot.jar --microbenchmarks'
             }
         }
         stage('Macrobenchmark - clusters') {
             steps {
 	        echo 'Running ogolem internal macrobenchmarks for cluster structure optimization'
-                sh 'java -jar build/libs/ogolem-snapshot.jar --macrobenchmarks -cluster cluster-macrobenchs.csv 2'
+                sh '/usr/local/openjdk16/bin/java --add-modules jdk.incubator.vector -jar build/libs/ogolem-snapshot.jar --macrobenchmarks -cluster cluster-macrobenchs.csv 2'
             }
         }
         stage('Macrobenchmark - adaptive') {
             steps {
 	        echo 'Running ogolem internal macrobenchmarks for adaptive parameter optimization'
-                sh 'java -jar build/libs/ogolem-snapshot.jar --macrobenchmarks -adaptive adaptive-macrobenchs.csv 2'
+                sh '/usr/local/openjdk16/bin/java --add-modules jdk.incubator.vector -jar build/libs/ogolem-snapshot.jar --macrobenchmarks -adaptive adaptive-macrobenchs.csv 2'
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# OGOLEM
+
+The Java source of the OGOLEM framework for global optimization.
+
+## To build OGOLEM
+Prerequisits:
+* Java16+ JDK
+* gradle7+
+
+Invoke `gradle build` and a shadowjar will be created in `build/libs/ogolem-snapshot.jar`.
+
+## To run OGOLEM
+Prerequisits:
+* Java16+ JRE
+* the OGOLEM shadowjar - either from building or from downloading a Jenkins artifact
+
+Please see the manual for input options.
+
+Currently, one MUST explicitly enable incubator modules used by OGOLEM:
+```
+java --add-modules=jdk.incubator.vector --add-modules=jdk.incubator.foreign -jar ogolem-snapshot.jar ....
+```

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,16 @@
 plugins {
-  id 'com.github.johnrengelman.shadow' version '6.1.0'
-  id 'com.diffplug.spotless' version '5.1.1'
+  id 'com.github.johnrengelman.shadow' version '7.0.0'
+  id 'com.diffplug.spotless' version '5.12.4'
   id 'com.github.spotbugs' version '4.6.1'
   id 'java'
   id 'application'
 }
 
-sourceCompatibility = '11'
-targetCompatibility = '11'
+//sourceCompatibility = '16'
+//targetCompatibility = '16'
 
 mainClassName = 'org.ogolem.general.MainOgolem'
+applicationDefaultJvmArgs = ["--add-modules=jdk.incubator.foreign", "--add-modules=jdk.incubator.vector"]
 
 version = 'snapshot'
 
@@ -45,6 +46,12 @@ dependencies {
   )
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(16)
+  }
+}
+
 sourceSets {
   main {
     java {
@@ -63,6 +70,8 @@ compileJava {
   options.warnings = true
   options.deprecation = true
   options.debug = true
+  options.compilerArgs += ["--add-modules=jdk.incubator.foreign"]
+  options.compilerArgs += ["--add-modules=jdk.incubator.vector"]
 }
 
 // This debug target can be used from within Netbeans. Note that the "Debug Project"
@@ -88,6 +97,7 @@ test {
   exclude 'org/ogolem/locopt/FleminLocOptTest*'
   exclude 'org/ogolem/locopt/PraxisLocOptTest*'
   exclude 'org/ogolem/locopt/RNK1MinLocOptTest*'
+  jvmArgs '--add-modules=jdk.incubator.foreign', '--add-modules=jdk.incubator.vector'
 }
 
 shadowJar {
@@ -107,5 +117,15 @@ spotless {
 
 spotbugs {
     ignoreFailures = true
+    effort = 'more'
     onlyAnalyze = [ 'org.ogolem.*' ]
 }
+
+//spotbugsMain {
+//  reports {
+//    html {
+//      enabled = true
+//      stylesheet = 'fancy-hist.xsl'
+//    }
+//  }
+//}

--- a/examples/benchmarks/ackley/ackley_10d.ogo
+++ b/examples/benchmarks/ackley/ackley_10d.ogo
@@ -10,8 +10,8 @@ AdaptivableChoice=ackleybench:10D
 ParameterGlobOpt=parameters{xover(portugal:nocuts=1)mutation(germany:)}
 ParamGlobOptIter=19000
 PopulationSize=1000
-ParamThreshLocOptParam=1e-4
-ParamThreshLocOptGradient=1e-4
+ParamThreshLocOptParam=1e-7
+ParamThreshLocOptGradient=1e-7
 ParameterLocOpt=lbfgs:backend=alldefault
 AcceptableFitness=1e-6
 <REFERENCE>

--- a/examples/benchmarks/rastrigin/rastrigin_10d.ogo
+++ b/examples/benchmarks/rastrigin/rastrigin_10d.ogo
@@ -10,8 +10,8 @@ AdaptivableChoice=rastriginbench:10D
 ParameterGlobOpt=parameters{xover(portugal:nocuts=1)mutation(germany:)}
 ParamGlobOptIter=19000
 PopulationSize=1000
-ParamThreshLocOptParam=1e-4
-ParamThreshLocOptGradient=1e-4
+ParamThreshLocOptParam=1e-7
+ParamThreshLocOptGradient=1e-7
 ParameterLocOpt=lbfgs:backend=alldefault
 AcceptableFitness=1e-6
 <REFERENCE>

--- a/examples/benchmarks/schwefel/schwefel_10d.ogo
+++ b/examples/benchmarks/schwefel/schwefel_10d.ogo
@@ -10,8 +10,8 @@ AdaptivableChoice=schwefelbench:10D
 ParameterGlobOpt=parameters{xover(portugal:nocuts=1)mutation(germany:)}
 ParamGlobOptIter=19000
 PopulationSize=1000
-ParamThreshLocOptParam=1e-4
-ParamThreshLocOptGradient=1e-4
+ParamThreshLocOptParam=1e-5
+ParamThreshLocOptGradient=1e-5
 ParameterLocOpt=lbfgs:backend=alldefault
 AcceptableFitness=1e-4
 <REFERENCE>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/src/org/ogolem/core/CoordTranslation.java
+++ b/src/org/ogolem/core/CoordTranslation.java
@@ -57,7 +57,8 @@ public final class CoordTranslation {
 
   private static final boolean DEBUG = false;
 
-  private CoordTranslation() {};
+  private CoordTranslation() {}
+  ;
 
   /**
    * Translates a Geometry into a CartesianCoordinates object.

--- a/src/org/ogolem/core/Input.java
+++ b/src/org/ogolem/core/Input.java
@@ -47,6 +47,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorSpecies;
 import org.ogolem.adaptive.AdaptiveParameters;
 import org.ogolem.generic.GenericBackend;
 import org.ogolem.generic.GenericFitnessFunction;
@@ -62,15 +64,19 @@ import org.ogolem.md.MDConfig;
 import org.ogolem.random.Lottery;
 import org.ogolem.random.RNGenerator;
 import org.ogolem.random.StandardRNG;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This invokes the IOHandler and checks the resulting array of Strings for configuration options
  * and configures a GlobalConfig object.
  *
  * @author Johannes Dieterich
- * @version 2021-04-19
+ * @version 2021-07-04
  */
 public final class Input {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Input.class);
 
   public static GlobalConfig ConfigureMe(final String inputPath)
       throws InitIOException, CastException, Exception {
@@ -99,6 +105,14 @@ public final class Input {
   public static GlobalConfig configureFromBlock(
       final String[] configInput, final String inputPath, final boolean failOnMissingGeom)
       throws InitIOException, CastException, Exception {
+
+    // since vectorapi is an incubating feature and we otherwise only use it within a
+    // threading environment that swallows exceptions (such as: add the incubator module)
+    // excplicitly use it here so that errors are user visible
+    final VectorSpecies<Double> species = DoubleVector.SPECIES_PREFERRED;
+    LOG.info(
+        "Vectorization through incubating vectorapi is accessible with a preferred vector length of : "
+            + species.length());
 
     final GlobalConfig globConf = new GlobalConfig();
 

--- a/src/org/ogolem/macrobenchmarks/Helpers.java
+++ b/src/org/ogolem/macrobenchmarks/Helpers.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2020-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -46,49 +46,57 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Some helpers solely for the macrobenchmarks
+ *
  * @author Johannes Dieterich
- * @version 2020-04-29
+ * @version 2021-06-29
  */
 class Helpers {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(Helpers.class);    
-    private static final boolean DEBUG = false;
 
-    static int executeJavaProcess(final String workDir, final String[] args) throws Exception {
-        
-        final String javaHome = System.getProperty("java.home");
-        final String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
-        final String pathToOurJar = new File(System.getProperty("java.class.path")).getAbsolutePath();
- 
-        if(DEBUG){
-            final Properties p = System.getProperties();
-            p.list(System.out);
-        }
+  private static final Logger LOG = LoggerFactory.getLogger(Helpers.class);
+  private static final boolean DEBUG = false;
 
-        final List<String> command = new ArrayList<>();
-        command.add(javaBin);
-        command.add("-ea");
-        command.add("-jar");
-        command.add(pathToOurJar);
-        
-        for(final String arg : args){
-            command.add(arg);
-        }
-        
-        LOG.debug("Executing " + javaBin + " with jar " + pathToOurJar);
-        
-        final ProcessBuilder builder = new ProcessBuilder(command);
-        final Process proc = builder.directory(new File(workDir)).redirectOutput(new File(workDir + File.separator + "bench.out")).redirectError(new File(workDir + File.separator + "bench.err")).start();
-        proc.waitFor();
-                
-        return proc.exitValue();
+  static int executeJavaProcess(final String workDir, final String[] args) throws Exception {
+
+    final String javaHome = System.getProperty("java.home");
+    final String javaBin = javaHome + File.separator + "bin" + File.separator + "java";
+    final String pathToOurJar = new File(System.getProperty("java.class.path")).getAbsolutePath();
+
+    if (DEBUG) {
+      final Properties p = System.getProperties();
+      p.list(System.out);
     }
-    
-    static class Rank0Filter implements FilenameFilter {
 
-        @Override
-        public boolean accept(File arg0, String arg1) {
-            return (arg1.startsWith("rank0individual"));
-        }
+    final List<String> command = new ArrayList<>();
+    command.add(javaBin);
+    command.add("-ea");
+    command.add("--add-modules");
+    command.add("jdk.incubator.vector");
+    command.add("-jar");
+    command.add(pathToOurJar);
+
+    for (final String arg : args) {
+      command.add(arg);
     }
+
+    LOG.debug("Executing " + javaBin + " with jar " + pathToOurJar);
+
+    final ProcessBuilder builder = new ProcessBuilder(command);
+    final Process proc =
+        builder
+            .directory(new File(workDir))
+            .redirectOutput(new File(workDir + File.separator + "bench.out"))
+            .redirectError(new File(workDir + File.separator + "bench.err"))
+            .start();
+    proc.waitFor();
+
+    return proc.exitValue();
+  }
+
+  static class Rank0Filter implements FilenameFilter {
+
+    @Override
+    public boolean accept(File arg0, String arg1) {
+      return (arg1.startsWith("rank0individual"));
+    }
+  }
 }


### PR DESCRIPTION
In anticipation of incubating feature use, enable foreign and vector.

Upgrade some plugins to work w/ Java16.

Work around googleformat shortcomings wrt encapsulated core JDK classes.

Add README (bare bones).

Fix the mismatch between convergence criteria and acceptable fitness in some tests.