### PR TITLE
Convert to Junit5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,10 @@ dependencies {
   implementation 'org.slf4j:slf4j-api:1.7.30'
   implementation 'org.slf4j:slf4j-simple:1.7.30'
   testImplementation(
-    'junit:junit:4.12',
-    'org.junit.jupiter:junit-jupiter-api:5.4.2'
+    'org.junit.jupiter:junit-jupiter-api:5.7.2'
   )
   testRuntimeOnly (
-    'org.junit.jupiter:junit-jupiter-engine:5.4.2',
-    'org.junit.vintage:junit-vintage-engine:5.4.2'
+    'org.junit.jupiter:junit-jupiter-engine:5.7.2',
   )
 }
 

--- a/src/org/ogolem/adaptive/BenchAckley.java
+++ b/src/org/ogolem/adaptive/BenchAckley.java
@@ -1,7 +1,7 @@
 /*
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2013, J. M. Dieterich
-              2015-2020, J. M. Dieterich and B. Hartke
+              2015-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tests/org/ogolem/adaptive/AdaptiveLJFFTest.java
+++ b/tests/org/ogolem/adaptive/AdaptiveLJFFTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,9 +36,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.adaptive;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.ArrayList;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 import org.ogolem.core.AtomicProperties;
 import org.ogolem.core.BondInfo;
 import org.ogolem.core.CartesianCoordinates;
@@ -46,248 +47,315 @@ import org.ogolem.core.Gradient;
 import org.ogolem.core.SimpleBondInfo;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2020-05-25
+ * @version 2021-07-17
  */
 public class AdaptiveLJFFTest {
-    
-    private static final String LJ38MIN = "38\n" +
-"Energy:            -173.2453\n" +
-"Ar              2.2635080             -1.3021673              0.2364510\n" +
-"Ar             -4.0696589             -1.7833951             -1.0912553\n" +
-"Ar              3.3465963              0.5473776              5.1173994\n" +
-"Ar              4.6352036              2.9641120             -1.9064564\n" +
-"Ar             -5.2396084              1.6412581             -2.1458985\n" +
-"Ar              2.1975346              3.9699958              4.0662786\n" +
-"Ar              2.9139336             -0.1048691             -3.2585750\n" +
-"Ar             -0.1537578             -0.2936708              6.2036580\n" +
-"Ar             -3.5310673              4.6998827             -0.7800296\n" +
-"Ar             -1.8706342             -3.3672049              4.8312587\n" +
-"Ar              3.9770026              1.7439961              1.5989158\n" +
-"Ar              5.1470505             -1.6806710              2.6532521\n" +
-"Ar              0.0611707              0.2542515             -5.6961461\n" +
-"Ar              1.1218741              2.0986964             -0.8081952\n" +
-"Ar             -5.8825641              0.4360893              1.3575178\n" +
-"Ar              1.7779228              3.3278948             -4.3237295\n" +
-"Ar              3.4384866             -4.7393483              1.2876312\n" +
-"Ar              4.0814241             -3.5339516             -2.2157154\n" +
-"Ar              5.7898690             -0.4751665             -0.8500914\n" +
-"Ar             -2.9362859             -5.2206833             -0.0378087\n" +
-"Ar             -1.2145583             -2.1381033              1.3158395\n" +
-"Ar             -4.1741020              3.4946992              2.7233876\n" +
-"Ar              2.8435532              5.1812951              0.5458881\n" +
-"Ar             -0.5757456             -0.9405450             -2.1653462\n" +
-"Ar              1.6313510             -2.5096021              3.7313159\n" +
-"Ar             -1.3028293              3.1289101              5.1523874\n" +
-"Ar             -3.0066453              0.0655822              3.7661092\n" +
-"Ar             -0.0136789              5.5451888             -1.8714567\n" +
-"Ar              0.5682738             -4.3585518             -1.1260230\n" +
-"Ar             -0.6609501              4.3190723              1.6338157\n" +
-"Ar             -2.2902497             -4.0096773             -3.5583525\n" +
-"Ar              0.4831067              0.9010895              2.6729642\n" +
-"Ar             -3.4390998             -0.5870227             -4.6098257\n" +
-"Ar             -2.3561517              1.2627716              0.2711277\n" +
-"Ar             -1.7239135              2.4701423             -3.2237536\n" +
-"Ar             -4.7280805             -3.0031875              2.4141292\n" +
-"Ar              1.2100750             -3.1683730             -4.6446476\n" +
-"Ar             -0.0788494             -5.5846809              2.3792819";
-    
-    private static final String LJ55MIN = "55\n" +
-"Energy:            -278.1517\n" +
-"Ar              0.2637670              0.0750218             -0.0305859\n" +
-"Ar              1.9400511             -5.9359266             -0.2182075\n" +
-"Ar             -3.3887782              5.5878993             -3.0857245\n" +
-"Ar              5.4645827              3.5286603             -0.0164234\n" +
-"Ar             -0.0611506             -6.3446547             -3.4581804\n" +
-"Ar             -4.7623515              2.0139627             -3.1856848\n" +
-"Ar             -2.7311677              1.0755806              5.3550730\n" +
-"Ar              5.1542978             -3.8014196             -0.2095618\n" +
-"Ar             -3.0861314             -3.9969872             -3.3732330\n" +
-"Ar              2.4421399              5.9244352              0.0941955\n" +
-"Ar              0.1530409              0.2714680             -7.3117752\n" +
-"Ar              3.2585466             -0.9253576             -5.4163715\n" +
-"Ar              0.2094058              0.1714695             -3.6056473\n" +
-"Ar              2.2225382              2.7895936             -5.3003453\n" +
-"Ar             -1.6999051             -2.4743290              1.5308355\n" +
-"Ar              6.5888663              1.7386441              3.1775426\n" +
-"Ar              0.4233255              3.2271118              1.6523928\n" +
-"Ar             -1.6951682             -2.6393958              5.2391891\n" +
-"Ar             -2.8418301             -0.7418962             -1.6057981\n" +
-"Ar             -2.7097004              1.1466854              1.6437936\n" +
-"Ar              0.3743391             -0.1213402              7.2505633\n" +
-"Ar              2.0571514             -2.6317879              1.4694758\n" +
-"Ar              3.3693659              0.8918850              1.5446257\n" +
-"Ar              3.9163409             -5.4378330              3.0245237\n" +
-"Ar             -1.4124661              6.0859683              0.1570572\n" +
-"Ar              0.4832106              3.2099543              5.3639202\n" +
-"Ar             -5.9730344              0.3363606              0.0711651\n" +
-"Ar             -4.6268008              3.9515551              0.1482164\n" +
-"Ar             -2.6231431              4.4083720              3.4138865\n" +
-"Ar             -2.9781957             -0.6641526             -5.3145255\n" +
-"Ar              4.2630175              5.2673226             -3.2106167\n" +
-"Ar             -1.9145285             -5.7743746             -0.1552363\n" +
-"Ar             -4.9370769             -3.3786155             -0.0447196\n" +
-"Ar             -6.0612815             -1.5887397             -3.2387501\n" +
-"Ar             -1.5296300              2.7818574             -1.5306798\n" +
-"Ar             -3.7355675             -5.1171473              3.1495165\n" +
-"Ar              0.4384309              5.4677007             -3.1714606\n" +
-"Ar              5.3289109              1.5912421             -3.3504794\n" +
-"Ar              0.0890783             -5.3175663              3.1103721\n" +
-"Ar             -4.8014991             -1.4410447              3.2891758\n" +
-"Ar             -1.6319388              2.9510461             -5.2374343\n" +
-"Ar              5.2899358             -1.8640178              3.1244180\n" +
-"Ar             -5.7921455              2.2576283              3.3795587\n" +
-"Ar              3.2371665             -0.9965492             -1.7050608\n" +
-"Ar              0.0442854             -3.0598980             -5.4250516\n" +
-"Ar              3.6137059              4.1469046              3.3121847\n" +
-"Ar              0.3180569             -0.0213815              3.5444697\n" +
-"Ar              2.1594096             -2.8009554              5.1762327\n" +
-"Ar              0.5887912              6.4946966              3.3970661\n" +
-"Ar              0.1042463             -3.0770498             -1.7135232\n" +
-"Ar              6.3195618             -2.1073732             -3.4409865\n" +
-"Ar              2.2274111              2.6244358             -1.5919829\n" +
-"Ar              3.5057247              0.8140948              5.2533412\n" +
-"Ar              3.1506760             -4.2582346             -3.4751765\n" +
-"Ar              6.5005124             -0.1862658             -0.1324787";
-    
-    private static final double ENERGYLJ38 = -0.0659856619926505;
-    private static final double ENERGYLJ55 = -0.10594240151944964;
-    private static final double NUMACC = 1.0e-8;
-    
-    private final AdaptiveLJFF adapLJFF;
-    
-    private final int[] atsPerMol38;
-    private final int[] atsPerMol55;
-    
-    private final CartesianCoordinates lj38;
-    private final CartesianCoordinates lj55;
-    
-    public AdaptiveLJFFTest(){
-        
-        this.atsPerMol38 = new int[38];
-        for(int i = 0; i < 38; i++){
-            atsPerMol38[i] = 1;
-        }
-        
-        this.atsPerMol55 = new int[55];
-        for(int i = 0; i < 55; i++){
-            atsPerMol55[i] = 1;
-        }
-        
-        CartesianCoordinates lj38 = null;
-        CartesianCoordinates lj55 = null;
-        
-        try {
-            final String[] fileCont38 = LJ38MIN.split("\n");
-            lj38 = org.ogolem.core.Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
-        
-            final String[] fileCont55 = LJ55MIN.split("\n");
-            lj55 = org.ogolem.core.Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
-        } catch(Exception e){
-           fail(e.toString());
-        }
-        
-        assert(lj38 != null);
-        assert(lj55 != null);
-        
-        this.lj38 = lj38;
-        this.lj55 = lj55;
-        
-        /*
-        parameters to constructor:
-            final boolean isInAdaptive, final boolean easyLBMix,
-            final int startPot, final int endPot, final int potIncr,
-            final AdaptiveParameters parameters, final boolean use3Body,
-            final double closeCutBlow, final double distCutBlow,
-            final boolean useCache, final boolean discard2Body
-        */
-        
-        final AdaptiveLJFF dummy = new AdaptiveLJFF(true /* pretend to be in adaptive*/, false,
-                6, 12, 6, null /* only then can we set params to null */, false, 1.2, 20.0,
-                false /* no cache, dummy */, false);
-        final ArrayList<CartesianCoordinates> cartes = new ArrayList<>();
-        cartes.add(lj38);
-        
-        final AdaptiveParameters params = dummy.createInitialParameterStub(cartes, dummy.getMethodID());
-        
-        // now set the parameters to our regular LJ parameters for Ar
-        final double sigma = AtomicProperties.giveLennardJonesSigma("Ar");
-        final double epsilon = AtomicProperties.giveLennardJonesEpsilon("Ar");
-        
-        final String[] keys = params.getAllKeysCopy();
-        assert(keys.length == 1); // there should only be one
-        
-        final int noParams = params.getAmountOfParametersForKey(keys[0]);
-        assert(noParams == 3); // must be one epsilon and two sigma (same sigma)
-        
-        final double[] paramVals = params.getAllParamters();
-        paramVals[0] = epsilon;
-        paramVals[1] = -sigma; // to make it 12-6
-        paramVals[2] = sigma;
-        
-        adapLJFF = new AdaptiveLJFF(false /* pretend to be in core*/, false,
-                6, 12, 6, params /* real params */, false, 1.2, 20.0,
-                false /* no cache, different LJ cluster sizes */, false);
-    }
-    
-    @Test
-    public void testEnergyCalculationAdapLJMins() {
-        
-        final BondInfo bonds38 = new SimpleBondInfo(38);
-        final BondInfo bonds55 = new SimpleBondInfo(55);
-        
-        final double e38 = adapLJFF.energyCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38, false);
-        
-        assertEquals(ENERGYLJ38, e38, NUMACC);
-        
-        final double e55 = adapLJFF.energyCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55, false);
-        
-        assertEquals(ENERGYLJ55, e55, NUMACC);
-    }
-    
-    @Test
-    public void testGradientCalculationAdapLJMins() {
 
-        final BondInfo bonds38 = new SimpleBondInfo(38);
-        final BondInfo bonds55 = new SimpleBondInfo(55);
-        
-        final Gradient grad38 = new Gradient(3, 38);
-        adapLJFF.gradientCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38,
-                grad38, false);
-        
-        assertEquals(ENERGYLJ38, grad38.getTotalEnergy(), NUMACC);
-        
-        final double[][] gradient38 = grad38.getTotalGradient();
-        
-        double gradTot38 = 0.0;
-        for(int i = 0; i < 3; i++){
-            for(int j = 0; j < 38; j++) gradTot38 += gradient38[i][j];
-        }
-        
-        assertEquals(0.0, gradTot38, NUMACC);
-        
-        final Gradient grad55 = new Gradient(3, 55);
-        adapLJFF.gradientCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55,
-                grad55, false);
-        
-        assertEquals(ENERGYLJ55, grad55.getTotalEnergy(), NUMACC);
-        
-        final double[][] gradient55 = grad55.getTotalGradient();
-        
-        double gradTot55 = 0.0;
-        for(int i = 0; i < 3; i++){
-            for(int j = 0; j < 55; j++) gradTot55 += gradient55[i][j];
-        }
-        
-        assertEquals(0.0, gradTot55, NUMACC);
+  private static final String LJ38MIN =
+      "38\n"
+          + "Energy:            -173.2453\n"
+          + "Ar              2.2635080             -1.3021673              0.2364510\n"
+          + "Ar             -4.0696589             -1.7833951             -1.0912553\n"
+          + "Ar              3.3465963              0.5473776              5.1173994\n"
+          + "Ar              4.6352036              2.9641120             -1.9064564\n"
+          + "Ar             -5.2396084              1.6412581             -2.1458985\n"
+          + "Ar              2.1975346              3.9699958              4.0662786\n"
+          + "Ar              2.9139336             -0.1048691             -3.2585750\n"
+          + "Ar             -0.1537578             -0.2936708              6.2036580\n"
+          + "Ar             -3.5310673              4.6998827             -0.7800296\n"
+          + "Ar             -1.8706342             -3.3672049              4.8312587\n"
+          + "Ar              3.9770026              1.7439961              1.5989158\n"
+          + "Ar              5.1470505             -1.6806710              2.6532521\n"
+          + "Ar              0.0611707              0.2542515             -5.6961461\n"
+          + "Ar              1.1218741              2.0986964             -0.8081952\n"
+          + "Ar             -5.8825641              0.4360893              1.3575178\n"
+          + "Ar              1.7779228              3.3278948             -4.3237295\n"
+          + "Ar              3.4384866             -4.7393483              1.2876312\n"
+          + "Ar              4.0814241             -3.5339516             -2.2157154\n"
+          + "Ar              5.7898690             -0.4751665             -0.8500914\n"
+          + "Ar             -2.9362859             -5.2206833             -0.0378087\n"
+          + "Ar             -1.2145583             -2.1381033              1.3158395\n"
+          + "Ar             -4.1741020              3.4946992              2.7233876\n"
+          + "Ar              2.8435532              5.1812951              0.5458881\n"
+          + "Ar             -0.5757456             -0.9405450             -2.1653462\n"
+          + "Ar              1.6313510             -2.5096021              3.7313159\n"
+          + "Ar             -1.3028293              3.1289101              5.1523874\n"
+          + "Ar             -3.0066453              0.0655822              3.7661092\n"
+          + "Ar             -0.0136789              5.5451888             -1.8714567\n"
+          + "Ar              0.5682738             -4.3585518             -1.1260230\n"
+          + "Ar             -0.6609501              4.3190723              1.6338157\n"
+          + "Ar             -2.2902497             -4.0096773             -3.5583525\n"
+          + "Ar              0.4831067              0.9010895              2.6729642\n"
+          + "Ar             -3.4390998             -0.5870227             -4.6098257\n"
+          + "Ar             -2.3561517              1.2627716              0.2711277\n"
+          + "Ar             -1.7239135              2.4701423             -3.2237536\n"
+          + "Ar             -4.7280805             -3.0031875              2.4141292\n"
+          + "Ar              1.2100750             -3.1683730             -4.6446476\n"
+          + "Ar             -0.0788494             -5.5846809              2.3792819";
+
+  private static final String LJ55MIN =
+      "55\n"
+          + "Energy:            -278.1517\n"
+          + "Ar              0.2637670              0.0750218             -0.0305859\n"
+          + "Ar              1.9400511             -5.9359266             -0.2182075\n"
+          + "Ar             -3.3887782              5.5878993             -3.0857245\n"
+          + "Ar              5.4645827              3.5286603             -0.0164234\n"
+          + "Ar             -0.0611506             -6.3446547             -3.4581804\n"
+          + "Ar             -4.7623515              2.0139627             -3.1856848\n"
+          + "Ar             -2.7311677              1.0755806              5.3550730\n"
+          + "Ar              5.1542978             -3.8014196             -0.2095618\n"
+          + "Ar             -3.0861314             -3.9969872             -3.3732330\n"
+          + "Ar              2.4421399              5.9244352              0.0941955\n"
+          + "Ar              0.1530409              0.2714680             -7.3117752\n"
+          + "Ar              3.2585466             -0.9253576             -5.4163715\n"
+          + "Ar              0.2094058              0.1714695             -3.6056473\n"
+          + "Ar              2.2225382              2.7895936             -5.3003453\n"
+          + "Ar             -1.6999051             -2.4743290              1.5308355\n"
+          + "Ar              6.5888663              1.7386441              3.1775426\n"
+          + "Ar              0.4233255              3.2271118              1.6523928\n"
+          + "Ar             -1.6951682             -2.6393958              5.2391891\n"
+          + "Ar             -2.8418301             -0.7418962             -1.6057981\n"
+          + "Ar             -2.7097004              1.1466854              1.6437936\n"
+          + "Ar              0.3743391             -0.1213402              7.2505633\n"
+          + "Ar              2.0571514             -2.6317879              1.4694758\n"
+          + "Ar              3.3693659              0.8918850              1.5446257\n"
+          + "Ar              3.9163409             -5.4378330              3.0245237\n"
+          + "Ar             -1.4124661              6.0859683              0.1570572\n"
+          + "Ar              0.4832106              3.2099543              5.3639202\n"
+          + "Ar             -5.9730344              0.3363606              0.0711651\n"
+          + "Ar             -4.6268008              3.9515551              0.1482164\n"
+          + "Ar             -2.6231431              4.4083720              3.4138865\n"
+          + "Ar             -2.9781957             -0.6641526             -5.3145255\n"
+          + "Ar              4.2630175              5.2673226             -3.2106167\n"
+          + "Ar             -1.9145285             -5.7743746             -0.1552363\n"
+          + "Ar             -4.9370769             -3.3786155             -0.0447196\n"
+          + "Ar             -6.0612815             -1.5887397             -3.2387501\n"
+          + "Ar             -1.5296300              2.7818574             -1.5306798\n"
+          + "Ar             -3.7355675             -5.1171473              3.1495165\n"
+          + "Ar              0.4384309              5.4677007             -3.1714606\n"
+          + "Ar              5.3289109              1.5912421             -3.3504794\n"
+          + "Ar              0.0890783             -5.3175663              3.1103721\n"
+          + "Ar             -4.8014991             -1.4410447              3.2891758\n"
+          + "Ar             -1.6319388              2.9510461             -5.2374343\n"
+          + "Ar              5.2899358             -1.8640178              3.1244180\n"
+          + "Ar             -5.7921455              2.2576283              3.3795587\n"
+          + "Ar              3.2371665             -0.9965492             -1.7050608\n"
+          + "Ar              0.0442854             -3.0598980             -5.4250516\n"
+          + "Ar              3.6137059              4.1469046              3.3121847\n"
+          + "Ar              0.3180569             -0.0213815              3.5444697\n"
+          + "Ar              2.1594096             -2.8009554              5.1762327\n"
+          + "Ar              0.5887912              6.4946966              3.3970661\n"
+          + "Ar              0.1042463             -3.0770498             -1.7135232\n"
+          + "Ar              6.3195618             -2.1073732             -3.4409865\n"
+          + "Ar              2.2274111              2.6244358             -1.5919829\n"
+          + "Ar              3.5057247              0.8140948              5.2533412\n"
+          + "Ar              3.1506760             -4.2582346             -3.4751765\n"
+          + "Ar              6.5005124             -0.1862658             -0.1324787";
+
+  private static final double ENERGYLJ38 = -0.0659856619926505;
+  private static final double ENERGYLJ55 = -0.10594240151944964;
+  private static final double NUMACC = 1.0e-8;
+
+  private final AdaptiveLJFF adapLJFF;
+
+  private final int[] atsPerMol38;
+  private final int[] atsPerMol55;
+
+  private final CartesianCoordinates lj38;
+  private final CartesianCoordinates lj55;
+
+  public AdaptiveLJFFTest() {
+
+    this.atsPerMol38 = new int[38];
+    for (int i = 0; i < 38; i++) {
+      atsPerMol38[i] = 1;
     }
+
+    this.atsPerMol55 = new int[55];
+    for (int i = 0; i < 55; i++) {
+      atsPerMol55[i] = 1;
+    }
+
+    CartesianCoordinates lj38 = null;
+    CartesianCoordinates lj55 = null;
+
+    try {
+      final String[] fileCont38 = LJ38MIN.split("\n");
+      lj38 =
+          org.ogolem.core.Input.parseCartesFromFileData(
+              fileCont38, 38, atsPerMol38, new short[38], new float[38]);
+
+      final String[] fileCont55 = LJ55MIN.split("\n");
+      lj55 =
+          org.ogolem.core.Input.parseCartesFromFileData(
+              fileCont55, 55, atsPerMol55, new short[55], new float[55]);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+
+    assert (lj38 != null);
+    assert (lj55 != null);
+
+    this.lj38 = lj38;
+    this.lj55 = lj55;
+
+    /*
+    parameters to constructor:
+        final boolean isInAdaptive, final boolean easyLBMix,
+        final int startPot, final int endPot, final int potIncr,
+        final AdaptiveParameters parameters, final boolean use3Body,
+        final double closeCutBlow, final double distCutBlow,
+        final boolean useCache, final boolean discard2Body
+    */
+
+    final AdaptiveLJFF dummy =
+        new AdaptiveLJFF(
+            true /* pretend to be in adaptive*/,
+            false,
+            6,
+            12,
+            6,
+            null /* only then can we set params to null */,
+            false,
+            1.2,
+            20.0,
+            false /* no cache, dummy */,
+            false);
+    final ArrayList<CartesianCoordinates> cartes = new ArrayList<>();
+    cartes.add(lj38);
+
+    final AdaptiveParameters params = dummy.createInitialParameterStub(cartes, dummy.getMethodID());
+
+    // now set the parameters to our regular LJ parameters for Ar
+    final double sigma = AtomicProperties.giveLennardJonesSigma("Ar");
+    final double epsilon = AtomicProperties.giveLennardJonesEpsilon("Ar");
+
+    final String[] keys = params.getAllKeysCopy();
+    assert (keys.length == 1); // there should only be one
+
+    final int noParams = params.getAmountOfParametersForKey(keys[0]);
+    assert (noParams == 3); // must be one epsilon and two sigma (same sigma)
+
+    final double[] paramVals = params.getAllParamters();
+    paramVals[0] = epsilon;
+    paramVals[1] = -sigma; // to make it 12-6
+    paramVals[2] = sigma;
+
+    adapLJFF =
+        new AdaptiveLJFF(
+            false /* pretend to be in core*/,
+            false,
+            6,
+            12,
+            6,
+            params /* real params */,
+            false,
+            1.2,
+            20.0,
+            false /* no cache, different LJ cluster sizes */,
+            false);
+  }
+
+  @Test
+  public void testEnergyCalculationAdapLJMins() {
+
+    final BondInfo bonds38 = new SimpleBondInfo(38);
+    final BondInfo bonds55 = new SimpleBondInfo(55);
+
+    final double e38 =
+        adapLJFF.energyCalculation(
+            -1,
+            0,
+            lj38.getAll1DCartes(),
+            lj38.getAllAtomTypes(),
+            lj38.getAllAtomNumbers(),
+            atsPerMol38,
+            new double[38],
+            lj38.getNoOfAtoms(),
+            lj38.getAllCharges(),
+            lj38.getAllSpins(),
+            bonds38,
+            false);
+
+    assertEquals(ENERGYLJ38, e38, NUMACC);
+
+    final double e55 =
+        adapLJFF.energyCalculation(
+            -1,
+            0,
+            lj55.getAll1DCartes(),
+            lj55.getAllAtomTypes(),
+            lj55.getAllAtomNumbers(),
+            atsPerMol55,
+            new double[55],
+            lj55.getNoOfAtoms(),
+            lj55.getAllCharges(),
+            lj55.getAllSpins(),
+            bonds55,
+            false);
+
+    assertEquals(ENERGYLJ55, e55, NUMACC);
+  }
+
+  @Test
+  public void testGradientCalculationAdapLJMins() {
+
+    final BondInfo bonds38 = new SimpleBondInfo(38);
+    final BondInfo bonds55 = new SimpleBondInfo(55);
+
+    final Gradient grad38 = new Gradient(3, 38);
+    adapLJFF.gradientCalculation(
+        -1,
+        0,
+        lj38.getAll1DCartes(),
+        lj38.getAllAtomTypes(),
+        lj38.getAllAtomNumbers(),
+        atsPerMol38,
+        new double[38],
+        lj38.getNoOfAtoms(),
+        lj38.getAllCharges(),
+        lj38.getAllSpins(),
+        bonds38,
+        grad38,
+        false);
+
+    assertEquals(ENERGYLJ38, grad38.getTotalEnergy(), NUMACC);
+
+    final double[][] gradient38 = grad38.getTotalGradient();
+
+    double gradTot38 = 0.0;
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 38; j++) gradTot38 += gradient38[i][j];
+    }
+
+    assertEquals(0.0, gradTot38, NUMACC);
+
+    final Gradient grad55 = new Gradient(3, 55);
+    adapLJFF.gradientCalculation(
+        -1,
+        0,
+        lj55.getAll1DCartes(),
+        lj55.getAllAtomTypes(),
+        lj55.getAllAtomNumbers(),
+        atsPerMol55,
+        new double[55],
+        lj55.getNoOfAtoms(),
+        lj55.getAllCharges(),
+        lj55.getAllSpins(),
+        bonds55,
+        grad55,
+        false);
+
+    assertEquals(ENERGYLJ55, grad55.getTotalEnergy(), NUMACC);
+
+    final double[][] gradient55 = grad55.getTotalGradient();
+
+    double gradTot55 = 0.0;
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 55; j++) gradTot55 += gradient55[i][j];
+    }
+
+    assertEquals(0.0, gradTot55, NUMACC);
+  }
 }

--- a/tests/org/ogolem/adaptive/AdaptiveSWG2BodyTermTest.java
+++ b/tests/org/ogolem/adaptive/AdaptiveSWG2BodyTermTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2016, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2016-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,290 +36,306 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.adaptive;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.ogolem.core.BondInfo;
-import org.ogolem.core.CartesianCoordinates;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.ogolem.core.Constants.ANGTOBOHR;
 import static org.ogolem.core.Constants.EVTOHARTREE;
+
+import org.junit.jupiter.api.Test;
+import org.ogolem.core.BondInfo;
+import org.ogolem.core.CartesianCoordinates;
 import org.ogolem.core.Gradient;
 import org.ogolem.core.SimpleBondInfo;
 import org.ogolem.core.Topology;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2016-02-25
+ * @version 2021-07-17
  */
 public class AdaptiveSWG2BodyTermTest {
-    
-    /**
-     * Test of partialInteraction method, of class AdaptiveSWG3BodyTerm.
-     */
-    @Test
-    public void testPartialInteraction1NC() {
-        
-        System.out.println("partialInteraction topo 1 no caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false,0.2);
-        final double expResult = 0.579173;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction1WC() {
-        
-        System.out.println("partialInteraction topo 1 with caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true,0.2);
-        final double expResult = 0.579173;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction2NC() {
-        
-        System.out.println("partialInteraction topo 2 no caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false,0.2);
-        final double expResult = 0.266691;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction2WC() {
-        
-        System.out.println("partialInteraction topo 2 with caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true,0.2);
-        final double expResult = 0.266691;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction3NC() {
-        
-        System.out.println("partialInteraction topo 3 no caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false,0.2);
-        final double expResult = 1.967588;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction3WC() {
-        
-        System.out.println("partialInteraction topo 3 with caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true,0.2);
-        final double expResult = 1.967588;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient1NC() {
-        
-        System.out.println("partialCartesianGradient topo 1 no caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false,0.2);
-        final double expResult = 0.579173;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-        
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-                
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient1WC() {
-        
-        System.out.println("partialCartesianGradient topo 1 with caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true,0.2);
-        final double expResult = 0.579173;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-                
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient2NC() {
-        
-        System.out.println("partialCartesianGradient topo 2 no caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false,0.2);
-        final double expResult = 0.266691;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-        
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient2WC() {
-        
-        System.out.println("partialCartesianGradient topo 2 with caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true,0.2);
-        final double expResult = 0.266691;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-                
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-                
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient3NC() {
-        
-        System.out.println("partialCartesianGradient topo 3 no caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false,0.2);
-        final double expResult = 1.967588;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-        
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient3WC() {
-        
-        System.out.println("partialCartesianGradient topo 3 with caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true,0.2);
-        final double expResult = 1.967588;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-                
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    private Topology setupTopo1(){
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(3,3,new int[]{1,1,1});
-        final String[] atoms = cartes.getAllAtomTypes();
-        atoms[0] = "Si";
-        atoms[1] = "Si";
-        atoms[2] = "Si";
-        cartes.recalcAtomNumbers();
-        
-        final double[][] xyz = cartes.getAllXYZCoord();
-        xyz[0][0] = 0.0; xyz[1][0] = 0.0; xyz[2][0] = 1.5*ANGTOBOHR;
-        xyz[0][1] = 0.0; xyz[1][1] = 0.0; xyz[2][1] = 0.0;
-        xyz[0][2] = 0.0; xyz[1][2] = 0.0; xyz[2][2] = -1.5*ANGTOBOHR;
-        
-        final BondInfo bonds = new SimpleBondInfo(3);
-        
-        final Topology topo = new Topology(cartes, bonds);
-        
-        return topo;
-    }
-    
-    private Topology setupTopo2(){
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(3,3,new int[]{1,1,1});
-        final String[] atoms = cartes.getAllAtomTypes();
-        atoms[0] = "Si";
-        atoms[1] = "Si";
-        atoms[2] = "Si";
-        cartes.recalcAtomNumbers();
-        
-        final double[][] xyz = cartes.getAllXYZCoord();
-        xyz[0][0] = 0.0; xyz[1][0] = 0.0; xyz[2][0] = 1.6*ANGTOBOHR;
-        xyz[0][1] = 0.0; xyz[1][1] = 0.0; xyz[2][1] = 0.0;
-        xyz[0][2] = 0.0; xyz[1][2] = 1.6*ANGTOBOHR; xyz[2][2] = 0.0;
-        
-        final BondInfo bonds = new SimpleBondInfo(3);
-        
-        final Topology topo = new Topology(cartes, bonds);
-        
-        return topo;
-    }
-    
-    private Topology setupTopo3(){
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(3,3,new int[]{1,1,1});
-        final String[] atoms = cartes.getAllAtomTypes();
-        atoms[0] = "Si";
-        atoms[1] = "Si";
-        atoms[2] = "Si";
-        cartes.recalcAtomNumbers();
-        
-        final double[][] xyz = cartes.getAllXYZCoord();
-        xyz[0][0] = 0.0; xyz[1][0] = 0.0; xyz[2][0] = 1.5*ANGTOBOHR;
-        xyz[0][1] = 0.0; xyz[1][1] = 0.0; xyz[2][1] = 0.0;
-        xyz[0][2] = 1.0*ANGTOBOHR; xyz[1][2] = 0.0; xyz[2][2] = 2.0*ANGTOBOHR;
-        
-        final BondInfo bonds = new SimpleBondInfo(3);
-        
-        final Topology topo = new Topology(cartes, bonds);
-        
-        return topo;
-    }
-    
-    private AdaptiveParameters setupParam1(){
-        
-        final int numberOfParameters = 4;
-        final int id = -1;
-        
-        final String[] keys = new String[1];
-        keys[0] = "adaptiveswg2b:SiSi";
-        
-        final int[] noOfParamsPerKey = new int[]{4};
-        
-        final String paramsForMethod = "ADAPTIVESWGTESTONLY";
-        
-        final AdaptiveParameters params = new AdaptiveParameters(numberOfParameters, id, keys,
-            noOfParamsPerKey, paramsForMethod);
-        
-        final double[] p = params.getAllParamters();
-        p[0] = 3.77*ANGTOBOHR;
-        p[1] = 16.3*EVTOHARTREE;
-        p[2] = 11.581*ANGTOBOHR*ANGTOBOHR*ANGTOBOHR*ANGTOBOHR;
-        p[3] = 2.095*ANGTOBOHR;
-        
-        return params;
-    }
+
+  /** Test of partialInteraction method, of class AdaptiveSWG3BodyTerm. */
+  @Test
+  public void testPartialInteraction1NC() {
+
+    System.out.println("partialInteraction topo 1 no caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false, 0.2);
+    final double expResult = 0.579173;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction1WC() {
+
+    System.out.println("partialInteraction topo 1 with caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true, 0.2);
+    final double expResult = 0.579173;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction2NC() {
+
+    System.out.println("partialInteraction topo 2 no caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false, 0.2);
+    final double expResult = 0.266691;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction2WC() {
+
+    System.out.println("partialInteraction topo 2 with caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true, 0.2);
+    final double expResult = 0.266691;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction3NC() {
+
+    System.out.println("partialInteraction topo 3 no caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false, 0.2);
+    final double expResult = 1.967588;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction3WC() {
+
+    System.out.println("partialInteraction topo 3 with caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true, 0.2);
+    final double expResult = 1.967588;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialCartesianGradient1NC() {
+
+    System.out.println("partialCartesianGradient topo 1 no caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false, 0.2);
+    final double expResult = 0.579173;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient1WC() {
+
+    System.out.println("partialCartesianGradient topo 1 with caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true, 0.2);
+    final double expResult = 0.579173;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient2NC() {
+
+    System.out.println("partialCartesianGradient topo 2 no caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false, 0.2);
+    final double expResult = 0.266691;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient2WC() {
+
+    System.out.println("partialCartesianGradient topo 2 with caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true, 0.2);
+    final double expResult = 0.266691;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient3NC() {
+
+    System.out.println("partialCartesianGradient topo 3 no caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(false, 0.2);
+    final double expResult = 1.967588;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient3WC() {
+
+    System.out.println("partialCartesianGradient topo 3 with caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG2BodyTerm instance = new AdaptiveSWG2BodyTerm(true, 0.2);
+    final double expResult = 1.967588;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  private Topology setupTopo1() {
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(3, 3, new int[] {1, 1, 1});
+    final String[] atoms = cartes.getAllAtomTypes();
+    atoms[0] = "Si";
+    atoms[1] = "Si";
+    atoms[2] = "Si";
+    cartes.recalcAtomNumbers();
+
+    final double[][] xyz = cartes.getAllXYZCoord();
+    xyz[0][0] = 0.0;
+    xyz[1][0] = 0.0;
+    xyz[2][0] = 1.5 * ANGTOBOHR;
+    xyz[0][1] = 0.0;
+    xyz[1][1] = 0.0;
+    xyz[2][1] = 0.0;
+    xyz[0][2] = 0.0;
+    xyz[1][2] = 0.0;
+    xyz[2][2] = -1.5 * ANGTOBOHR;
+
+    final BondInfo bonds = new SimpleBondInfo(3);
+
+    final Topology topo = new Topology(cartes, bonds);
+
+    return topo;
+  }
+
+  private Topology setupTopo2() {
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(3, 3, new int[] {1, 1, 1});
+    final String[] atoms = cartes.getAllAtomTypes();
+    atoms[0] = "Si";
+    atoms[1] = "Si";
+    atoms[2] = "Si";
+    cartes.recalcAtomNumbers();
+
+    final double[][] xyz = cartes.getAllXYZCoord();
+    xyz[0][0] = 0.0;
+    xyz[1][0] = 0.0;
+    xyz[2][0] = 1.6 * ANGTOBOHR;
+    xyz[0][1] = 0.0;
+    xyz[1][1] = 0.0;
+    xyz[2][1] = 0.0;
+    xyz[0][2] = 0.0;
+    xyz[1][2] = 1.6 * ANGTOBOHR;
+    xyz[2][2] = 0.0;
+
+    final BondInfo bonds = new SimpleBondInfo(3);
+
+    final Topology topo = new Topology(cartes, bonds);
+
+    return topo;
+  }
+
+  private Topology setupTopo3() {
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(3, 3, new int[] {1, 1, 1});
+    final String[] atoms = cartes.getAllAtomTypes();
+    atoms[0] = "Si";
+    atoms[1] = "Si";
+    atoms[2] = "Si";
+    cartes.recalcAtomNumbers();
+
+    final double[][] xyz = cartes.getAllXYZCoord();
+    xyz[0][0] = 0.0;
+    xyz[1][0] = 0.0;
+    xyz[2][0] = 1.5 * ANGTOBOHR;
+    xyz[0][1] = 0.0;
+    xyz[1][1] = 0.0;
+    xyz[2][1] = 0.0;
+    xyz[0][2] = 1.0 * ANGTOBOHR;
+    xyz[1][2] = 0.0;
+    xyz[2][2] = 2.0 * ANGTOBOHR;
+
+    final BondInfo bonds = new SimpleBondInfo(3);
+
+    final Topology topo = new Topology(cartes, bonds);
+
+    return topo;
+  }
+
+  private AdaptiveParameters setupParam1() {
+
+    final int numberOfParameters = 4;
+    final int id = -1;
+
+    final String[] keys = new String[1];
+    keys[0] = "adaptiveswg2b:SiSi";
+
+    final int[] noOfParamsPerKey = new int[] {4};
+
+    final String paramsForMethod = "ADAPTIVESWGTESTONLY";
+
+    final AdaptiveParameters params =
+        new AdaptiveParameters(numberOfParameters, id, keys, noOfParamsPerKey, paramsForMethod);
+
+    final double[] p = params.getAllParamters();
+    p[0] = 3.77 * ANGTOBOHR;
+    p[1] = 16.3 * EVTOHARTREE;
+    p[2] = 11.581 * ANGTOBOHR * ANGTOBOHR * ANGTOBOHR * ANGTOBOHR;
+    p[3] = 2.095 * ANGTOBOHR;
+
+    return params;
+  }
 }

--- a/tests/org/ogolem/adaptive/AdaptiveSWG3BodyTermTest.java
+++ b/tests/org/ogolem/adaptive/AdaptiveSWG3BodyTermTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2016, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2016-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,292 +36,308 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.adaptive;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.ogolem.core.BondInfo;
-import org.ogolem.core.CartesianCoordinates;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.ogolem.core.Constants.ANGTOBOHR;
 import static org.ogolem.core.Constants.EVTOHARTREE;
+
+import org.junit.jupiter.api.Test;
+import org.ogolem.core.BondInfo;
+import org.ogolem.core.CartesianCoordinates;
 import org.ogolem.core.Gradient;
 import org.ogolem.core.SimpleBondInfo;
 import org.ogolem.core.Topology;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2016-02-24
+ * @version 2021-07-17
  */
 public class AdaptiveSWG3BodyTermTest {
-    
-    /**
-     * Test of partialInteraction method, of class AdaptiveSWG3BodyTerm.
-     */
-    @Test
-    public void testPartialInteraction1NC() {
-        
-        System.out.println("partialInteraction topo 1 no caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
-        final double expResult = 0.0221406;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction1WC() {
-        
-        System.out.println("partialInteraction topo 1 with caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
-        final double expResult = 0.0221406;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction2NC() {
-        
-        System.out.println("partialInteraction topo 2 no caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
-        final double expResult = 0.00484799;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction2WC() {
-        
-        System.out.println("partialInteraction topo 2 with caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
-        final double expResult = 0.00484799;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction3NC() {
-        
-        System.out.println("partialInteraction topo 3 no caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
-        final double expResult = 0.00903518;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialInteraction3WC() {
-        
-        System.out.println("partialInteraction topo 3 with caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
-        final double expResult = 0.00903518;
-        final double result = instance.partialInteraction(topology, params);
-        assertEquals(expResult, result, 1e-6);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient1NC() {
-        
-        System.out.println("partialCartesianGradient topo 1 no caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
-        final double expResult = 0.0221406;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-        
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient1WC() {
-        
-        System.out.println("partialCartesianGradient topo 1 with caching");
-        final Topology topology = setupTopo1();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
-        final double expResult = 0.0221406;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-                
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient2NC() {
-        
-        System.out.println("partialCartesianGradient topo 2 no caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
-        final double expResult = 0.00484799;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-        
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient2WC() {
-        
-        System.out.println("partialCartesianGradient topo 2 with caching");
-        final Topology topology = setupTopo2();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
-        final double expResult = 0.00484799;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-                
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient3NC() {
-        
-        System.out.println("partialCartesianGradient topo 3 no caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
-        final double expResult = 0.00903518;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-        
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testPartialCartesianGradient3WC() {
-        
-        System.out.println("partialCartesianGradient topo 3 with caching");
-        final Topology topology = setupTopo3();
-        final AdaptiveParameters params = setupParam1();
-        final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
-        final double expResult = 0.00903518;
-        final Gradient g = instance.partialCartesianGradient(topology, params);
-        final double result = g.getTotalEnergy();
-        assertEquals(expResult, result, 1e-6);
-                
-        final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
-        
-        final boolean same = g.compare(numGrad, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    private Topology setupTopo1(){
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(3,3,new int[]{1,1,1});
-        final String[] atoms = cartes.getAllAtomTypes();
-        atoms[0] = "Si";
-        atoms[1] = "Si";
-        atoms[2] = "Si";
-        cartes.recalcAtomNumbers();
-        
-        final double[][] xyz = cartes.getAllXYZCoord();
-        xyz[0][0] = 0.0; xyz[1][0] = 0.0; xyz[2][0] = 1.5*ANGTOBOHR;
-        xyz[0][1] = 0.0; xyz[1][1] = 0.0; xyz[2][1] = 0.0;
-        xyz[0][2] = 0.0; xyz[1][2] = 0.0; xyz[2][2] = -1.5*ANGTOBOHR;
-        
-        final BondInfo bonds = new SimpleBondInfo(3);
-        
-        final Topology topo = new Topology(cartes, bonds);
-        
-        return topo;
-    }
-    
-    private Topology setupTopo2(){
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(3,3,new int[]{1,1,1});
-        final String[] atoms = cartes.getAllAtomTypes();
-        atoms[0] = "Si";
-        atoms[1] = "Si";
-        atoms[2] = "Si";
-        cartes.recalcAtomNumbers();
-        
-        final double[][] xyz = cartes.getAllXYZCoord();
-        xyz[0][0] = 0.0; xyz[1][0] = 0.0; xyz[2][0] = 1.6*ANGTOBOHR;
-        xyz[0][1] = 0.0; xyz[1][1] = 0.0; xyz[2][1] = 0.0;
-        xyz[0][2] = 0.0; xyz[1][2] = 1.6*ANGTOBOHR; xyz[2][2] = 0.0;
-        
-        final BondInfo bonds = new SimpleBondInfo(3);
-        
-        final Topology topo = new Topology(cartes, bonds);
-        
-        return topo;
-    }
-    
-    private Topology setupTopo3(){
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(3,3,new int[]{1,1,1});
-        final String[] atoms = cartes.getAllAtomTypes();
-        atoms[0] = "Si";
-        atoms[1] = "Si";
-        atoms[2] = "Si";
-        cartes.recalcAtomNumbers();
-        
-        final double[][] xyz = cartes.getAllXYZCoord();
-        xyz[0][0] = 0.0; xyz[1][0] = 0.0; xyz[2][0] = 1.5*ANGTOBOHR;
-        xyz[0][1] = 0.0; xyz[1][1] = 0.0; xyz[2][1] = 0.0;
-        xyz[0][2] = 1.0*ANGTOBOHR; xyz[1][2] = 0.0; xyz[2][2] = 2.0*ANGTOBOHR;
-        
-        final BondInfo bonds = new SimpleBondInfo(3);
-        
-        final Topology topo = new Topology(cartes, bonds);
-        
-        return topo;
-    }
-    
-    private AdaptiveParameters setupParam1(){
-        
-        final int numberOfParameters = 5;
-        final int id = -1;
-        
-        final String[] keys = new String[2];
-        keys[0] = "adaptiveswg3b2b:SiSi";
-        keys[1] = "adaptiveswg3b:SiSiSi";
-        
-        final int[] noOfParamsPerKey = new int[]{2,3};
-        
-        final String paramsForMethod = "ADAPTIVESWGTESTONLY";
-        
-        final AdaptiveParameters params = new AdaptiveParameters(numberOfParameters, id, keys,
-            noOfParamsPerKey, paramsForMethod);
-        
-        final double[] p = params.getAllParamters();
-        p[0] = 3.77*ANGTOBOHR;
-        p[1] = 2.4*ANGTOBOHR;
-        p[2] = -0.5;
-        p[3] = 0.15;
-        p[4] = 4.0*EVTOHARTREE;
-        
-        return params;
-    }
+
+  /** Test of partialInteraction method, of class AdaptiveSWG3BodyTerm. */
+  @Test
+  public void testPartialInteraction1NC() {
+
+    System.out.println("partialInteraction topo 1 no caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
+    final double expResult = 0.0221406;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction1WC() {
+
+    System.out.println("partialInteraction topo 1 with caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
+    final double expResult = 0.0221406;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction2NC() {
+
+    System.out.println("partialInteraction topo 2 no caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
+    final double expResult = 0.00484799;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction2WC() {
+
+    System.out.println("partialInteraction topo 2 with caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
+    final double expResult = 0.00484799;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction3NC() {
+
+    System.out.println("partialInteraction topo 3 no caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
+    final double expResult = 0.00903518;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialInteraction3WC() {
+
+    System.out.println("partialInteraction topo 3 with caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
+    final double expResult = 0.00903518;
+    final double result = instance.partialInteraction(topology, params);
+    assertEquals(expResult, result, 1e-6);
+  }
+
+  @Test
+  public void testPartialCartesianGradient1NC() {
+
+    System.out.println("partialCartesianGradient topo 1 no caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
+    final double expResult = 0.0221406;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient1WC() {
+
+    System.out.println("partialCartesianGradient topo 1 with caching");
+    final Topology topology = setupTopo1();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
+    final double expResult = 0.0221406;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient2NC() {
+
+    System.out.println("partialCartesianGradient topo 2 no caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
+    final double expResult = 0.00484799;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient2WC() {
+
+    System.out.println("partialCartesianGradient topo 2 with caching");
+    final Topology topology = setupTopo2();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
+    final double expResult = 0.00484799;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient3NC() {
+
+    System.out.println("partialCartesianGradient topo 3 no caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(false);
+    final double expResult = 0.00903518;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testPartialCartesianGradient3WC() {
+
+    System.out.println("partialCartesianGradient topo 3 with caching");
+    final Topology topology = setupTopo3();
+    final AdaptiveParameters params = setupParam1();
+    final AdaptiveSWG3BodyTerm instance = new AdaptiveSWG3BodyTerm(true);
+    final double expResult = 0.00903518;
+    final Gradient g = instance.partialCartesianGradient(topology, params);
+    final double result = g.getTotalEnergy();
+    assertEquals(expResult, result, 1e-6);
+
+    final Gradient numGrad = NumericalGradients.calculateGrad(params, instance, topology);
+
+    final boolean same = g.compare(numGrad, 1e-6, true);
+    assertTrue(same);
+  }
+
+  private Topology setupTopo1() {
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(3, 3, new int[] {1, 1, 1});
+    final String[] atoms = cartes.getAllAtomTypes();
+    atoms[0] = "Si";
+    atoms[1] = "Si";
+    atoms[2] = "Si";
+    cartes.recalcAtomNumbers();
+
+    final double[][] xyz = cartes.getAllXYZCoord();
+    xyz[0][0] = 0.0;
+    xyz[1][0] = 0.0;
+    xyz[2][0] = 1.5 * ANGTOBOHR;
+    xyz[0][1] = 0.0;
+    xyz[1][1] = 0.0;
+    xyz[2][1] = 0.0;
+    xyz[0][2] = 0.0;
+    xyz[1][2] = 0.0;
+    xyz[2][2] = -1.5 * ANGTOBOHR;
+
+    final BondInfo bonds = new SimpleBondInfo(3);
+
+    final Topology topo = new Topology(cartes, bonds);
+
+    return topo;
+  }
+
+  private Topology setupTopo2() {
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(3, 3, new int[] {1, 1, 1});
+    final String[] atoms = cartes.getAllAtomTypes();
+    atoms[0] = "Si";
+    atoms[1] = "Si";
+    atoms[2] = "Si";
+    cartes.recalcAtomNumbers();
+
+    final double[][] xyz = cartes.getAllXYZCoord();
+    xyz[0][0] = 0.0;
+    xyz[1][0] = 0.0;
+    xyz[2][0] = 1.6 * ANGTOBOHR;
+    xyz[0][1] = 0.0;
+    xyz[1][1] = 0.0;
+    xyz[2][1] = 0.0;
+    xyz[0][2] = 0.0;
+    xyz[1][2] = 1.6 * ANGTOBOHR;
+    xyz[2][2] = 0.0;
+
+    final BondInfo bonds = new SimpleBondInfo(3);
+
+    final Topology topo = new Topology(cartes, bonds);
+
+    return topo;
+  }
+
+  private Topology setupTopo3() {
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(3, 3, new int[] {1, 1, 1});
+    final String[] atoms = cartes.getAllAtomTypes();
+    atoms[0] = "Si";
+    atoms[1] = "Si";
+    atoms[2] = "Si";
+    cartes.recalcAtomNumbers();
+
+    final double[][] xyz = cartes.getAllXYZCoord();
+    xyz[0][0] = 0.0;
+    xyz[1][0] = 0.0;
+    xyz[2][0] = 1.5 * ANGTOBOHR;
+    xyz[0][1] = 0.0;
+    xyz[1][1] = 0.0;
+    xyz[2][1] = 0.0;
+    xyz[0][2] = 1.0 * ANGTOBOHR;
+    xyz[1][2] = 0.0;
+    xyz[2][2] = 2.0 * ANGTOBOHR;
+
+    final BondInfo bonds = new SimpleBondInfo(3);
+
+    final Topology topo = new Topology(cartes, bonds);
+
+    return topo;
+  }
+
+  private AdaptiveParameters setupParam1() {
+
+    final int numberOfParameters = 5;
+    final int id = -1;
+
+    final String[] keys = new String[2];
+    keys[0] = "adaptiveswg3b2b:SiSi";
+    keys[1] = "adaptiveswg3b:SiSiSi";
+
+    final int[] noOfParamsPerKey = new int[] {2, 3};
+
+    final String paramsForMethod = "ADAPTIVESWGTESTONLY";
+
+    final AdaptiveParameters params =
+        new AdaptiveParameters(numberOfParameters, id, keys, noOfParamsPerKey, paramsForMethod);
+
+    final double[] p = params.getAllParamters();
+    p[0] = 3.77 * ANGTOBOHR;
+    p[1] = 2.4 * ANGTOBOHR;
+    p[2] = -0.5;
+    p[3] = 0.15;
+    p[4] = 4.0 * EVTOHARTREE;
+
+    return params;
+  }
 }

--- a/tests/org/ogolem/adaptive/AdaptiveSWGFFTest.java
+++ b/tests/org/ogolem/adaptive/AdaptiveSWGFFTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2016-2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2016-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,206 +36,284 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.adaptive;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.ogolem.core.BondInfo;
-import org.ogolem.core.CartesianCoordinates;
-import org.ogolem.core.CollisionDetection;
-import org.ogolem.core.DissociationDetection;
-import org.ogolem.core.Geometry;
-
+import static org.junit.jupiter.api.Assertions.*;
 import static org.ogolem.core.Constants.ANGTOBOHR;
 import static org.ogolem.core.Constants.EVTOHARTREE;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import org.junit.jupiter.api.Test;
+import org.ogolem.core.BondInfo;
+import org.ogolem.core.CartesianCoordinates;
+import org.ogolem.core.CollisionDetection;
+import org.ogolem.core.DissociationDetection;
+import org.ogolem.core.Geometry;
 import org.ogolem.core.Gradient;
 import org.ogolem.core.NorwayGeometryMutation;
 import org.ogolem.core.SimpleBondInfo;
-import org.ogolem.core.Topology;
 import org.ogolem.random.Lottery;
 import org.ogolem.random.StandardRNG;
 
 /**
-*
-* @author Johannes Dieterich
-* @version 2020-08-09
-*/
+ * @author Johannes Dieterich
+ * @version 2021-07-17
+ */
 public class AdaptiveSWGFFTest {
 
-    @Test
-    public void testCartesianGradient() {
-        
-        System.out.println("CartesianGradient Si6 with caching");
-        final AdaptiveParameters params = setupParam();
-        final AdaptiveSWGFF instance = new AdaptiveSWGFF(false, params, true, 1.4);
-        
-        // assemble a random set of 6 silicon atoms
-        final int noAtoms = 6;
-        final BondInfo bonds = new SimpleBondInfo(noAtoms);
-        final int[] atsPerMol = new int[noAtoms];
-        final boolean[] molFlexies = new boolean[noAtoms];
-        final List<boolean[][]> allFlexies = new ArrayList<>();
-        final boolean[] molConstraints = new boolean[noAtoms];
-        final boolean[][] constrXYZ = new boolean[3][noAtoms];
-        final String[] sids = new String[noAtoms];
-        
-        for(int i = 0; i < noAtoms; i++){
-            atsPerMol[i] = 1;
-            molFlexies[i] = false;
-            molConstraints[i] = false;
-            sids[i] = "Si";
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-            allFlexies.add(null);
-        }
-        
-        CartesianCoordinates cartes = new CartesianCoordinates(noAtoms, noAtoms, atsPerMol);
-        final String[] atoms = cartes.getAllAtomTypes();
-        
-        for(int i = 0; i < noAtoms; i++){
-            atoms[i] = "Si";
-        }
-        
-        cartes.recalcAtomNumbersForced();
+  @Test
+  public void testCartesianGradient() {
 
-        Lottery.setGenerator(new StandardRNG(142));
-        final NorwayGeometryMutation norway = new NorwayGeometryMutation(NorwayGeometryMutation.PACKDIM.THREED, CollisionDetection.CDTYPE.SIMPLEPAIRWISE, 1.4, 4.0,
-                DissociationDetection.DEFAULTDD, NorwayGeometryMutation.MUTMODE.ASCENDING);
-        
-        final Geometry geom = new Geometry(cartes, 0, noAtoms, atsPerMol, molFlexies, allFlexies, molConstraints,
-                constrXYZ, sids, bonds);
-        final Geometry packed = norway.mutate(geom);
-        
-        cartes = packed.getCartesians();
-        
-        final double[] energyparts = new double[noAtoms];
-        final Gradient g = new Gradient(3, noAtoms);
-        instance.gradientCalculation(0, 0, cartes.getAll1DCartes(), atoms, cartes.getAllAtomNumbers(),
-        		atsPerMol, energyparts, noAtoms, cartes.getAllCharges(), cartes.getAllSpins(), bonds, g, false);
-        
-        final Gradient numG = NumericalGradients.numericalGradient(0, 0, cartes.getAll1DCartes(), atoms, cartes.getAllAtomNumbers(),
-        		atsPerMol, energyparts, noAtoms, cartes.getAllCharges(), cartes.getAllSpins(), bonds, instance, false);
-        
-        System.out.println("E reference " + g.getTotalEnergy());
-        System.out.println("E numerical " + numG.getTotalEnergy());
-        
-        assertEquals(g.getTotalEnergy(), numG.getTotalEnergy(), 1e-8);
-        
-        final double[] grad1D = g.getGradient();
-        for(int i = 0; i < grad1D.length; i++) {
-        	System.out.println("Analytical flattened gradient element " + i + " " + grad1D[i]);
-        }
-        
-        final boolean same = g.compare(numG, 1e-6, true);
-        assertTrue(same);
-    }
-    
-    @Test
-    public void testCartesianGradient42() {
-        
-        System.out.println("CartesianGradient Si42 with caching");
-        final AdaptiveParameters params = setupParam();
-        final AdaptiveSWGFF instance = new AdaptiveSWGFF(false, params, true, 1.4);
-        
-        // assemble a random set of 42 silicon atoms
-        final int noAtoms = 42;
-        final BondInfo bonds = new SimpleBondInfo(noAtoms);
-        final int[] atsPerMol = new int[noAtoms];
-        final boolean[] molFlexies = new boolean[noAtoms];
-        final List<boolean[][]> allFlexies = new ArrayList<>();
-        final boolean[] molConstraints = new boolean[noAtoms];
-        final boolean[][] constrXYZ = new boolean[3][noAtoms];
-        final String[] sids = new String[noAtoms];
-        
-        for(int i = 0; i < noAtoms; i++){
-            atsPerMol[i] = 1;
-            molFlexies[i] = false;
-            molConstraints[i] = false;
-            sids[i] = "Si";
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-            allFlexies.add(null);
-        }
-        
-        CartesianCoordinates cartes = new CartesianCoordinates(noAtoms, noAtoms, atsPerMol);
-        final String[] atoms = cartes.getAllAtomTypes();
-        
-        for(int i = 0; i < noAtoms; i++){
-            atoms[i] = "Si";
-        }
-        
-        cartes.recalcAtomNumbersForced();
+    System.out.println("CartesianGradient Si6 with caching");
+    final AdaptiveParameters params = setupParam();
+    final AdaptiveSWGFF instance = new AdaptiveSWGFF(false, params, true, 1.4);
 
-        Lottery.setGenerator(new StandardRNG(141));
-        final NorwayGeometryMutation norway = new NorwayGeometryMutation(NorwayGeometryMutation.PACKDIM.THREED, CollisionDetection.CDTYPE.SIMPLEPAIRWISE, 1.4, 4.0,
-                DissociationDetection.DEFAULTDD, NorwayGeometryMutation.MUTMODE.ASCENDING);
-        
-        final Geometry geom = new Geometry(cartes, 0, noAtoms, atsPerMol, molFlexies, allFlexies, molConstraints,
-                constrXYZ, sids, bonds);
-        final Geometry packed = norway.mutate(geom);
-        
-        cartes = packed.getCartesians();
-        
-        final double[] energyparts = new double[noAtoms];
-        final Gradient g = new Gradient(3, noAtoms);
-        instance.gradientCalculation(0, 0, cartes.getAll1DCartes(), atoms, cartes.getAllAtomNumbers(),
-        		atsPerMol, energyparts, noAtoms, cartes.getAllCharges(), cartes.getAllSpins(), bonds, g, false);
-        
-        final Gradient numG = NumericalGradients.numericalGradient(0, 0, cartes.getAll1DCartes(), atoms, cartes.getAllAtomNumbers(),
-        		atsPerMol, energyparts, noAtoms, cartes.getAllCharges(), cartes.getAllSpins(), bonds, instance, false);
-        
-        System.out.println("E reference " + g.getTotalEnergy());
-        System.out.println("E numerical " + numG.getTotalEnergy());
-        
-        assertEquals(g.getTotalEnergy(), numG.getTotalEnergy(), 1e-8);
-        
-        final double[] grad1D = g.getGradient();
-        for(int i = 0; i < grad1D.length; i++) {
-        	System.out.println("Analytical flattened gradient element " + i + " " + grad1D[i]);
-        }
-        
-        final boolean same = g.compare(numG, 1e-6, true);
-        assertTrue(same);
+    // assemble a random set of 6 silicon atoms
+    final int noAtoms = 6;
+    final BondInfo bonds = new SimpleBondInfo(noAtoms);
+    final int[] atsPerMol = new int[noAtoms];
+    final boolean[] molFlexies = new boolean[noAtoms];
+    final List<boolean[][]> allFlexies = new ArrayList<>();
+    final boolean[] molConstraints = new boolean[noAtoms];
+    final boolean[][] constrXYZ = new boolean[3][noAtoms];
+    final String[] sids = new String[noAtoms];
+
+    for (int i = 0; i < noAtoms; i++) {
+      atsPerMol[i] = 1;
+      molFlexies[i] = false;
+      molConstraints[i] = false;
+      sids[i] = "Si";
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+      allFlexies.add(null);
     }
-	
-    private AdaptiveParameters setupParam(){
-        
-        final int numberOfParameters = 9;
-        final int id = -1;
-        
-        final String[] keys = new String[3];
-        keys[0] = "adaptiveswg3b2b:SiSi";
-        keys[1] = "adaptiveswg3b:SiSiSi";
-        keys[2] = "adaptiveswg2b:SiSi";
-        
-        final int[] noOfParamsPerKey = new int[]{2,3,4};
-        
-        final String paramsForMethod = "ADAPTIVESWGTESTONLY";
-        
-        final AdaptiveParameters params = new AdaptiveParameters(numberOfParameters, id, keys,
-            noOfParamsPerKey, paramsForMethod);
-        
-        final int offset1 = params.getStartPointForKey(keys[0]);
-        final double[] p = params.getAllParamters();
-        
-        p[offset1] = 3.77*ANGTOBOHR;
-        p[offset1+1] = 2.4*ANGTOBOHR;
-        
-        final int offset2 = params.getStartPointForKey(keys[1]);
-        p[offset2] = -0.5;
-        p[offset2+1] = 0.15;
-        p[offset2+2] = 4.0*EVTOHARTREE;
-        
-        final int offset3 = params.getStartPointForKey(keys[2]);
-        p[offset3] = 3.77*ANGTOBOHR;
-        p[offset3+1] = 16.3*EVTOHARTREE;
-        p[offset3+2] = 11.581*ANGTOBOHR*ANGTOBOHR*ANGTOBOHR*ANGTOBOHR;
-        p[offset3+3] = 2.095*ANGTOBOHR;
-        
-        return params;
+
+    CartesianCoordinates cartes = new CartesianCoordinates(noAtoms, noAtoms, atsPerMol);
+    final String[] atoms = cartes.getAllAtomTypes();
+
+    for (int i = 0; i < noAtoms; i++) {
+      atoms[i] = "Si";
     }
+
+    cartes.recalcAtomNumbersForced();
+
+    Lottery.setGenerator(new StandardRNG(142));
+    final NorwayGeometryMutation norway =
+        new NorwayGeometryMutation(
+            NorwayGeometryMutation.PACKDIM.THREED,
+            CollisionDetection.CDTYPE.SIMPLEPAIRWISE,
+            1.4,
+            4.0,
+            DissociationDetection.DEFAULTDD,
+            NorwayGeometryMutation.MUTMODE.ASCENDING);
+
+    final Geometry geom =
+        new Geometry(
+            cartes,
+            0,
+            noAtoms,
+            atsPerMol,
+            molFlexies,
+            allFlexies,
+            molConstraints,
+            constrXYZ,
+            sids,
+            bonds);
+    final Geometry packed = norway.mutate(geom);
+
+    cartes = packed.getCartesians();
+
+    final double[] energyparts = new double[noAtoms];
+    final Gradient g = new Gradient(3, noAtoms);
+    instance.gradientCalculation(
+        0,
+        0,
+        cartes.getAll1DCartes(),
+        atoms,
+        cartes.getAllAtomNumbers(),
+        atsPerMol,
+        energyparts,
+        noAtoms,
+        cartes.getAllCharges(),
+        cartes.getAllSpins(),
+        bonds,
+        g,
+        false);
+
+    final Gradient numG =
+        NumericalGradients.numericalGradient(
+            0,
+            0,
+            cartes.getAll1DCartes(),
+            atoms,
+            cartes.getAllAtomNumbers(),
+            atsPerMol,
+            energyparts,
+            noAtoms,
+            cartes.getAllCharges(),
+            cartes.getAllSpins(),
+            bonds,
+            instance,
+            false);
+
+    System.out.println("E reference " + g.getTotalEnergy());
+    System.out.println("E numerical " + numG.getTotalEnergy());
+
+    assertEquals(g.getTotalEnergy(), numG.getTotalEnergy(), 1e-8);
+
+    final double[] grad1D = g.getGradient();
+    for (int i = 0; i < grad1D.length; i++) {
+      System.out.println("Analytical flattened gradient element " + i + " " + grad1D[i]);
+    }
+
+    final boolean same = g.compare(numG, 1e-6, true);
+    assertTrue(same);
+  }
+
+  @Test
+  public void testCartesianGradient42() {
+
+    System.out.println("CartesianGradient Si42 with caching");
+    final AdaptiveParameters params = setupParam();
+    final AdaptiveSWGFF instance = new AdaptiveSWGFF(false, params, true, 1.4);
+
+    // assemble a random set of 42 silicon atoms
+    final int noAtoms = 42;
+    final BondInfo bonds = new SimpleBondInfo(noAtoms);
+    final int[] atsPerMol = new int[noAtoms];
+    final boolean[] molFlexies = new boolean[noAtoms];
+    final List<boolean[][]> allFlexies = new ArrayList<>();
+    final boolean[] molConstraints = new boolean[noAtoms];
+    final boolean[][] constrXYZ = new boolean[3][noAtoms];
+    final String[] sids = new String[noAtoms];
+
+    for (int i = 0; i < noAtoms; i++) {
+      atsPerMol[i] = 1;
+      molFlexies[i] = false;
+      molConstraints[i] = false;
+      sids[i] = "Si";
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+      allFlexies.add(null);
+    }
+
+    CartesianCoordinates cartes = new CartesianCoordinates(noAtoms, noAtoms, atsPerMol);
+    final String[] atoms = cartes.getAllAtomTypes();
+
+    for (int i = 0; i < noAtoms; i++) {
+      atoms[i] = "Si";
+    }
+
+    cartes.recalcAtomNumbersForced();
+
+    Lottery.setGenerator(new StandardRNG(141));
+    final NorwayGeometryMutation norway =
+        new NorwayGeometryMutation(
+            NorwayGeometryMutation.PACKDIM.THREED,
+            CollisionDetection.CDTYPE.SIMPLEPAIRWISE,
+            1.4,
+            4.0,
+            DissociationDetection.DEFAULTDD,
+            NorwayGeometryMutation.MUTMODE.ASCENDING);
+
+    final Geometry geom =
+        new Geometry(
+            cartes,
+            0,
+            noAtoms,
+            atsPerMol,
+            molFlexies,
+            allFlexies,
+            molConstraints,
+            constrXYZ,
+            sids,
+            bonds);
+    final Geometry packed = norway.mutate(geom);
+
+    cartes = packed.getCartesians();
+
+    final double[] energyparts = new double[noAtoms];
+    final Gradient g = new Gradient(3, noAtoms);
+    instance.gradientCalculation(
+        0,
+        0,
+        cartes.getAll1DCartes(),
+        atoms,
+        cartes.getAllAtomNumbers(),
+        atsPerMol,
+        energyparts,
+        noAtoms,
+        cartes.getAllCharges(),
+        cartes.getAllSpins(),
+        bonds,
+        g,
+        false);
+
+    final Gradient numG =
+        NumericalGradients.numericalGradient(
+            0,
+            0,
+            cartes.getAll1DCartes(),
+            atoms,
+            cartes.getAllAtomNumbers(),
+            atsPerMol,
+            energyparts,
+            noAtoms,
+            cartes.getAllCharges(),
+            cartes.getAllSpins(),
+            bonds,
+            instance,
+            false);
+
+    System.out.println("E reference " + g.getTotalEnergy());
+    System.out.println("E numerical " + numG.getTotalEnergy());
+
+    assertEquals(g.getTotalEnergy(), numG.getTotalEnergy(), 1e-8);
+
+    final double[] grad1D = g.getGradient();
+    for (int i = 0; i < grad1D.length; i++) {
+      System.out.println("Analytical flattened gradient element " + i + " " + grad1D[i]);
+    }
+
+    final boolean same = g.compare(numG, 1e-6, true);
+    assertTrue(same);
+  }
+
+  private AdaptiveParameters setupParam() {
+
+    final int numberOfParameters = 9;
+    final int id = -1;
+
+    final String[] keys = new String[3];
+    keys[0] = "adaptiveswg3b2b:SiSi";
+    keys[1] = "adaptiveswg3b:SiSiSi";
+    keys[2] = "adaptiveswg2b:SiSi";
+
+    final int[] noOfParamsPerKey = new int[] {2, 3, 4};
+
+    final String paramsForMethod = "ADAPTIVESWGTESTONLY";
+
+    final AdaptiveParameters params =
+        new AdaptiveParameters(numberOfParameters, id, keys, noOfParamsPerKey, paramsForMethod);
+
+    final int offset1 = params.getStartPointForKey(keys[0]);
+    final double[] p = params.getAllParamters();
+
+    p[offset1] = 3.77 * ANGTOBOHR;
+    p[offset1 + 1] = 2.4 * ANGTOBOHR;
+
+    final int offset2 = params.getStartPointForKey(keys[1]);
+    p[offset2] = -0.5;
+    p[offset2 + 1] = 0.15;
+    p[offset2 + 2] = 4.0 * EVTOHARTREE;
+
+    final int offset3 = params.getStartPointForKey(keys[2]);
+    p[offset3] = 3.77 * ANGTOBOHR;
+    p[offset3 + 1] = 16.3 * EVTOHARTREE;
+    p[offset3 + 2] = 11.581 * ANGTOBOHR * ANGTOBOHR * ANGTOBOHR * ANGTOBOHR;
+    p[offset3 + 3] = 2.095 * ANGTOBOHR;
+
+    return params;
+  }
 }

--- a/tests/org/ogolem/core/AdvancedPairWiseTest.java
+++ b/tests/org/ogolem/core/AdvancedPairWiseTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2020-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,73 +36,73 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 /**
- * 
  * @author Johannes Dieterich
- * @version 2020-02-01
+ * @version 2021-07-17
  */
 public class AdvancedPairWiseTest {
-   
-    @Test
-    public void testCheckOnlyForCollision() {
-        
-        final int noLJAtoms = 4;
-        final int[] atsPerMol = new int[noLJAtoms];
-        
-        for(int i = 0; i < noLJAtoms; i++){
-            atsPerMol[i] = 1;
-        }
-        
-        final CartesianCoordinates cartes = new CartesianCoordinates(noLJAtoms, noLJAtoms, atsPerMol);
-        final String[] atoms = cartes.getAllAtomTypes();
-        final double[][] xyz = cartes.getAllXYZCoord();
-        
-        for(int i = 0; i < noLJAtoms; i++){
-            atoms[i] = "Ar";
-            xyz[0][i] = 4*i;
-        }
-        cartes.recalcAtomNumbersForced();
-        
-        final BondInfo bonds = new SimpleBondInfo(4);
-        
-        final AdvancedPairWise cd = new AdvancedPairWise(true, new DummyCollisionStrengthComputer());
-        
-        System.out.println("check only for collision: no collision");
-        final boolean res1 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
-        assertTrue(!res1); // no collision
 
-        System.out.println("check only for collision: no collision in window");
-        xyz[0][1] = 0.0;
-        final boolean res2 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
-        xyz[0][1] = 4.0;
-        assertTrue(!res2); // no collision
-        
-        System.out.println("check only for collision: collision with outside window");
-        xyz[0][3] = 4*2.0;
-        final boolean res3 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
-        xyz[0][3] = 4*3.0;
-        assertTrue(res3); // collision
-        
-        System.out.println("check only for collision: collision with outside window 2");
-        xyz[0][0] = 8.0;
-        final boolean res4 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
-        xyz[0][0] = 0.0;
-        assertTrue(res4); // collision
-        
-        System.out.println("check only for collision: collision inside window");
-        xyz[0][2] = 4*3.0;
-        final boolean res5 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
-        xyz[0][2] = 4*2.0;
-        assertTrue(res5); // collision
-        
-        System.out.println("check only for collision: collision inside window but bond");
-        xyz[0][2] = 4*3.0;
-        bonds.setBond(2,3,(short)1);
-        final boolean res6 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
-        xyz[0][2] = 4*2.0;
-        assertTrue(!res6); // no collision
+  @Test
+  public void testCheckOnlyForCollision() {
+
+    final int noLJAtoms = 4;
+    final int[] atsPerMol = new int[noLJAtoms];
+
+    for (int i = 0; i < noLJAtoms; i++) {
+      atsPerMol[i] = 1;
     }
+
+    final CartesianCoordinates cartes = new CartesianCoordinates(noLJAtoms, noLJAtoms, atsPerMol);
+    final String[] atoms = cartes.getAllAtomTypes();
+    final double[][] xyz = cartes.getAllXYZCoord();
+
+    for (int i = 0; i < noLJAtoms; i++) {
+      atoms[i] = "Ar";
+      xyz[0][i] = 4 * i;
+    }
+    cartes.recalcAtomNumbersForced();
+
+    final BondInfo bonds = new SimpleBondInfo(4);
+
+    final AdvancedPairWise cd = new AdvancedPairWise(true, new DummyCollisionStrengthComputer());
+
+    System.out.println("check only for collision: no collision");
+    final boolean res1 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
+    assertTrue(!res1); // no collision
+
+    System.out.println("check only for collision: no collision in window");
+    xyz[0][1] = 0.0;
+    final boolean res2 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
+    xyz[0][1] = 4.0;
+    assertTrue(!res2); // no collision
+
+    System.out.println("check only for collision: collision with outside window");
+    xyz[0][3] = 4 * 2.0;
+    final boolean res3 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
+    xyz[0][3] = 4 * 3.0;
+    assertTrue(res3); // collision
+
+    System.out.println("check only for collision: collision with outside window 2");
+    xyz[0][0] = 8.0;
+    final boolean res4 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
+    xyz[0][0] = 0.0;
+    assertTrue(res4); // collision
+
+    System.out.println("check only for collision: collision inside window");
+    xyz[0][2] = 4 * 3.0;
+    final boolean res5 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
+    xyz[0][2] = 4 * 2.0;
+    assertTrue(res5); // collision
+
+    System.out.println("check only for collision: collision inside window but bond");
+    xyz[0][2] = 4 * 3.0;
+    bonds.setBond(2, 3, (short) 1);
+    final boolean res6 = cd.checkOnlyForCollision(cartes, 1.0, bonds, 2, 3);
+    xyz[0][2] = 4 * 2.0;
+    assertTrue(!res6); // no collision
+  }
 }

--- a/tests/org/ogolem/core/CoordTranslationTest.java
+++ b/tests/org/ogolem/core/CoordTranslationTest.java
@@ -1,6 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
-              2019, J. M. Dieterich and B. Hartke
+              2019-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,252 +37,240 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2019-12-30
+ * @version 2021-07-17
  */
 public class CoordTranslationTest {
-    
-    private static final double NUMACC = 1e-10;
-    private final Random r;
-    
-    public CoordTranslationTest(){
-        this.r = new Random();
-    }
-    
-    /**
-     * Test of sanitizePhi method, of class CoordTranslation.
-     */
-    @Test
-    public void testSanitizePhi() {
-        System.out.println("sanitizePhi");
-        
-        final int TRIALS = 1000;
-        final double lower = -Math.PI;
-        final double upper = Math.PI;
-        final double period = 2*Math.PI;
-        final int maxPer = 10;
-        
-        for(int i = 0; i < TRIALS; i++){
-            final double ang1 = lower + r.nextDouble()*period;
-            final double san1 = CoordTranslation.sanitizePhi(ang1);
-            assertEquals(ang1,san1,NUMACC);
-            
-            // now one period on top
-            final double ang2 = ang1+period;
-            final double san2 = CoordTranslation.sanitizePhi(ang2);
-            assertEquals(ang1,san2,NUMACC);
-            
-            // remove one period
-            final double ang3 = ang1-period;
-            final double san3 = CoordTranslation.sanitizePhi(ang3);
-            assertEquals(ang1,san3,NUMACC);
-            
-            // add rnd periods
-            final int pers1 = r.nextInt(maxPer);
-            final double ang4 = ang1+pers1*period;
-            final double san4 = CoordTranslation.sanitizePhi(ang4);
-            assertEquals(ang1,san4,NUMACC);
-            
-            
-            // remove rnd periods
-            final int pers2 = r.nextInt(maxPer);
-            final double ang5 = ang1-pers2*period;
-            final double san5 = CoordTranslation.sanitizePhi(ang5);
-            assertEquals(ang1,san5,NUMACC);
-            
-        }        
-    }
 
-    /**
-     * Test of sanitizeOmega method, of class CoordTranslation.
-     */
-    @Test
-    public void testSanitizeOmega() {
-        System.out.println("sanitizeOmega");
-        final int TRIALS = 1000;
-        final double lower = -0.5*Math.PI;
-        final double upper = 0.5*Math.PI;
-        final double period = Math.PI;
-        final int maxPer = 10;
-        
-        for(int i = 0; i < TRIALS; i++){
-            final double ang1 = lower + r.nextDouble()*period;
-            final double san1 = CoordTranslation.sanitizeOmega(ang1);
-            assertEquals(ang1,san1,NUMACC);
-            
-            // now one period on top
-            final double ang2 = ang1+period;
-            final double san2 = CoordTranslation.sanitizeOmega(ang2);
-            assertEquals(ang1,san2,NUMACC);
-            
-            // remove one period
-            final double ang3 = ang1-period;
-            final double san3 = CoordTranslation.sanitizeOmega(ang3);
-            assertEquals(ang1,san3,NUMACC);
-            
-            // add rnd periods
-            final int pers1 = r.nextInt(maxPer);
-            final double ang4 = ang1+pers1*period;
-            final double san4 = CoordTranslation.sanitizeOmega(ang4);
-            assertEquals(ang1,san4,NUMACC);
-            
-            
-            // remove rnd periods
-            final int pers2 = r.nextInt(maxPer);
-            final double ang5 = ang1-pers2*period;
-            final double san5 = CoordTranslation.sanitizeOmega(ang5);
-            assertEquals(ang1,san5,NUMACC);
-            
-        }        
-    }
+  private static final double NUMACC = 1e-10;
+  private final Random r;
 
-    /**
-     * Test of sanitizePsi method, of class CoordTranslation.
-     */
-    @Test
-    public void testSanitizePsi() {
-        System.out.println("sanitizePsi");
-        
-        final int TRIALS = 1000;
-        final double lower = -Math.PI;
-        final double upper = Math.PI;
-        final double period = 2*Math.PI;
-        final int maxPer = 10;
-        
-        for(int i = 0; i < TRIALS; i++){
-            final double ang1 = lower + r.nextDouble()*period;
-            final double san1 = CoordTranslation.sanitizePsi(ang1);
-            assertEquals(ang1,san1,NUMACC);
-            
-            // now one period on top
-            final double ang2 = ang1+period;
-            final double san2 = CoordTranslation.sanitizePsi(ang2);
-            assertEquals(ang1,san2,NUMACC);
-            
-            // remove one period
-            final double ang3 = ang1-period;
-            final double san3 = CoordTranslation.sanitizePsi(ang3);
-            assertEquals(ang1,san3,NUMACC);
-            
-            // add rnd periods
-            final int pers1 = r.nextInt(maxPer);
-            final double ang4 = ang1+pers1*period;
-            final double san4 = CoordTranslation.sanitizePsi(ang4);
-            assertEquals(ang1,san4,NUMACC);
-            
-            
-            // remove rnd periods
-            final int pers2 = r.nextInt(maxPer);
-            final double ang5 = ang1-pers2*period;
-            final double san5 = CoordTranslation.sanitizePsi(ang5);
-            assertEquals(ang1,san5,NUMACC);
-            
-        }
+  public CoordTranslationTest() {
+    this.r = new Random();
+  }
+
+  /** Test of sanitizePhi method, of class CoordTranslation. */
+  @Test
+  public void testSanitizePhi() {
+    System.out.println("sanitizePhi");
+
+    final int TRIALS = 1000;
+    final double lower = -Math.PI;
+    final double upper = Math.PI;
+    final double period = 2 * Math.PI;
+    final int maxPer = 10;
+
+    for (int i = 0; i < TRIALS; i++) {
+      final double ang1 = lower + r.nextDouble() * period;
+      final double san1 = CoordTranslation.sanitizePhi(ang1);
+      assertEquals(ang1, san1, NUMACC);
+
+      // now one period on top
+      final double ang2 = ang1 + period;
+      final double san2 = CoordTranslation.sanitizePhi(ang2);
+      assertEquals(ang1, san2, NUMACC);
+
+      // remove one period
+      final double ang3 = ang1 - period;
+      final double san3 = CoordTranslation.sanitizePhi(ang3);
+      assertEquals(ang1, san3, NUMACC);
+
+      // add rnd periods
+      final int pers1 = r.nextInt(maxPer);
+      final double ang4 = ang1 + pers1 * period;
+      final double san4 = CoordTranslation.sanitizePhi(ang4);
+      assertEquals(ang1, san4, NUMACC);
+
+      // remove rnd periods
+      final int pers2 = r.nextInt(maxPer);
+      final double ang5 = ang1 - pers2 * period;
+      final double san5 = CoordTranslation.sanitizePhi(ang5);
+      assertEquals(ang1, san5, NUMACC);
     }
-    
-    @Test
-    public void testCalcAngle() {
-        
-        double[][] xyz = new double[3][3];
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        double angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
-        assertEquals(Math.PI,angle,NUMACC);
-        
-        xyz = new double[3][3];
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 1.0;
-        xyz[1][2] = 1.0;
-        angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
-        assertEquals(Math.PI/2,angle,NUMACC);
-        
-        xyz = new double[3][3];
-        xyz[0][1] = 1.0;
-        angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
-        assertEquals(0.0,angle,NUMACC);
-        
-        xyz = new double[3][3];
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 1.0;
-        xyz[1][2] = -1.0;
-        angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
-        assertEquals(Math.PI/2,angle,NUMACC);
+  }
+
+  /** Test of sanitizeOmega method, of class CoordTranslation. */
+  @Test
+  public void testSanitizeOmega() {
+    System.out.println("sanitizeOmega");
+    final int TRIALS = 1000;
+    final double lower = -0.5 * Math.PI;
+    final double upper = 0.5 * Math.PI;
+    final double period = Math.PI;
+    final int maxPer = 10;
+
+    for (int i = 0; i < TRIALS; i++) {
+      final double ang1 = lower + r.nextDouble() * period;
+      final double san1 = CoordTranslation.sanitizeOmega(ang1);
+      assertEquals(ang1, san1, NUMACC);
+
+      // now one period on top
+      final double ang2 = ang1 + period;
+      final double san2 = CoordTranslation.sanitizeOmega(ang2);
+      assertEquals(ang1, san2, NUMACC);
+
+      // remove one period
+      final double ang3 = ang1 - period;
+      final double san3 = CoordTranslation.sanitizeOmega(ang3);
+      assertEquals(ang1, san3, NUMACC);
+
+      // add rnd periods
+      final int pers1 = r.nextInt(maxPer);
+      final double ang4 = ang1 + pers1 * period;
+      final double san4 = CoordTranslation.sanitizeOmega(ang4);
+      assertEquals(ang1, san4, NUMACC);
+
+      // remove rnd periods
+      final int pers2 = r.nextInt(maxPer);
+      final double ang5 = ang1 - pers2 * period;
+      final double san5 = CoordTranslation.sanitizeOmega(ang5);
+      assertEquals(ang1, san5, NUMACC);
     }
-    
-    @Test
-    public void testCalcDihedral() {
-        
-        double[][] xyz = new double[3][4];
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 3.0;
-        double dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(0.0,dihedral,NUMACC);
-        
-        xyz = new double[3][4];
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 2.0;
-        xyz[1][3] = 1.0;
-        dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(0.0,dihedral,NUMACC);
-        
-        xyz = new double[3][4];
-        xyz[1][0] = -1.0;
-        xyz[0][0] = 1.0;
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 2.0;
-        xyz[1][3] = 1.0;
-        dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(Math.PI,dihedral,NUMACC);
-        
-        xyz = new double[3][4];
-        xyz[1][0] = -1.0;
-        xyz[0][0] = 1.0;
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 2.0;
-        xyz[2][3] = 1.0;
-        dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(-Math.PI/2,dihedral,NUMACC);
-        
-        xyz = new double[3][4];
-        xyz[1][0] = -1.0;
-        xyz[0][0] = 1.0;
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 2.0;
-        xyz[2][3] = -1.0;
-        dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(Math.PI/2,dihedral,NUMACC);
-        
-        xyz = new double[3][4];
-        xyz[1][0] = -1.0;
-        xyz[0][0] = 1.0;
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 2.0;
-        xyz[1][3] = -1.0;
-        xyz[2][3] = -1.0;
-        dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(Math.PI/4,dihedral,NUMACC);
-        
-        xyz = new double[3][4];
-        xyz[1][0] = -1.0;
-        xyz[0][0] = 1.0;
-        xyz[0][1] = 1.0;
-        xyz[0][2] = 2.0;
-        xyz[0][3] = 2.0;
-        xyz[1][3] = 1.0;
-        xyz[2][3] = -1.0;
-        dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
-        assertEquals(3*Math.PI/4,dihedral,NUMACC);
+  }
+
+  /** Test of sanitizePsi method, of class CoordTranslation. */
+  @Test
+  public void testSanitizePsi() {
+    System.out.println("sanitizePsi");
+
+    final int TRIALS = 1000;
+    final double lower = -Math.PI;
+    final double upper = Math.PI;
+    final double period = 2 * Math.PI;
+    final int maxPer = 10;
+
+    for (int i = 0; i < TRIALS; i++) {
+      final double ang1 = lower + r.nextDouble() * period;
+      final double san1 = CoordTranslation.sanitizePsi(ang1);
+      assertEquals(ang1, san1, NUMACC);
+
+      // now one period on top
+      final double ang2 = ang1 + period;
+      final double san2 = CoordTranslation.sanitizePsi(ang2);
+      assertEquals(ang1, san2, NUMACC);
+
+      // remove one period
+      final double ang3 = ang1 - period;
+      final double san3 = CoordTranslation.sanitizePsi(ang3);
+      assertEquals(ang1, san3, NUMACC);
+
+      // add rnd periods
+      final int pers1 = r.nextInt(maxPer);
+      final double ang4 = ang1 + pers1 * period;
+      final double san4 = CoordTranslation.sanitizePsi(ang4);
+      assertEquals(ang1, san4, NUMACC);
+
+      // remove rnd periods
+      final int pers2 = r.nextInt(maxPer);
+      final double ang5 = ang1 - pers2 * period;
+      final double san5 = CoordTranslation.sanitizePsi(ang5);
+      assertEquals(ang1, san5, NUMACC);
     }
+  }
+
+  @Test
+  public void testCalcAngle() {
+
+    double[][] xyz = new double[3][3];
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    double angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
+    assertEquals(Math.PI, angle, NUMACC);
+
+    xyz = new double[3][3];
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 1.0;
+    xyz[1][2] = 1.0;
+    angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
+    assertEquals(Math.PI / 2, angle, NUMACC);
+
+    xyz = new double[3][3];
+    xyz[0][1] = 1.0;
+    angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
+    assertEquals(0.0, angle, NUMACC);
+
+    xyz = new double[3][3];
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 1.0;
+    xyz[1][2] = -1.0;
+    angle = CoordTranslation.calcAngle(xyz, 0, 1, 2);
+    assertEquals(Math.PI / 2, angle, NUMACC);
+  }
+
+  @Test
+  public void testCalcDihedral() {
+
+    double[][] xyz = new double[3][4];
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 3.0;
+    double dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(0.0, dihedral, NUMACC);
+
+    xyz = new double[3][4];
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 2.0;
+    xyz[1][3] = 1.0;
+    dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(0.0, dihedral, NUMACC);
+
+    xyz = new double[3][4];
+    xyz[1][0] = -1.0;
+    xyz[0][0] = 1.0;
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 2.0;
+    xyz[1][3] = 1.0;
+    dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(Math.PI, dihedral, NUMACC);
+
+    xyz = new double[3][4];
+    xyz[1][0] = -1.0;
+    xyz[0][0] = 1.0;
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 2.0;
+    xyz[2][3] = 1.0;
+    dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(-Math.PI / 2, dihedral, NUMACC);
+
+    xyz = new double[3][4];
+    xyz[1][0] = -1.0;
+    xyz[0][0] = 1.0;
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 2.0;
+    xyz[2][3] = -1.0;
+    dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(Math.PI / 2, dihedral, NUMACC);
+
+    xyz = new double[3][4];
+    xyz[1][0] = -1.0;
+    xyz[0][0] = 1.0;
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 2.0;
+    xyz[1][3] = -1.0;
+    xyz[2][3] = -1.0;
+    dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(Math.PI / 4, dihedral, NUMACC);
+
+    xyz = new double[3][4];
+    xyz[1][0] = -1.0;
+    xyz[0][0] = 1.0;
+    xyz[0][1] = 1.0;
+    xyz[0][2] = 2.0;
+    xyz[0][3] = 2.0;
+    xyz[1][3] = 1.0;
+    xyz[2][3] = -1.0;
+    dihedral = CoordTranslation.calcDihedral(xyz, 0, 1, 2, 3);
+    assertEquals(3 * Math.PI / 4, dihedral, NUMACC);
+  }
 }

--- a/tests/org/ogolem/core/CoulombMatrixTest.java
+++ b/tests/org/ogolem/core/CoulombMatrixTest.java
@@ -30,21 +30,21 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.core;
 
 import java.util.ArrayList;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.ogolem.generic.genericpool.Niche;
 
 /**
  * Test Class for Coulomb-Matrix
  *
  * @author Dominik Behrens
- * @version 2021-07-06
+ * @version 2021-07-17
  */
 public class CoulombMatrixTest {
   private CoulombMatrixNicheComp comp;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     comp =
         new CoulombMatrixNicheComp(
@@ -55,28 +55,28 @@ public class CoulombMatrixTest {
   public void testSetupAllSameSpot() {
     Geometry sample = constructGoldCube(0, 0);
     Niche niche = comp.computeNiche(sample);
-    Assert.assertEquals("cmat-0", niche.getID());
+    Assertions.assertEquals("cmat-0", niche.getID());
   }
 
   @Test
   public void testSetupWidthLower() {
     Geometry sample = constructGoldCube(5, -0.219);
     Niche niche = comp.computeNiche(sample);
-    Assert.assertEquals("cmat-45", niche.getID());
+    Assertions.assertEquals("cmat-45", niche.getID());
   }
 
   @Test
   public void testSetupWidthUpper() {
     Geometry sample = constructGoldCube(5, 0.228);
     Niche niche = comp.computeNiche(sample);
-    Assert.assertEquals("cmat-45", niche.getID());
+    Assertions.assertEquals("cmat-45", niche.getID());
   }
 
   @Test
   public void testSetupJustOutWidthLower() {
     Geometry sample = constructGoldCube(5, -0.220);
     Niche niche = comp.computeNiche(sample);
-    Assert.assertEquals("cmat-44", niche.getID());
+    Assertions.assertEquals("cmat-44", niche.getID());
   }
 
   @Test
@@ -84,7 +84,7 @@ public class CoulombMatrixTest {
     Geometry sample = constructGoldCube(5, 0.229);
     CartesianCoordinates dfv = sample.getCartesians();
     Niche niche = comp.computeNiche(sample);
-    Assert.assertEquals("cmat-44", niche.getID());
+    Assertions.assertEquals("cmat-44", niche.getID());
   }
 
   private Geometry constructGoldCube(double a, double b) {

--- a/tests/org/ogolem/core/LennardJonesFFTest.java
+++ b/tests/org/ogolem/core/LennardJonesFFTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2020-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,224 +36,272 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2020-05-25
+ * @version 2021-07-17
  */
 public class LennardJonesFFTest {
-    
-    private static final String LJ38MIN = "38\n" +
-"Energy:            -173.2453\n" +
-"Ar              2.2635080             -1.3021673              0.2364510\n" +
-"Ar             -4.0696589             -1.7833951             -1.0912553\n" +
-"Ar              3.3465963              0.5473776              5.1173994\n" +
-"Ar              4.6352036              2.9641120             -1.9064564\n" +
-"Ar             -5.2396084              1.6412581             -2.1458985\n" +
-"Ar              2.1975346              3.9699958              4.0662786\n" +
-"Ar              2.9139336             -0.1048691             -3.2585750\n" +
-"Ar             -0.1537578             -0.2936708              6.2036580\n" +
-"Ar             -3.5310673              4.6998827             -0.7800296\n" +
-"Ar             -1.8706342             -3.3672049              4.8312587\n" +
-"Ar              3.9770026              1.7439961              1.5989158\n" +
-"Ar              5.1470505             -1.6806710              2.6532521\n" +
-"Ar              0.0611707              0.2542515             -5.6961461\n" +
-"Ar              1.1218741              2.0986964             -0.8081952\n" +
-"Ar             -5.8825641              0.4360893              1.3575178\n" +
-"Ar              1.7779228              3.3278948             -4.3237295\n" +
-"Ar              3.4384866             -4.7393483              1.2876312\n" +
-"Ar              4.0814241             -3.5339516             -2.2157154\n" +
-"Ar              5.7898690             -0.4751665             -0.8500914\n" +
-"Ar             -2.9362859             -5.2206833             -0.0378087\n" +
-"Ar             -1.2145583             -2.1381033              1.3158395\n" +
-"Ar             -4.1741020              3.4946992              2.7233876\n" +
-"Ar              2.8435532              5.1812951              0.5458881\n" +
-"Ar             -0.5757456             -0.9405450             -2.1653462\n" +
-"Ar              1.6313510             -2.5096021              3.7313159\n" +
-"Ar             -1.3028293              3.1289101              5.1523874\n" +
-"Ar             -3.0066453              0.0655822              3.7661092\n" +
-"Ar             -0.0136789              5.5451888             -1.8714567\n" +
-"Ar              0.5682738             -4.3585518             -1.1260230\n" +
-"Ar             -0.6609501              4.3190723              1.6338157\n" +
-"Ar             -2.2902497             -4.0096773             -3.5583525\n" +
-"Ar              0.4831067              0.9010895              2.6729642\n" +
-"Ar             -3.4390998             -0.5870227             -4.6098257\n" +
-"Ar             -2.3561517              1.2627716              0.2711277\n" +
-"Ar             -1.7239135              2.4701423             -3.2237536\n" +
-"Ar             -4.7280805             -3.0031875              2.4141292\n" +
-"Ar              1.2100750             -3.1683730             -4.6446476\n" +
-"Ar             -0.0788494             -5.5846809              2.3792819";
-    
-    private static final String LJ55MIN = "55\n" +
-"Energy:            -278.1517\n" +
-"Ar              0.2637670              0.0750218             -0.0305859\n" +
-"Ar              1.9400511             -5.9359266             -0.2182075\n" +
-"Ar             -3.3887782              5.5878993             -3.0857245\n" +
-"Ar              5.4645827              3.5286603             -0.0164234\n" +
-"Ar             -0.0611506             -6.3446547             -3.4581804\n" +
-"Ar             -4.7623515              2.0139627             -3.1856848\n" +
-"Ar             -2.7311677              1.0755806              5.3550730\n" +
-"Ar              5.1542978             -3.8014196             -0.2095618\n" +
-"Ar             -3.0861314             -3.9969872             -3.3732330\n" +
-"Ar              2.4421399              5.9244352              0.0941955\n" +
-"Ar              0.1530409              0.2714680             -7.3117752\n" +
-"Ar              3.2585466             -0.9253576             -5.4163715\n" +
-"Ar              0.2094058              0.1714695             -3.6056473\n" +
-"Ar              2.2225382              2.7895936             -5.3003453\n" +
-"Ar             -1.6999051             -2.4743290              1.5308355\n" +
-"Ar              6.5888663              1.7386441              3.1775426\n" +
-"Ar              0.4233255              3.2271118              1.6523928\n" +
-"Ar             -1.6951682             -2.6393958              5.2391891\n" +
-"Ar             -2.8418301             -0.7418962             -1.6057981\n" +
-"Ar             -2.7097004              1.1466854              1.6437936\n" +
-"Ar              0.3743391             -0.1213402              7.2505633\n" +
-"Ar              2.0571514             -2.6317879              1.4694758\n" +
-"Ar              3.3693659              0.8918850              1.5446257\n" +
-"Ar              3.9163409             -5.4378330              3.0245237\n" +
-"Ar             -1.4124661              6.0859683              0.1570572\n" +
-"Ar              0.4832106              3.2099543              5.3639202\n" +
-"Ar             -5.9730344              0.3363606              0.0711651\n" +
-"Ar             -4.6268008              3.9515551              0.1482164\n" +
-"Ar             -2.6231431              4.4083720              3.4138865\n" +
-"Ar             -2.9781957             -0.6641526             -5.3145255\n" +
-"Ar              4.2630175              5.2673226             -3.2106167\n" +
-"Ar             -1.9145285             -5.7743746             -0.1552363\n" +
-"Ar             -4.9370769             -3.3786155             -0.0447196\n" +
-"Ar             -6.0612815             -1.5887397             -3.2387501\n" +
-"Ar             -1.5296300              2.7818574             -1.5306798\n" +
-"Ar             -3.7355675             -5.1171473              3.1495165\n" +
-"Ar              0.4384309              5.4677007             -3.1714606\n" +
-"Ar              5.3289109              1.5912421             -3.3504794\n" +
-"Ar              0.0890783             -5.3175663              3.1103721\n" +
-"Ar             -4.8014991             -1.4410447              3.2891758\n" +
-"Ar             -1.6319388              2.9510461             -5.2374343\n" +
-"Ar              5.2899358             -1.8640178              3.1244180\n" +
-"Ar             -5.7921455              2.2576283              3.3795587\n" +
-"Ar              3.2371665             -0.9965492             -1.7050608\n" +
-"Ar              0.0442854             -3.0598980             -5.4250516\n" +
-"Ar              3.6137059              4.1469046              3.3121847\n" +
-"Ar              0.3180569             -0.0213815              3.5444697\n" +
-"Ar              2.1594096             -2.8009554              5.1762327\n" +
-"Ar              0.5887912              6.4946966              3.3970661\n" +
-"Ar              0.1042463             -3.0770498             -1.7135232\n" +
-"Ar              6.3195618             -2.1073732             -3.4409865\n" +
-"Ar              2.2274111              2.6244358             -1.5919829\n" +
-"Ar              3.5057247              0.8140948              5.2533412\n" +
-"Ar              3.1506760             -4.2582346             -3.4751765\n" +
-"Ar              6.5005124             -0.1862658             -0.1324787";
-    
-    private static final double ENERGYLJ38 = -0.0659856619926505;
-    private static final double ENERGYLJ55 = -0.10594240151944964;
-    private static final double NUMACC = 1.0e-8;
-    
-    @Test
-    public void testEnergyCalculationLJMins() {
-        
-        final int[] atsPerMol38 = new int[38];
-        for(int i = 0; i < 38; i++){
-            atsPerMol38[i] = 1;
-        }
-        
-        final int[] atsPerMol55 = new int[55];
-        for(int i = 0; i < 55; i++){
-            atsPerMol55[i] = 1;
-        }
-        
-        CartesianCoordinates lj38 = null;
-        CartesianCoordinates lj55 = null;
-        try {
-            final String[] fileCont38 = LJ38MIN.split("\n");
-            lj38 = Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
-        
-            final String[] fileCont55 = LJ55MIN.split("\n");
-            lj55 = Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
-        } catch(Exception e){
-           fail(e.toString());
-        }
 
-        final BondInfo bonds38 = new SimpleBondInfo(38);
-        final BondInfo bonds55 = new SimpleBondInfo(55);
-        
-        final LennardJonesFF ljFF = new LennardJonesFF(true);
-       
-        final double e38 = ljFF.energyCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38, false);
-        
-        assertEquals(ENERGYLJ38, e38, NUMACC);
-        
-        final double e55 = ljFF.energyCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55, false);
-        
-        assertEquals(ENERGYLJ55, e55, NUMACC);
-    }
-    
-    @Test
-    public void testGradientCalculationLJMins() {
-        
-        final int[] atsPerMol38 = new int[38];
-        for(int i = 0; i < 38; i++){
-            atsPerMol38[i] = 1;
-        }
-        
-        final int[] atsPerMol55 = new int[55];
-        for(int i = 0; i < 55; i++){
-            atsPerMol55[i] = 1;
-        }
-        
-        CartesianCoordinates lj38 = null;
-        CartesianCoordinates lj55 = null;
-        try {
-            final String[] fileCont38 = LJ38MIN.split("\n");
-            lj38 = Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
-        
-            final String[] fileCont55 = LJ55MIN.split("\n");
-            lj55 = Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
-        } catch(Exception e){
-           fail(e.toString());
-        }
+  private static final String LJ38MIN =
+      "38\n"
+          + "Energy:            -173.2453\n"
+          + "Ar              2.2635080             -1.3021673              0.2364510\n"
+          + "Ar             -4.0696589             -1.7833951             -1.0912553\n"
+          + "Ar              3.3465963              0.5473776              5.1173994\n"
+          + "Ar              4.6352036              2.9641120             -1.9064564\n"
+          + "Ar             -5.2396084              1.6412581             -2.1458985\n"
+          + "Ar              2.1975346              3.9699958              4.0662786\n"
+          + "Ar              2.9139336             -0.1048691             -3.2585750\n"
+          + "Ar             -0.1537578             -0.2936708              6.2036580\n"
+          + "Ar             -3.5310673              4.6998827             -0.7800296\n"
+          + "Ar             -1.8706342             -3.3672049              4.8312587\n"
+          + "Ar              3.9770026              1.7439961              1.5989158\n"
+          + "Ar              5.1470505             -1.6806710              2.6532521\n"
+          + "Ar              0.0611707              0.2542515             -5.6961461\n"
+          + "Ar              1.1218741              2.0986964             -0.8081952\n"
+          + "Ar             -5.8825641              0.4360893              1.3575178\n"
+          + "Ar              1.7779228              3.3278948             -4.3237295\n"
+          + "Ar              3.4384866             -4.7393483              1.2876312\n"
+          + "Ar              4.0814241             -3.5339516             -2.2157154\n"
+          + "Ar              5.7898690             -0.4751665             -0.8500914\n"
+          + "Ar             -2.9362859             -5.2206833             -0.0378087\n"
+          + "Ar             -1.2145583             -2.1381033              1.3158395\n"
+          + "Ar             -4.1741020              3.4946992              2.7233876\n"
+          + "Ar              2.8435532              5.1812951              0.5458881\n"
+          + "Ar             -0.5757456             -0.9405450             -2.1653462\n"
+          + "Ar              1.6313510             -2.5096021              3.7313159\n"
+          + "Ar             -1.3028293              3.1289101              5.1523874\n"
+          + "Ar             -3.0066453              0.0655822              3.7661092\n"
+          + "Ar             -0.0136789              5.5451888             -1.8714567\n"
+          + "Ar              0.5682738             -4.3585518             -1.1260230\n"
+          + "Ar             -0.6609501              4.3190723              1.6338157\n"
+          + "Ar             -2.2902497             -4.0096773             -3.5583525\n"
+          + "Ar              0.4831067              0.9010895              2.6729642\n"
+          + "Ar             -3.4390998             -0.5870227             -4.6098257\n"
+          + "Ar             -2.3561517              1.2627716              0.2711277\n"
+          + "Ar             -1.7239135              2.4701423             -3.2237536\n"
+          + "Ar             -4.7280805             -3.0031875              2.4141292\n"
+          + "Ar              1.2100750             -3.1683730             -4.6446476\n"
+          + "Ar             -0.0788494             -5.5846809              2.3792819";
 
-        final BondInfo bonds38 = new SimpleBondInfo(38);
-        final BondInfo bonds55 = new SimpleBondInfo(55);
-        
-        final LennardJonesFF ljFF = new LennardJonesFF(true);
-       
-        final Gradient grad38 = new Gradient(3, 38);
-        ljFF.gradientCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38,
-                grad38, false);
-        
-        assertEquals(ENERGYLJ38, grad38.getTotalEnergy(), NUMACC);
-        
-        final double[][] gradient38 = grad38.getTotalGradient();
-        
-        double gradTot38 = 0.0;
-        for(int i = 0; i < 3; i++){
-            for(int j = 0; j < 38; j++) gradTot38 += gradient38[i][j];
-        }
-        
-        assertEquals(0.0, gradTot38, NUMACC);
-        
-        final Gradient grad55 = new Gradient(3, 55);
-        ljFF.gradientCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55,
-                grad55, false);
-        
-        assertEquals(ENERGYLJ55, grad55.getTotalEnergy(), NUMACC);
-        
-        final double[][] gradient55 = grad55.getTotalGradient();
-        
-        double gradTot55 = 0.0;
-        for(int i = 0; i < 3; i++){
-            for(int j = 0; j < 55; j++) gradTot55 += gradient55[i][j];
-        }
-        
-        assertEquals(0.0, gradTot55, NUMACC);
+  private static final String LJ55MIN =
+      "55\n"
+          + "Energy:            -278.1517\n"
+          + "Ar              0.2637670              0.0750218             -0.0305859\n"
+          + "Ar              1.9400511             -5.9359266             -0.2182075\n"
+          + "Ar             -3.3887782              5.5878993             -3.0857245\n"
+          + "Ar              5.4645827              3.5286603             -0.0164234\n"
+          + "Ar             -0.0611506             -6.3446547             -3.4581804\n"
+          + "Ar             -4.7623515              2.0139627             -3.1856848\n"
+          + "Ar             -2.7311677              1.0755806              5.3550730\n"
+          + "Ar              5.1542978             -3.8014196             -0.2095618\n"
+          + "Ar             -3.0861314             -3.9969872             -3.3732330\n"
+          + "Ar              2.4421399              5.9244352              0.0941955\n"
+          + "Ar              0.1530409              0.2714680             -7.3117752\n"
+          + "Ar              3.2585466             -0.9253576             -5.4163715\n"
+          + "Ar              0.2094058              0.1714695             -3.6056473\n"
+          + "Ar              2.2225382              2.7895936             -5.3003453\n"
+          + "Ar             -1.6999051             -2.4743290              1.5308355\n"
+          + "Ar              6.5888663              1.7386441              3.1775426\n"
+          + "Ar              0.4233255              3.2271118              1.6523928\n"
+          + "Ar             -1.6951682             -2.6393958              5.2391891\n"
+          + "Ar             -2.8418301             -0.7418962             -1.6057981\n"
+          + "Ar             -2.7097004              1.1466854              1.6437936\n"
+          + "Ar              0.3743391             -0.1213402              7.2505633\n"
+          + "Ar              2.0571514             -2.6317879              1.4694758\n"
+          + "Ar              3.3693659              0.8918850              1.5446257\n"
+          + "Ar              3.9163409             -5.4378330              3.0245237\n"
+          + "Ar             -1.4124661              6.0859683              0.1570572\n"
+          + "Ar              0.4832106              3.2099543              5.3639202\n"
+          + "Ar             -5.9730344              0.3363606              0.0711651\n"
+          + "Ar             -4.6268008              3.9515551              0.1482164\n"
+          + "Ar             -2.6231431              4.4083720              3.4138865\n"
+          + "Ar             -2.9781957             -0.6641526             -5.3145255\n"
+          + "Ar              4.2630175              5.2673226             -3.2106167\n"
+          + "Ar             -1.9145285             -5.7743746             -0.1552363\n"
+          + "Ar             -4.9370769             -3.3786155             -0.0447196\n"
+          + "Ar             -6.0612815             -1.5887397             -3.2387501\n"
+          + "Ar             -1.5296300              2.7818574             -1.5306798\n"
+          + "Ar             -3.7355675             -5.1171473              3.1495165\n"
+          + "Ar              0.4384309              5.4677007             -3.1714606\n"
+          + "Ar              5.3289109              1.5912421             -3.3504794\n"
+          + "Ar              0.0890783             -5.3175663              3.1103721\n"
+          + "Ar             -4.8014991             -1.4410447              3.2891758\n"
+          + "Ar             -1.6319388              2.9510461             -5.2374343\n"
+          + "Ar              5.2899358             -1.8640178              3.1244180\n"
+          + "Ar             -5.7921455              2.2576283              3.3795587\n"
+          + "Ar              3.2371665             -0.9965492             -1.7050608\n"
+          + "Ar              0.0442854             -3.0598980             -5.4250516\n"
+          + "Ar              3.6137059              4.1469046              3.3121847\n"
+          + "Ar              0.3180569             -0.0213815              3.5444697\n"
+          + "Ar              2.1594096             -2.8009554              5.1762327\n"
+          + "Ar              0.5887912              6.4946966              3.3970661\n"
+          + "Ar              0.1042463             -3.0770498             -1.7135232\n"
+          + "Ar              6.3195618             -2.1073732             -3.4409865\n"
+          + "Ar              2.2274111              2.6244358             -1.5919829\n"
+          + "Ar              3.5057247              0.8140948              5.2533412\n"
+          + "Ar              3.1506760             -4.2582346             -3.4751765\n"
+          + "Ar              6.5005124             -0.1862658             -0.1324787";
+
+  private static final double ENERGYLJ38 = -0.0659856619926505;
+  private static final double ENERGYLJ55 = -0.10594240151944964;
+  private static final double NUMACC = 1.0e-8;
+
+  @Test
+  public void testEnergyCalculationLJMins() {
+
+    final int[] atsPerMol38 = new int[38];
+    for (int i = 0; i < 38; i++) {
+      atsPerMol38[i] = 1;
     }
+
+    final int[] atsPerMol55 = new int[55];
+    for (int i = 0; i < 55; i++) {
+      atsPerMol55[i] = 1;
+    }
+
+    CartesianCoordinates lj38 = null;
+    CartesianCoordinates lj55 = null;
+    try {
+      final String[] fileCont38 = LJ38MIN.split("\n");
+      lj38 =
+          Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
+
+      final String[] fileCont55 = LJ55MIN.split("\n");
+      lj55 =
+          Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+
+    final BondInfo bonds38 = new SimpleBondInfo(38);
+    final BondInfo bonds55 = new SimpleBondInfo(55);
+
+    final LennardJonesFF ljFF = new LennardJonesFF(true);
+
+    final double e38 =
+        ljFF.energyCalculation(
+            -1,
+            0,
+            lj38.getAll1DCartes(),
+            lj38.getAllAtomTypes(),
+            lj38.getAllAtomNumbers(),
+            atsPerMol38,
+            new double[38],
+            lj38.getNoOfAtoms(),
+            lj38.getAllCharges(),
+            lj38.getAllSpins(),
+            bonds38,
+            false);
+
+    assertEquals(ENERGYLJ38, e38, NUMACC);
+
+    final double e55 =
+        ljFF.energyCalculation(
+            -1,
+            0,
+            lj55.getAll1DCartes(),
+            lj55.getAllAtomTypes(),
+            lj55.getAllAtomNumbers(),
+            atsPerMol55,
+            new double[55],
+            lj55.getNoOfAtoms(),
+            lj55.getAllCharges(),
+            lj55.getAllSpins(),
+            bonds55,
+            false);
+
+    assertEquals(ENERGYLJ55, e55, NUMACC);
+  }
+
+  @Test
+  public void testGradientCalculationLJMins() {
+
+    final int[] atsPerMol38 = new int[38];
+    for (int i = 0; i < 38; i++) {
+      atsPerMol38[i] = 1;
+    }
+
+    final int[] atsPerMol55 = new int[55];
+    for (int i = 0; i < 55; i++) {
+      atsPerMol55[i] = 1;
+    }
+
+    CartesianCoordinates lj38 = null;
+    CartesianCoordinates lj55 = null;
+    try {
+      final String[] fileCont38 = LJ38MIN.split("\n");
+      lj38 =
+          Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
+
+      final String[] fileCont55 = LJ55MIN.split("\n");
+      lj55 =
+          Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+
+    final BondInfo bonds38 = new SimpleBondInfo(38);
+    final BondInfo bonds55 = new SimpleBondInfo(55);
+
+    final LennardJonesFF ljFF = new LennardJonesFF(true);
+
+    final Gradient grad38 = new Gradient(3, 38);
+    ljFF.gradientCalculation(
+        -1,
+        0,
+        lj38.getAll1DCartes(),
+        lj38.getAllAtomTypes(),
+        lj38.getAllAtomNumbers(),
+        atsPerMol38,
+        new double[38],
+        lj38.getNoOfAtoms(),
+        lj38.getAllCharges(),
+        lj38.getAllSpins(),
+        bonds38,
+        grad38,
+        false);
+
+    assertEquals(ENERGYLJ38, grad38.getTotalEnergy(), NUMACC);
+
+    final double[][] gradient38 = grad38.getTotalGradient();
+
+    double gradTot38 = 0.0;
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 38; j++) gradTot38 += gradient38[i][j];
+    }
+
+    assertEquals(0.0, gradTot38, NUMACC);
+
+    final Gradient grad55 = new Gradient(3, 55);
+    ljFF.gradientCalculation(
+        -1,
+        0,
+        lj55.getAll1DCartes(),
+        lj55.getAllAtomTypes(),
+        lj55.getAllAtomNumbers(),
+        atsPerMol55,
+        new double[55],
+        lj55.getNoOfAtoms(),
+        lj55.getAllCharges(),
+        lj55.getAllSpins(),
+        bonds55,
+        grad55,
+        false);
+
+    assertEquals(ENERGYLJ55, grad55.getTotalEnergy(), NUMACC);
+
+    final double[][] gradient55 = grad55.getTotalGradient();
+
+    double gradTot55 = 0.0;
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 55; j++) gradTot55 += gradient55[i][j];
+    }
+
+    assertEquals(0.0, gradTot55, NUMACC);
+  }
 }

--- a/tests/org/ogolem/core/MixedLJFFTest.java
+++ b/tests/org/ogolem/core/MixedLJFFTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2020-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,240 +36,310 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2020-07-19
+ * @version 2021-07-17
  */
 public class MixedLJFFTest {
-    
-    private static final String LJ38MIN = "38\n" +
-"Energy:            -173.2453\n" +
-"Ar              2.2635080             -1.3021673              0.2364510\n" +
-"Ar             -4.0696589             -1.7833951             -1.0912553\n" +
-"Ar              3.3465963              0.5473776              5.1173994\n" +
-"Ar              4.6352036              2.9641120             -1.9064564\n" +
-"Ar             -5.2396084              1.6412581             -2.1458985\n" +
-"Ar              2.1975346              3.9699958              4.0662786\n" +
-"Ar              2.9139336             -0.1048691             -3.2585750\n" +
-"Ar             -0.1537578             -0.2936708              6.2036580\n" +
-"Ar             -3.5310673              4.6998827             -0.7800296\n" +
-"Ar             -1.8706342             -3.3672049              4.8312587\n" +
-"Ar              3.9770026              1.7439961              1.5989158\n" +
-"Ar              5.1470505             -1.6806710              2.6532521\n" +
-"Ar              0.0611707              0.2542515             -5.6961461\n" +
-"Ar              1.1218741              2.0986964             -0.8081952\n" +
-"Ar             -5.8825641              0.4360893              1.3575178\n" +
-"Ar              1.7779228              3.3278948             -4.3237295\n" +
-"Ar              3.4384866             -4.7393483              1.2876312\n" +
-"Ar              4.0814241             -3.5339516             -2.2157154\n" +
-"Ar              5.7898690             -0.4751665             -0.8500914\n" +
-"Ar             -2.9362859             -5.2206833             -0.0378087\n" +
-"Ar             -1.2145583             -2.1381033              1.3158395\n" +
-"Ar             -4.1741020              3.4946992              2.7233876\n" +
-"Ar              2.8435532              5.1812951              0.5458881\n" +
-"Ar             -0.5757456             -0.9405450             -2.1653462\n" +
-"Ar              1.6313510             -2.5096021              3.7313159\n" +
-"Ar             -1.3028293              3.1289101              5.1523874\n" +
-"Ar             -3.0066453              0.0655822              3.7661092\n" +
-"Ar             -0.0136789              5.5451888             -1.8714567\n" +
-"Ar              0.5682738             -4.3585518             -1.1260230\n" +
-"Ar             -0.6609501              4.3190723              1.6338157\n" +
-"Ar             -2.2902497             -4.0096773             -3.5583525\n" +
-"Ar              0.4831067              0.9010895              2.6729642\n" +
-"Ar             -3.4390998             -0.5870227             -4.6098257\n" +
-"Ar             -2.3561517              1.2627716              0.2711277\n" +
-"Ar             -1.7239135              2.4701423             -3.2237536\n" +
-"Ar             -4.7280805             -3.0031875              2.4141292\n" +
-"Ar              1.2100750             -3.1683730             -4.6446476\n" +
-"Ar             -0.0788494             -5.5846809              2.3792819";
-    
-    private static final String LJ55MIN = "55\n" +
-"Energy:            -278.1517\n" +
-"Ar              0.2637670              0.0750218             -0.0305859\n" +
-"Ar              1.9400511             -5.9359266             -0.2182075\n" +
-"Ar             -3.3887782              5.5878993             -3.0857245\n" +
-"Ar              5.4645827              3.5286603             -0.0164234\n" +
-"Ar             -0.0611506             -6.3446547             -3.4581804\n" +
-"Ar             -4.7623515              2.0139627             -3.1856848\n" +
-"Ar             -2.7311677              1.0755806              5.3550730\n" +
-"Ar              5.1542978             -3.8014196             -0.2095618\n" +
-"Ar             -3.0861314             -3.9969872             -3.3732330\n" +
-"Ar              2.4421399              5.9244352              0.0941955\n" +
-"Ar              0.1530409              0.2714680             -7.3117752\n" +
-"Ar              3.2585466             -0.9253576             -5.4163715\n" +
-"Ar              0.2094058              0.1714695             -3.6056473\n" +
-"Ar              2.2225382              2.7895936             -5.3003453\n" +
-"Ar             -1.6999051             -2.4743290              1.5308355\n" +
-"Ar              6.5888663              1.7386441              3.1775426\n" +
-"Ar              0.4233255              3.2271118              1.6523928\n" +
-"Ar             -1.6951682             -2.6393958              5.2391891\n" +
-"Ar             -2.8418301             -0.7418962             -1.6057981\n" +
-"Ar             -2.7097004              1.1466854              1.6437936\n" +
-"Ar              0.3743391             -0.1213402              7.2505633\n" +
-"Ar              2.0571514             -2.6317879              1.4694758\n" +
-"Ar              3.3693659              0.8918850              1.5446257\n" +
-"Ar              3.9163409             -5.4378330              3.0245237\n" +
-"Ar             -1.4124661              6.0859683              0.1570572\n" +
-"Ar              0.4832106              3.2099543              5.3639202\n" +
-"Ar             -5.9730344              0.3363606              0.0711651\n" +
-"Ar             -4.6268008              3.9515551              0.1482164\n" +
-"Ar             -2.6231431              4.4083720              3.4138865\n" +
-"Ar             -2.9781957             -0.6641526             -5.3145255\n" +
-"Ar              4.2630175              5.2673226             -3.2106167\n" +
-"Ar             -1.9145285             -5.7743746             -0.1552363\n" +
-"Ar             -4.9370769             -3.3786155             -0.0447196\n" +
-"Ar             -6.0612815             -1.5887397             -3.2387501\n" +
-"Ar             -1.5296300              2.7818574             -1.5306798\n" +
-"Ar             -3.7355675             -5.1171473              3.1495165\n" +
-"Ar              0.4384309              5.4677007             -3.1714606\n" +
-"Ar              5.3289109              1.5912421             -3.3504794\n" +
-"Ar              0.0890783             -5.3175663              3.1103721\n" +
-"Ar             -4.8014991             -1.4410447              3.2891758\n" +
-"Ar             -1.6319388              2.9510461             -5.2374343\n" +
-"Ar              5.2899358             -1.8640178              3.1244180\n" +
-"Ar             -5.7921455              2.2576283              3.3795587\n" +
-"Ar              3.2371665             -0.9965492             -1.7050608\n" +
-"Ar              0.0442854             -3.0598980             -5.4250516\n" +
-"Ar              3.6137059              4.1469046              3.3121847\n" +
-"Ar              0.3180569             -0.0213815              3.5444697\n" +
-"Ar              2.1594096             -2.8009554              5.1762327\n" +
-"Ar              0.5887912              6.4946966              3.3970661\n" +
-"Ar              0.1042463             -3.0770498             -1.7135232\n" +
-"Ar              6.3195618             -2.1073732             -3.4409865\n" +
-"Ar              2.2274111              2.6244358             -1.5919829\n" +
-"Ar              3.5057247              0.8140948              5.2533412\n" +
-"Ar              3.1506760             -4.2582346             -3.4751765\n" +
-"Ar              6.5005124             -0.1862658             -0.1324787";
-    
-    private static final double ENERGYLJ38 = -0.0659856619926505;
-    private static final double ENERGYLJ55 = -0.10594240151944964;
-    private static final double NUMACC = 1.0e-8;
-    
-    @Test
-    public void testEnergyCalculationLJMins() {
-        
-        final int[] atsPerMol38 = new int[38];
-        for(int i = 0; i < 38; i++){
-            atsPerMol38[i] = 1;
-        }
-        
-        final int[] atsPerMol55 = new int[55];
-        for(int i = 0; i < 55; i++){
-            atsPerMol55[i] = 1;
-        }
-        
-        CartesianCoordinates lj38 = null;
-        CartesianCoordinates lj55 = null;
-        try {
-            final String[] fileCont38 = LJ38MIN.split("\n");
-            lj38 = Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
-        
-            final String[] fileCont55 = LJ55MIN.split("\n");
-            lj55 = Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
-        } catch(Exception e){
-           fail(e.toString());
-        }
 
-        final BondInfo bonds38 = new SimpleBondInfo(38);
-        final BondInfo bonds55 = new SimpleBondInfo(55);
-        
-        final MixedLJForceField ljFF = new MixedLJForceField(true);
-       
-        final double e38 = ljFF.energyCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38, false);
-        
-        assertEquals(ENERGYLJ38, e38, NUMACC);
-        
-        final double e38_2 = ljFF.energyCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38, false);
-        
-        assertEquals(ENERGYLJ38, e38_2, NUMACC);
-        
-        final MixedLJForceField ljFF2 = new MixedLJForceField(true);
-        
-        final double e55 = ljFF2.energyCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55, false);
-        
-        assertEquals(ENERGYLJ55, e55, NUMACC);
-        
-        final double e55_2 = ljFF2.energyCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55, false);
-        
-        assertEquals(ENERGYLJ55, e55_2, NUMACC);
+  private static final String LJ38MIN =
+      "38\n"
+          + "Energy:            -173.2453\n"
+          + "Ar              2.2635080             -1.3021673              0.2364510\n"
+          + "Ar             -4.0696589             -1.7833951             -1.0912553\n"
+          + "Ar              3.3465963              0.5473776              5.1173994\n"
+          + "Ar              4.6352036              2.9641120             -1.9064564\n"
+          + "Ar             -5.2396084              1.6412581             -2.1458985\n"
+          + "Ar              2.1975346              3.9699958              4.0662786\n"
+          + "Ar              2.9139336             -0.1048691             -3.2585750\n"
+          + "Ar             -0.1537578             -0.2936708              6.2036580\n"
+          + "Ar             -3.5310673              4.6998827             -0.7800296\n"
+          + "Ar             -1.8706342             -3.3672049              4.8312587\n"
+          + "Ar              3.9770026              1.7439961              1.5989158\n"
+          + "Ar              5.1470505             -1.6806710              2.6532521\n"
+          + "Ar              0.0611707              0.2542515             -5.6961461\n"
+          + "Ar              1.1218741              2.0986964             -0.8081952\n"
+          + "Ar             -5.8825641              0.4360893              1.3575178\n"
+          + "Ar              1.7779228              3.3278948             -4.3237295\n"
+          + "Ar              3.4384866             -4.7393483              1.2876312\n"
+          + "Ar              4.0814241             -3.5339516             -2.2157154\n"
+          + "Ar              5.7898690             -0.4751665             -0.8500914\n"
+          + "Ar             -2.9362859             -5.2206833             -0.0378087\n"
+          + "Ar             -1.2145583             -2.1381033              1.3158395\n"
+          + "Ar             -4.1741020              3.4946992              2.7233876\n"
+          + "Ar              2.8435532              5.1812951              0.5458881\n"
+          + "Ar             -0.5757456             -0.9405450             -2.1653462\n"
+          + "Ar              1.6313510             -2.5096021              3.7313159\n"
+          + "Ar             -1.3028293              3.1289101              5.1523874\n"
+          + "Ar             -3.0066453              0.0655822              3.7661092\n"
+          + "Ar             -0.0136789              5.5451888             -1.8714567\n"
+          + "Ar              0.5682738             -4.3585518             -1.1260230\n"
+          + "Ar             -0.6609501              4.3190723              1.6338157\n"
+          + "Ar             -2.2902497             -4.0096773             -3.5583525\n"
+          + "Ar              0.4831067              0.9010895              2.6729642\n"
+          + "Ar             -3.4390998             -0.5870227             -4.6098257\n"
+          + "Ar             -2.3561517              1.2627716              0.2711277\n"
+          + "Ar             -1.7239135              2.4701423             -3.2237536\n"
+          + "Ar             -4.7280805             -3.0031875              2.4141292\n"
+          + "Ar              1.2100750             -3.1683730             -4.6446476\n"
+          + "Ar             -0.0788494             -5.5846809              2.3792819";
+
+  private static final String LJ55MIN =
+      "55\n"
+          + "Energy:            -278.1517\n"
+          + "Ar              0.2637670              0.0750218             -0.0305859\n"
+          + "Ar              1.9400511             -5.9359266             -0.2182075\n"
+          + "Ar             -3.3887782              5.5878993             -3.0857245\n"
+          + "Ar              5.4645827              3.5286603             -0.0164234\n"
+          + "Ar             -0.0611506             -6.3446547             -3.4581804\n"
+          + "Ar             -4.7623515              2.0139627             -3.1856848\n"
+          + "Ar             -2.7311677              1.0755806              5.3550730\n"
+          + "Ar              5.1542978             -3.8014196             -0.2095618\n"
+          + "Ar             -3.0861314             -3.9969872             -3.3732330\n"
+          + "Ar              2.4421399              5.9244352              0.0941955\n"
+          + "Ar              0.1530409              0.2714680             -7.3117752\n"
+          + "Ar              3.2585466             -0.9253576             -5.4163715\n"
+          + "Ar              0.2094058              0.1714695             -3.6056473\n"
+          + "Ar              2.2225382              2.7895936             -5.3003453\n"
+          + "Ar             -1.6999051             -2.4743290              1.5308355\n"
+          + "Ar              6.5888663              1.7386441              3.1775426\n"
+          + "Ar              0.4233255              3.2271118              1.6523928\n"
+          + "Ar             -1.6951682             -2.6393958              5.2391891\n"
+          + "Ar             -2.8418301             -0.7418962             -1.6057981\n"
+          + "Ar             -2.7097004              1.1466854              1.6437936\n"
+          + "Ar              0.3743391             -0.1213402              7.2505633\n"
+          + "Ar              2.0571514             -2.6317879              1.4694758\n"
+          + "Ar              3.3693659              0.8918850              1.5446257\n"
+          + "Ar              3.9163409             -5.4378330              3.0245237\n"
+          + "Ar             -1.4124661              6.0859683              0.1570572\n"
+          + "Ar              0.4832106              3.2099543              5.3639202\n"
+          + "Ar             -5.9730344              0.3363606              0.0711651\n"
+          + "Ar             -4.6268008              3.9515551              0.1482164\n"
+          + "Ar             -2.6231431              4.4083720              3.4138865\n"
+          + "Ar             -2.9781957             -0.6641526             -5.3145255\n"
+          + "Ar              4.2630175              5.2673226             -3.2106167\n"
+          + "Ar             -1.9145285             -5.7743746             -0.1552363\n"
+          + "Ar             -4.9370769             -3.3786155             -0.0447196\n"
+          + "Ar             -6.0612815             -1.5887397             -3.2387501\n"
+          + "Ar             -1.5296300              2.7818574             -1.5306798\n"
+          + "Ar             -3.7355675             -5.1171473              3.1495165\n"
+          + "Ar              0.4384309              5.4677007             -3.1714606\n"
+          + "Ar              5.3289109              1.5912421             -3.3504794\n"
+          + "Ar              0.0890783             -5.3175663              3.1103721\n"
+          + "Ar             -4.8014991             -1.4410447              3.2891758\n"
+          + "Ar             -1.6319388              2.9510461             -5.2374343\n"
+          + "Ar              5.2899358             -1.8640178              3.1244180\n"
+          + "Ar             -5.7921455              2.2576283              3.3795587\n"
+          + "Ar              3.2371665             -0.9965492             -1.7050608\n"
+          + "Ar              0.0442854             -3.0598980             -5.4250516\n"
+          + "Ar              3.6137059              4.1469046              3.3121847\n"
+          + "Ar              0.3180569             -0.0213815              3.5444697\n"
+          + "Ar              2.1594096             -2.8009554              5.1762327\n"
+          + "Ar              0.5887912              6.4946966              3.3970661\n"
+          + "Ar              0.1042463             -3.0770498             -1.7135232\n"
+          + "Ar              6.3195618             -2.1073732             -3.4409865\n"
+          + "Ar              2.2274111              2.6244358             -1.5919829\n"
+          + "Ar              3.5057247              0.8140948              5.2533412\n"
+          + "Ar              3.1506760             -4.2582346             -3.4751765\n"
+          + "Ar              6.5005124             -0.1862658             -0.1324787";
+
+  private static final double ENERGYLJ38 = -0.0659856619926505;
+  private static final double ENERGYLJ55 = -0.10594240151944964;
+  private static final double NUMACC = 1.0e-8;
+
+  @Test
+  public void testEnergyCalculationLJMins() {
+
+    final int[] atsPerMol38 = new int[38];
+    for (int i = 0; i < 38; i++) {
+      atsPerMol38[i] = 1;
     }
-    
-    @Test
-    public void testGradientCalculationLJMins() {
-        
-        final int[] atsPerMol38 = new int[38];
-        for(int i = 0; i < 38; i++){
-            atsPerMol38[i] = 1;
-        }
-        
-        final int[] atsPerMol55 = new int[55];
-        for(int i = 0; i < 55; i++){
-            atsPerMol55[i] = 1;
-        }
-        
-        CartesianCoordinates lj38 = null;
-        CartesianCoordinates lj55 = null;
-        try {
-            final String[] fileCont38 = LJ38MIN.split("\n");
-            lj38 = Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
-        
-            final String[] fileCont55 = LJ55MIN.split("\n");
-            lj55 = Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
-        } catch(Exception e){
-           fail(e.toString());
-        }
 
-        final BondInfo bonds38 = new SimpleBondInfo(38);
-        final BondInfo bonds55 = new SimpleBondInfo(55);
-        
-        final MixedLJForceField ljFF = new MixedLJForceField(true);
-       
-        final Gradient grad38 = new Gradient(3, 38);
-        ljFF.gradientCalculation(-1, 0, lj38.getAll1DCartes(),
-                lj38.getAllAtomTypes(), lj38.getAllAtomNumbers(), atsPerMol38, new double[38],
-                lj38.getNoOfAtoms(), lj38.getAllCharges(), lj38.getAllSpins(), bonds38,
-                grad38, false);
-        
-        assertEquals(ENERGYLJ38, grad38.getTotalEnergy(), NUMACC);
-        
-        final double[][] gradient38 = grad38.getTotalGradient();
-        
-        double gradTot38 = 0.0;
-        for(int i = 0; i < 3; i++){
-            for(int j = 0; j < 38; j++) gradTot38 += gradient38[i][j];
-        }
-        
-        assertEquals(0.0, gradTot38, NUMACC);
-        
-        final MixedLJForceField ljFF2 = new MixedLJForceField(true);
-        
-        final Gradient grad55 = new Gradient(3, 55);
-        ljFF2.gradientCalculation(-1, 0, lj55.getAll1DCartes(),
-                lj55.getAllAtomTypes(), lj55.getAllAtomNumbers(), atsPerMol55, new double[55],
-                lj55.getNoOfAtoms(), lj55.getAllCharges(), lj55.getAllSpins(), bonds55,
-                grad55, false);
-        
-        assertEquals(ENERGYLJ55, grad55.getTotalEnergy(), NUMACC);
-        
-        final double[][] gradient55 = grad55.getTotalGradient();
-        
-        double gradTot55 = 0.0;
-        for(int i = 0; i < 3; i++){
-            for(int j = 0; j < 55; j++) gradTot55 += gradient55[i][j];
-        }
-        
-        assertEquals(0.0, gradTot55, NUMACC);
-    }    
+    final int[] atsPerMol55 = new int[55];
+    for (int i = 0; i < 55; i++) {
+      atsPerMol55[i] = 1;
+    }
+
+    CartesianCoordinates lj38 = null;
+    CartesianCoordinates lj55 = null;
+    try {
+      final String[] fileCont38 = LJ38MIN.split("\n");
+      lj38 =
+          Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
+
+      final String[] fileCont55 = LJ55MIN.split("\n");
+      lj55 =
+          Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+
+    final BondInfo bonds38 = new SimpleBondInfo(38);
+    final BondInfo bonds55 = new SimpleBondInfo(55);
+
+    final MixedLJForceField ljFF = new MixedLJForceField(true);
+
+    final double e38 =
+        ljFF.energyCalculation(
+            -1,
+            0,
+            lj38.getAll1DCartes(),
+            lj38.getAllAtomTypes(),
+            lj38.getAllAtomNumbers(),
+            atsPerMol38,
+            new double[38],
+            lj38.getNoOfAtoms(),
+            lj38.getAllCharges(),
+            lj38.getAllSpins(),
+            bonds38,
+            false);
+
+    assertEquals(ENERGYLJ38, e38, NUMACC);
+
+    final double e38_2 =
+        ljFF.energyCalculation(
+            -1,
+            0,
+            lj38.getAll1DCartes(),
+            lj38.getAllAtomTypes(),
+            lj38.getAllAtomNumbers(),
+            atsPerMol38,
+            new double[38],
+            lj38.getNoOfAtoms(),
+            lj38.getAllCharges(),
+            lj38.getAllSpins(),
+            bonds38,
+            false);
+
+    assertEquals(ENERGYLJ38, e38_2, NUMACC);
+
+    final MixedLJForceField ljFF2 = new MixedLJForceField(true);
+
+    final double e55 =
+        ljFF2.energyCalculation(
+            -1,
+            0,
+            lj55.getAll1DCartes(),
+            lj55.getAllAtomTypes(),
+            lj55.getAllAtomNumbers(),
+            atsPerMol55,
+            new double[55],
+            lj55.getNoOfAtoms(),
+            lj55.getAllCharges(),
+            lj55.getAllSpins(),
+            bonds55,
+            false);
+
+    assertEquals(ENERGYLJ55, e55, NUMACC);
+
+    final double e55_2 =
+        ljFF2.energyCalculation(
+            -1,
+            0,
+            lj55.getAll1DCartes(),
+            lj55.getAllAtomTypes(),
+            lj55.getAllAtomNumbers(),
+            atsPerMol55,
+            new double[55],
+            lj55.getNoOfAtoms(),
+            lj55.getAllCharges(),
+            lj55.getAllSpins(),
+            bonds55,
+            false);
+
+    assertEquals(ENERGYLJ55, e55_2, NUMACC);
+  }
+
+  @Test
+  public void testGradientCalculationLJMins() {
+
+    final int[] atsPerMol38 = new int[38];
+    for (int i = 0; i < 38; i++) {
+      atsPerMol38[i] = 1;
+    }
+
+    final int[] atsPerMol55 = new int[55];
+    for (int i = 0; i < 55; i++) {
+      atsPerMol55[i] = 1;
+    }
+
+    CartesianCoordinates lj38 = null;
+    CartesianCoordinates lj55 = null;
+    try {
+      final String[] fileCont38 = LJ38MIN.split("\n");
+      lj38 =
+          Input.parseCartesFromFileData(fileCont38, 38, atsPerMol38, new short[38], new float[38]);
+
+      final String[] fileCont55 = LJ55MIN.split("\n");
+      lj55 =
+          Input.parseCartesFromFileData(fileCont55, 55, atsPerMol55, new short[55], new float[55]);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+
+    final BondInfo bonds38 = new SimpleBondInfo(38);
+    final BondInfo bonds55 = new SimpleBondInfo(55);
+
+    final MixedLJForceField ljFF = new MixedLJForceField(true);
+
+    final Gradient grad38 = new Gradient(3, 38);
+    ljFF.gradientCalculation(
+        -1,
+        0,
+        lj38.getAll1DCartes(),
+        lj38.getAllAtomTypes(),
+        lj38.getAllAtomNumbers(),
+        atsPerMol38,
+        new double[38],
+        lj38.getNoOfAtoms(),
+        lj38.getAllCharges(),
+        lj38.getAllSpins(),
+        bonds38,
+        grad38,
+        false);
+
+    assertEquals(ENERGYLJ38, grad38.getTotalEnergy(), NUMACC);
+
+    final double[][] gradient38 = grad38.getTotalGradient();
+
+    double gradTot38 = 0.0;
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 38; j++) gradTot38 += gradient38[i][j];
+    }
+
+    assertEquals(0.0, gradTot38, NUMACC);
+
+    final MixedLJForceField ljFF2 = new MixedLJForceField(true);
+
+    final Gradient grad55 = new Gradient(3, 55);
+    ljFF2.gradientCalculation(
+        -1,
+        0,
+        lj55.getAll1DCartes(),
+        lj55.getAllAtomTypes(),
+        lj55.getAllAtomNumbers(),
+        atsPerMol55,
+        new double[55],
+        lj55.getNoOfAtoms(),
+        lj55.getAllCharges(),
+        lj55.getAllSpins(),
+        bonds55,
+        grad55,
+        false);
+
+    assertEquals(ENERGYLJ55, grad55.getTotalEnergy(), NUMACC);
+
+    final double[][] gradient55 = grad55.getTotalGradient();
+
+    double gradTot55 = 0.0;
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 55; j++) gradTot55 += gradient55[i][j];
+    }
+
+    assertEquals(0.0, gradTot55, NUMACC);
+  }
 }

--- a/tests/org/ogolem/core/MoleculeUntanglerTest.java
+++ b/tests/org/ogolem/core/MoleculeUntanglerTest.java
@@ -1,110 +1,123 @@
-/**
- Copyright (c) 2020, D. Behrens, J. M. Dieterich, B. Hartke
- All rights reserved.
+/*
+Copyright (c) 2020-2021, D. Behrens, J. M. Dieterich, B. Hartke
+All rights reserved.
 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
 
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
 
- * Neither the name of the copyright holder nor the names of its
- contributors may be used to endorse or promote products derived from
- this software without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 package org.ogolem.core;
 
-import org.junit.Test;
-import static org.junit.Assert.*;
-import org.ogolem.locopt.LBFGSLocOpt;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.ogolem.locopt.LBFGSLocOpt;
 
 /**
- * A simple test for the Untangler. For now, it simply runs through the methods and uses the Untangler in a very
- * simple L-BFGS Locopt, just to make sure everything runs smoothly. No benchmarking here.
+ * A simple test for the Untangler. For now, it simply runs through the methods and uses the
+ * Untangler in a very simple L-BFGS Locopt, just to make sure everything runs smoothly. No
+ * benchmarking here.
  */
 public class MoleculeUntanglerTest {
-    @Test
-    public void testTerms() {
-        MoleculeUntangler instance = new MoleculeUntangler(1.0, true);
+  @Test
+  public void testTerms() {
+    MoleculeUntangler instance = new MoleculeUntangler(1.0, true);
 
-        double[][] distances = new double[3][];
-        // Three corner cases using 1-atom molecules
-        //  * The atoms are exceptionally close (same coordinates in double precision)
-        distances[0] = new double[]{0, 0, 0, 0, 0, 0};
-        //  * The atoms are in between lower and upper limits
-        distances[1] = new double[]{0, 5, 0, 0, 0, 0};
-        //  * The atoms are within summedRadius distance
-        distances[2] = new double[]{0, 5.14 * Constants.ANGTOBOHR, 0, 0, 0, 0};
+    double[][] distances = new double[3][];
+    // Three corner cases using 1-atom molecules
+    //  * The atoms are exceptionally close (same coordinates in double precision)
+    distances[0] = new double[] {0, 0, 0, 0, 0, 0};
+    //  * The atoms are in between lower and upper limits
+    distances[1] = new double[] {0, 5, 0, 0, 0, 0};
+    //  * The atoms are within summedRadius distance
+    distances[2] = new double[] {0, 5.14 * Constants.ANGTOBOHR, 0, 0, 0, 0};
 
-        // Expected Values
-        double[] energies = new double[3];
-        double[] gradx = new double[3];
-        energies[0] = 1.9999999999221;
-        energies[1] = 1.1922724326284E-4;
-        energies[2] = 0;
-        gradx[0] = 7.78210116701E-6;
-        gradx[1] = 2.3195961724288E-4;
-        gradx[2] = 0;
+    // Expected Values
+    double[] energies = new double[3];
+    double[] gradx = new double[3];
+    energies[0] = 1.9999999999221;
+    energies[1] = 1.1922724326284E-4;
+    energies[2] = 0;
+    gradx[0] = 7.78210116701E-6;
+    gradx[1] = 2.3195961724288E-4;
+    gradx[2] = 0;
 
-        // Basic stuff we'll need to call the methods
-        int noOfAtoms = 2;
-        int[] atsPerMol = new int[]{1, 1};
-        // Two gold atoms
-        short[] atomNos = new short[]{(short) 79, (short) 79};
+    // Basic stuff we'll need to call the methods
+    int noOfAtoms = 2;
+    int[] atsPerMol = new int[] {1, 1};
+    // Two gold atoms
+    short[] atomNos = new short[] {(short) 79, (short) 79};
 
-        for (int i = 0; i < 3; i++) {
-            Gradient grad = new Gradient(3, noOfAtoms);
-            instance.gradientCalculation(0, 42, distances[i], null, atomNos, atsPerMol, null, noOfAtoms,
-                    null, null, null, grad, false);
-            assertEquals(energies[i], grad.getTotalEnergy(), 1e-12);
-            assertEquals(gradx[i], grad.getGradient()[0], 1e-12);
-        }
+    for (int i = 0; i < 3; i++) {
+      Gradient grad = new Gradient(3, noOfAtoms);
+      instance.gradientCalculation(
+          0,
+          42,
+          distances[i],
+          null,
+          atomNos,
+          atsPerMol,
+          null,
+          noOfAtoms,
+          null,
+          null,
+          null,
+          grad,
+          false);
+      assertEquals(energies[i], grad.getTotalEnergy(), 1e-12);
+      assertEquals(gradx[i], grad.getGradient()[0], 1e-12);
     }
+  }
 
-    @Test
-    public void testLocOpt() {
-        // Build an actual example using an OGOLEM-style locopt cycle.
-        MoleculeUntangler untangler = new MoleculeUntangler(1.0, true);
+  @Test
+  public void testLocOpt() {
+    // Build an actual example using an OGOLEM-style locopt cycle.
+    MoleculeUntangler untangler = new MoleculeUntangler(1.0, true);
 
-        CartesianCoordinates coords = new CartesianCoordinates(1, 1, new int[]{1});
-        coords.setAllAtomTypes(new String[]{"Au"});
-        coords.setAtomNumbers(new short[]{(short) 79});
+    CartesianCoordinates coords = new CartesianCoordinates(1, 1, new int[] {1});
+    coords.setAllAtomTypes(new String[] {"Au"});
+    coords.setAtomNumbers(new short[] {(short) 79});
 
-        Molecule mol1 = new Molecule(coords, 0, "au0");
-        Molecule mol2 = new Molecule(coords, 1, "au1");
-        Molecule mol3 = new Molecule(coords, 2, "au2");
-        mol3.setExternalCenterOfMass(0, 5.14 * Constants.ANGTOBOHR, 0);
-        GeometryConfig gc = new GeometryConfig();
-        gc.geomMCs = new ArrayList<>();
-        gc.geomMCs.add(mol1.returnMyConfig());
-        gc.geomMCs.add(mol2.returnMyConfig());
-        gc.geomMCs.add(mol3.returnMyConfig());
-        gc.bonds = new SimpleBondInfo(3);
-        gc.noOfParticles = 3;
-        Geometry geom = new Geometry(gc);
+    Molecule mol1 = new Molecule(coords, 0, "au0");
+    Molecule mol2 = new Molecule(coords, 1, "au1");
+    Molecule mol3 = new Molecule(coords, 2, "au2");
+    mol3.setExternalCenterOfMass(0, 5.14 * Constants.ANGTOBOHR, 0);
+    GeometryConfig gc = new GeometryConfig();
+    gc.geomMCs = new ArrayList<>();
+    gc.geomMCs.add(mol1.returnMyConfig());
+    gc.geomMCs.add(mol2.returnMyConfig());
+    gc.geomMCs.add(mol3.returnMyConfig());
+    gc.bonds = new SimpleBondInfo(3);
+    gc.noOfParticles = 3;
+    Geometry geom = new Geometry(gc);
 
-        FullyCartesianCoordinates xyz = new FullyCartesianCoordinates(untangler);
-        LBFGSLocOpt<Molecule, Geometry> LocOpt = new LBFGSLocOpt<>(xyz, 7, 400, 1e-15, 0.9, 50, 0);
-        Geometry opt = LocOpt.fitness(geom, false);
+    FullyCartesianCoordinates xyz = new FullyCartesianCoordinates(untangler);
+    LBFGSLocOpt<Molecule, Geometry> LocOpt = new LBFGSLocOpt<>(xyz, 7, 400, 1e-15, 0.9, 50, 0);
+    Geometry opt = LocOpt.fitness(geom, false);
 
-        // Just make sure the L-BFGS converged fine.
-        assert (opt.getFitness() < 1e-14);
-    }
+    // Just make sure the L-BFGS converged fine.
+    assert (opt.getFitness() < 1e-14);
+  }
 }

--- a/tests/org/ogolem/core/RigidBodyCoordinatesTest.java
+++ b/tests/org/ogolem/core/RigidBodyCoordinatesTest.java
@@ -1,6 +1,6 @@
-/**
+/*
 Copyright (c) 2014-2015, J. M. Dieterich
-              2016-2020, J. M. Dieterich and B. Hartke
+              2016-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,1040 +37,1415 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.ogolem.core.Constants.ANGTOBOHR;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
 /**
- *
  * @author Johannes Dieterich
- * @version 2020-04-29
+ * @version 2021-07-17
  */
 public class RigidBodyCoordinatesTest {
-    
-    private static final double NUMACC = 1e-6;
-    private static final double NUMACCLOOSE = 1e-4;
-    private final Geometry gWaterWrong;
-    private final Geometry gWater2;
-    private final Geometry gWater2Distorted;
-    private final Geometry gWater20;
-    private final TIP3PForceField tip3p = new TIP3PForceField();
-    private final TIP4PForceField tip4p = new TIP4PForceField();
-    private final RigidBodyCoordinates rigidEmpt;
-    private final RigidBodyCoordinates rigidW2TIP3P;
-    private final RigidBodyCoordinates rigidW2DisTIP3P;
-    private final RigidBodyCoordinates rigidW20TIP3P;
-    private final RigidBodyCoordinates rigidW2TIP4P;
-    private final RigidBodyCoordinates rigidW2DisTIP4P;
-    private final RigidBodyCoordinates rigidW20TIP4P;
-    private final double[] gradW2Phenix = new double[]{
-            -2.49299292E-09,
-            -1.74202093E-08,
-            1.09019958E-08,
-            -1.00777087E-09, // ATTENTION, PHENIX Euler definition different!
-            3.99753608E-09, // ATTENTION, PHENIX Euler definition different!
-            -1.47489343E-09, // ATTENTION, PHENIX Euler definition different!
-            2.49299292E-09,
-            1.74202093E-08,
-            -1.09019958E-08,
-            -4.38705738E-10, // ATTENTION, PHENIX Euler definition different!
-            2.52028243E-09, // ATTENTION, PHENIX Euler definition different!
-            4.31826158E-10 // ATTENTION, PHENIX Euler definition different!
-        };
-    private final double[] gradW2DisPhenix = new double[]{
-            -4.61163116E-04,
-            -1.06346468E-03,
-             3.18424893E-04,
-             2.27286480E-03, // ATTENTION, PHENIX Euler definition different!
-            -1.51189405E-03, // ATTENTION, PHENIX Euler definition different!
-            -1.47368794E-03, // ATTENTION, PHENIX Euler definition different!
-            4.61163116E-04,
-            1.06346468E-03,
-            -3.18424893E-04,
-            -9.05349967E-04, // ATTENTION, PHENIX Euler definition different!
-            5.10955811E-04, // ATTENTION, PHENIX Euler definition different!
-            -1.25210837E-03 // ATTENTION, PHENIX Euler definition different!
-        };
-    
 
-    
-    public RigidBodyCoordinatesTest(){
-        // build a few test geometries...
-        this.gWater2 = getWater2TIP4P();
-        this.gWater2Distorted = getWater2TIP4PDistorted();
-        this.gWater20 = getWater20TIP4P();
-        this.gWaterWrong = getNoWaterTIP4P();
-        this.rigidEmpt = new RigidBodyCoordinates(tip4p);
-        this.rigidW2TIP3P = new RigidBodyCoordinates(tip3p);
-        this.rigidW2DisTIP3P = new RigidBodyCoordinates(tip3p);
-        this.rigidW20TIP3P = new RigidBodyCoordinates(tip3p);
-        this.rigidW2TIP4P = new RigidBodyCoordinates(tip4p);
-        this.rigidW2DisTIP4P = new RigidBodyCoordinates(tip4p);
-        this.rigidW20TIP4P = new RigidBodyCoordinates(tip4p);
+  private static final double NUMACC = 1e-6;
+  private static final double NUMACCLOOSE = 1e-4;
+  private final Geometry gWaterWrong;
+  private final Geometry gWater2;
+  private final Geometry gWater2Distorted;
+  private final Geometry gWater20;
+  private final TIP3PForceField tip3p = new TIP3PForceField();
+  private final TIP4PForceField tip4p = new TIP4PForceField();
+  private final RigidBodyCoordinates rigidEmpt;
+  private final RigidBodyCoordinates rigidW2TIP3P;
+  private final RigidBodyCoordinates rigidW2DisTIP3P;
+  private final RigidBodyCoordinates rigidW20TIP3P;
+  private final RigidBodyCoordinates rigidW2TIP4P;
+  private final RigidBodyCoordinates rigidW2DisTIP4P;
+  private final RigidBodyCoordinates rigidW20TIP4P;
+  private final double[] gradW2Phenix =
+      new double[] {
+        -2.49299292E-09,
+        -1.74202093E-08,
+        1.09019958E-08,
+        -1.00777087E-09, // ATTENTION, PHENIX Euler definition different!
+        3.99753608E-09, // ATTENTION, PHENIX Euler definition different!
+        -1.47489343E-09, // ATTENTION, PHENIX Euler definition different!
+        2.49299292E-09,
+        1.74202093E-08,
+        -1.09019958E-08,
+        -4.38705738E-10, // ATTENTION, PHENIX Euler definition different!
+        2.52028243E-09, // ATTENTION, PHENIX Euler definition different!
+        4.31826158E-10 // ATTENTION, PHENIX Euler definition different!
+      };
+  private final double[] gradW2DisPhenix =
+      new double[] {
+        -4.61163116E-04,
+        -1.06346468E-03,
+        3.18424893E-04,
+        2.27286480E-03, // ATTENTION, PHENIX Euler definition different!
+        -1.51189405E-03, // ATTENTION, PHENIX Euler definition different!
+        -1.47368794E-03, // ATTENTION, PHENIX Euler definition different!
+        4.61163116E-04,
+        1.06346468E-03,
+        -3.18424893E-04,
+        -9.05349967E-04, // ATTENTION, PHENIX Euler definition different!
+        5.10955811E-04, // ATTENTION, PHENIX Euler definition different!
+        -1.25210837E-03 // ATTENTION, PHENIX Euler definition different!
+      };
+
+  public RigidBodyCoordinatesTest() {
+    // build a few test geometries...
+    this.gWater2 = getWater2TIP4P();
+    this.gWater2Distorted = getWater2TIP4PDistorted();
+    this.gWater20 = getWater20TIP4P();
+    this.gWaterWrong = getNoWaterTIP4P();
+    this.rigidEmpt = new RigidBodyCoordinates(tip4p);
+    this.rigidW2TIP3P = new RigidBodyCoordinates(tip3p);
+    this.rigidW2DisTIP3P = new RigidBodyCoordinates(tip3p);
+    this.rigidW20TIP3P = new RigidBodyCoordinates(tip3p);
+    this.rigidW2TIP4P = new RigidBodyCoordinates(tip4p);
+    this.rigidW2DisTIP4P = new RigidBodyCoordinates(tip4p);
+    this.rigidW20TIP4P = new RigidBodyCoordinates(tip4p);
+  }
+
+  /** Test of numberOfActiveCoordinates method, of class RigidBodyCoordinates. */
+  @Test
+  public void testNumberOfActiveCoordinates() {
+    System.out.println("numberOfActiveCoordinates");
+
+    // should be empty
+    final int expResEmpty = 0;
+    final int resEmpty = rigidEmpt.numberOfActiveCoordinates(gWaterWrong);
+    assertEquals(expResEmpty, resEmpty);
+
+    // should be 12 and 120, respectively
+    final int expResW2 = 12;
+    final int expResW20 = 120;
+    final int resW2 = rigidW2TIP4P.numberOfActiveCoordinates(gWater2);
+    final int resW20 = rigidW2TIP4P.numberOfActiveCoordinates(gWater20);
+    assertEquals(expResW2, resW2);
+    assertEquals(expResW20, resW20);
+  }
+
+  /** Test of getActiveCoordinates method, of class RigidBodyCoordinates. */
+  @Test
+  public void testGetActiveCoordinates() {
+    System.out.println("getActiveCoordinates");
+    // basically just checks if we get arrays of proper length back, can certainly be extended
+    // should be 12 and 120, respectively
+    final int expResW2 = 12;
+    final int expResW20 = 120;
+    final int resW2 = rigidW2TIP4P.getActiveCoordinates(gWater2).length;
+    final int resW20 = rigidW2TIP4P.getActiveCoordinates(gWater20).length;
+    assertEquals(expResW2, resW2);
+    assertEquals(expResW20, resW20);
+  }
+
+  /** Test of updateActiveCoordinates method, of class RigidBodyCoordinates. */
+  /*@Test
+  public void testUpdateActiveCoordinates() {
+      System.out.println("updateActiveCoordinates");
+
+      // required to initialize..
+      rigidW2TIP4P.getActiveCoordinates(gWater2.clone());
+
+      // again, very basic...
+      final Geometry g2Work = gWater2.clone();
+      final double[] comEuler = new double[12];
+      rigidW2TIP4P.updateActiveCoordinates(g2Work, comEuler);
+
+      // check if they are all zero
+      final double[] extCOM = g2Work.getAllExtCoords();
+      for(int i = 0; i < 12; i++){
+          assertEquals(0.0,extCOM[i],1e-10);
+      }
+
+      // put some random ones in
+      final Random r = new Random();
+      for(int i = 0; i < 12; i++){
+          comEuler[i] = (r.nextBoolean()) ? r.nextDouble() : -r.nextDouble(); // will work even with the Eulers
+      }
+
+      rigidW2TIP4P.updateActiveCoordinates(g2Work, comEuler);
+
+      // check if they are all the same
+      final double[] extCOMRand = g2Work.getAllExtCoords();
+      for(int i = 0; i < 12; i++){
+
+          //TODO since the rigidify fix this will need to be compared more... intricately...
+          assertEquals(comEuler[i],extCOMRand[i],1e-10);
+      }
+  }*/
+
+  /** Test of fitness method, of class RigidBodyCoordinates. */
+  @Test
+  public void testFitness_doubleArr_int() {
+    System.out.println("fitness");
+
+    // make sure that w2 and w20 have the right energy
+    final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
+    final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
+
+    final double e2 = rigidW2TIP4P.fitness(extCoord2, 0);
+    final double e20 = rigidW20TIP4P.fitness(extCoord20, 0);
+
+    // from DJW
+    final double expResult2 = -0.009936231756023471;
+    final double expResult20 = -0.3325038695132564;
+
+    assertEquals(expResult2, e2, NUMACC);
+    assertEquals(expResult20, e20, NUMACC);
+  }
+
+  /** Test of fitness method, of class RigidBodyCoordinates. */
+  @Test
+  public void testFitness_Geometry_boolean() {
+    System.out.println("fitness");
+
+    // make sure that w2 and w20 have the right energy
+
+    final double e2 = rigidW2TIP4P.fitness(gWater2.copy(), true).getFitness();
+    final double e20 = rigidW20TIP4P.fitness(gWater20.copy(), true).getFitness();
+
+    // from DJW
+    final double expResult2 = -0.009936231756023471;
+    final double expResult20 = -0.3325038695132564;
+
+    assertEquals(expResult2, e2, NUMACC);
+    assertEquals(expResult20, e20, NUMACC);
+  }
+
+  /** Test of gradient method, of class RigidBodyCoordinates. */
+  @Test
+  public void testGradient() {
+    System.out.println("gradient");
+
+    // make sure that w2 and w20 have the right energy and gradient
+    final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
+    final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
+    final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
+
+    final double[] grad2W = new double[6 * 2];
+    final double[] grad2WDis = new double[6 * 2];
+    final double[] grad20W = new double[6 * 20];
+
+    final double e2 = rigidW2TIP4P.gradient(extCoord2, grad2W, 0);
+    final double e2Dis = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDis, 0);
+    final double e20 = rigidW20TIP4P.gradient(extCoord20, grad20W, 0);
+
+    // from DJW
+    final double expResult2 = -0.009936231756023471;
+    final double expResult20 = -0.3325038695132564;
+    // from Phenix
+    final double expResult2Dis = -0.002495066061667801;
+
+    assertEquals(expResult2, e2, NUMACC);
+    assertEquals(expResult2Dis, e2Dis, NUMACC);
+    assertEquals(expResult20, e20, NUMACC);
+
+    // check the gradients vs Bernd's Phenix implementation of TIP4P
+    // and yes, since these are minimum geometries, the gradient elements SHOULD BE very small
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          gradW2Phenix[i],
+          grad2W[i],
+          NUMACCLOOSE,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + gradW2Phenix[i]
+              + " ours "
+              + grad2W[i]
+              + " diff "
+              + Math.abs(gradW2Phenix[i] - grad2W[i]));
     }
-    
-    /**
-     * Test of numberOfActiveCoordinates method, of class RigidBodyCoordinates.
-     */
-    @Test
-    public void testNumberOfActiveCoordinates() {
-        System.out.println("numberOfActiveCoordinates");
 
-        // should be empty
-        final int expResEmpty = 0;
-        final int resEmpty = rigidEmpt.numberOfActiveCoordinates(gWaterWrong);
-        assertEquals(expResEmpty, resEmpty);
-        
-        // should be 12 and 120, respectively
-        final int expResW2 = 12;
-        final int expResW20 = 120;
-        final int resW2 = rigidW2TIP4P.numberOfActiveCoordinates(gWater2);
-        final int resW20 = rigidW2TIP4P.numberOfActiveCoordinates(gWater20);
-        assertEquals(expResW2, resW2);
-        assertEquals(expResW20, resW20);
+    // distorted gradient
+    // only check the translational elements as the rotational ones are different
+    for (int i = 0; i < 3; i++) {
+      assertEquals(
+          gradW2DisPhenix[i],
+          grad2WDis[i],
+          NUMACC,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + gradW2DisPhenix[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(gradW2DisPhenix[i] - grad2WDis[i]));
+    }
+    for (int i = 6; i < 9; i++) {
+      assertEquals(
+          gradW2DisPhenix[i],
+          grad2WDis[i],
+          NUMACC,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + gradW2DisPhenix[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(gradW2DisPhenix[i] - grad2WDis[i]));
     }
 
-    /**
-     * Test of getActiveCoordinates method, of class RigidBodyCoordinates.
-     */
-    @Test
-    public void testGetActiveCoordinates() {
-        System.out.println("getActiveCoordinates");
-        // basically just checks if we get arrays of proper length back, can certainly be extended
-        // should be 12 and 120, respectively
-        final int expResW2 = 12;
-        final int expResW20 = 120;
-        final int resW2 = rigidW2TIP4P.getActiveCoordinates(gWater2).length;
-        final int resW20 = rigidW2TIP4P.getActiveCoordinates(gWater20).length;
-        assertEquals(expResW2, resW2);
-        assertEquals(expResW20, resW20);
+    // don't bother to put in individual elements...
+    for (int i = 0; i < 120; i++) {
+      assertEquals(
+          0.0,
+          grad20W[i],
+          NUMACC,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + 0.0
+              + " ours "
+              + grad20W[i]
+              + " diff "
+              + Math.abs(grad20W[i]));
+    }
+  }
+
+  @Test
+  public void testNumericalGradient() {
+
+    System.out.println("numerical gradients");
+
+    // make sure that w2 and w20 have the right energy and gradient
+    final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
+    final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
+    final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
+
+    final double[] grad2W = new double[6 * 2];
+    final double[] grad2WDis = new double[6 * 2];
+    final double[] grad20W = new double[6 * 20];
+    final double[] grad2WAna = new double[6 * 2];
+    final double[] grad2WDisAna = new double[6 * 2];
+    final double[] grad20WAna = new double[6 * 20];
+
+    // this is kinda weird, so let me explain: we need to calculate the gradient analytically to
+    // make sure
+    // that the internal caches are properly filled. yes, this is a test that relies on a specific
+    // implementation
+    // behavior but that is life
+
+    rigidW2TIP4P.gradient(extCoord2, grad2WAna, 0);
+    final double e2 =
+        NumericalGradients.gradientForRigidBody(
+            gWater2,
+            rigidW2TIP4P.getCartesBackupCopy(),
+            RigidBodyCoordinates.getCOMs(extCoord2, 2),
+            RigidBodyCoordinates.getEulers(extCoord2, 2),
+            grad2W,
+            tip4p,
+            0);
+
+    rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
+    final double e2Dis =
+        NumericalGradients.gradientForRigidBody(
+            gWater2Distorted,
+            rigidW2DisTIP4P.getCartesBackupCopy(),
+            RigidBodyCoordinates.getCOMs(extCoord2Dis, 2),
+            RigidBodyCoordinates.getEulers(extCoord2Dis, 2),
+            grad2WDis,
+            tip4p,
+            0);
+
+    rigidW20TIP4P.gradient(extCoord20, grad20WAna, 0);
+    final double e20 =
+        NumericalGradients.gradientForRigidBody(
+            gWater20,
+            rigidW20TIP4P.getCartesBackupCopy(),
+            RigidBodyCoordinates.getCOMs(extCoord20, 20),
+            RigidBodyCoordinates.getEulers(extCoord20, 20),
+            grad20W,
+            tip4p,
+            0);
+
+    // from DJW
+    final double expResult2 = -0.009936231756023471;
+    final double expResult20 = -0.3325038695132564;
+    // from Phenix
+    final double expResult2Dis = -0.002495066061667801;
+
+    assertEquals(expResult2, e2, NUMACC);
+    assertEquals(expResult2Dis, e2Dis, NUMACC);
+    assertEquals(expResult20, e20, NUMACC);
+
+    // check numerical vs analytical gradient
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WAna[i],
+          grad2W[i],
+          NUMACCLOOSE,
+          "Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad2WAna[i]
+              + " ours "
+              + grad2W[i]
+              + " diff "
+              + Math.abs(grad2WAna[i] - grad2W[i]));
+    }
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna[i],
+          grad2WDis[i],
+          NUMACC,
+          "Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad2WDisAna[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(grad2WDisAna[i] - grad2WDis[i]));
+    }
+    for (int i = 0; i < 120; i++) {
+      assertEquals(
+          grad20WAna[i],
+          grad20W[i],
+          NUMACC,
+          "Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad20WAna[i]
+              + " ours "
+              + grad20W[i]
+              + " diff "
+              + Math.abs(grad20WAna[i] - grad20W[i]));
     }
 
-    /**
-     * Test of updateActiveCoordinates method, of class RigidBodyCoordinates.
-     */
-    /*@Test
-    public void testUpdateActiveCoordinates() {
-        System.out.println("updateActiveCoordinates");
-        
-        // required to initialize..
-        rigidW2TIP4P.getActiveCoordinates(gWater2.clone());
+    // check the gradients vs Bernd's Phenix implementation of TIP4P
+    // and yes, since these are minimum geometries, the gradient elements SHOULD BE very small
 
-        // again, very basic...
-        final Geometry g2Work = gWater2.clone();
-        final double[] comEuler = new double[12];
-        rigidW2TIP4P.updateActiveCoordinates(g2Work, comEuler);
-        
-        // check if they are all zero
-        final double[] extCOM = g2Work.getAllExtCoords();
-        for(int i = 0; i < 12; i++){
-            assertEquals(0.0,extCOM[i],1e-10);
-        }
-        
-        // put some random ones in
-        final Random r = new Random();
-        for(int i = 0; i < 12; i++){
-            comEuler[i] = (r.nextBoolean()) ? r.nextDouble() : -r.nextDouble(); // will work even with the Eulers
-        }
-        
-        rigidW2TIP4P.updateActiveCoordinates(g2Work, comEuler);
-        
-        // check if they are all the same
-        final double[] extCOMRand = g2Work.getAllExtCoords();
-        for(int i = 0; i < 12; i++){
-            
-            //TODO since the rigidify fix this will need to be compared more... intricately...
-            assertEquals(comEuler[i],extCOMRand[i],1e-10);
-        }
-    }*/
-
-    /**
-     * Test of fitness method, of class RigidBodyCoordinates.
-     */
-    @Test
-    public void testFitness_doubleArr_int() {
-        System.out.println("fitness");
-
-        // make sure that w2 and w20 have the right energy
-        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
-        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
-        
-        final double e2 = rigidW2TIP4P.fitness(extCoord2, 0);
-        final double e20 = rigidW20TIP4P.fitness(extCoord20, 0);
-        
-        // from DJW
-        final double expResult2 = -0.009936231756023471;
-        final double expResult20 = -0.3325038695132564;
-        
-        assertEquals(expResult2, e2, NUMACC);
-        assertEquals(expResult20, e20, NUMACC);
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          gradW2Phenix[i],
+          grad2W[i],
+          NUMACCLOOSE,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + gradW2Phenix[i]
+              + " ours "
+              + grad2W[i]
+              + " diff "
+              + Math.abs(gradW2Phenix[i] - grad2W[i]));
     }
 
-    /**
-     * Test of fitness method, of class RigidBodyCoordinates.
-     */
-    @Test
-    public void testFitness_Geometry_boolean() {
-        System.out.println("fitness");
-        
-        // make sure that w2 and w20 have the right energy
-
-        final double e2 = rigidW2TIP4P.fitness(gWater2.copy(), true).getFitness();
-        final double e20 = rigidW20TIP4P.fitness(gWater20.copy(), true).getFitness();
-        
-        // from DJW
-        final double expResult2 = -0.009936231756023471;
-        final double expResult20 = -0.3325038695132564;
-        
-        assertEquals(expResult2, e2, NUMACC);
-        assertEquals(expResult20, e20, NUMACC);
+    // only check the translational elements as the rotational ones are different
+    for (int i = 0; i < 3; i++) {
+      assertEquals(
+          gradW2DisPhenix[i],
+          grad2WDis[i],
+          NUMACC,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + gradW2DisPhenix[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(gradW2DisPhenix[i] - grad2WDis[i]));
+    }
+    for (int i = 6; i < 9; i++) {
+      assertEquals(
+          gradW2DisPhenix[i],
+          grad2WDis[i],
+          NUMACC,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + gradW2DisPhenix[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(gradW2DisPhenix[i] - grad2WDis[i]));
     }
 
-    /**
-     * Test of gradient method, of class RigidBodyCoordinates.
-     */
-    @Test
-    public void testGradient() {
-        System.out.println("gradient");
-
-        // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
-        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
-        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
-        
-        final double[] grad2W = new double[6*2];
-        final double[] grad2WDis = new double[6*2];
-        final double[] grad20W = new double[6*20];
-        
-        final double e2 = rigidW2TIP4P.gradient(extCoord2, grad2W, 0);
-        final double e2Dis = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDis, 0);
-        final double e20 = rigidW20TIP4P.gradient(extCoord20, grad20W, 0);
-        
-        // from DJW
-        final double expResult2 = -0.009936231756023471;
-        final double expResult20 = -0.3325038695132564;
-        // from Phenix
-        final double expResult2Dis = -0.002495066061667801;
-        
-        assertEquals(expResult2, e2, NUMACC);
-        assertEquals(expResult2Dis, e2Dis, NUMACC);
-        assertEquals(expResult20, e20, NUMACC);
-        
-        // check the gradients vs Bernd's Phenix implementation of TIP4P
-        // and yes, since these are minimum geometries, the gradient elements SHOULD BE very small
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + gradW2Phenix[i] + " ours " + grad2W[i] + " diff " + Math.abs(gradW2Phenix[i]-grad2W[i])
-                    ,gradW2Phenix[i],grad2W[i],NUMACCLOOSE);
-        }
-        
-        // distorted gradient
-        // only check the translational elements as the rotational ones are different
-        for(int i = 0; i < 3; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + gradW2DisPhenix[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(gradW2DisPhenix[i]-grad2WDis[i]),
-                    gradW2DisPhenix[i],grad2WDis[i],NUMACC);
-        }
-        for(int i = 6; i < 9; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + gradW2DisPhenix[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(gradW2DisPhenix[i]-grad2WDis[i]),
-                    gradW2DisPhenix[i],grad2WDis[i],NUMACC);
-        }
-        
-        
-        // don't bother to put in individual elements...
-        for(int i = 0; i < 120; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + 0.0 + " ours " + grad20W[i] + " diff " + Math.abs(grad20W[i]),
-                    0.0,grad20W[i],NUMACC);
-        }
+    // don't bother to put in individual elements...
+    for (int i = 0; i < 120; i++) {
+      assertEquals(
+          0.0,
+          grad20W[i],
+          NUMACC,
+          "Failure in gradient element "
+              + i
+              + " reference element "
+              + 0.0
+              + " ours "
+              + grad20W[i]
+              + " diff "
+              + Math.abs(grad20W[i]));
     }
-    
-    @Test
-    public void testNumericalGradient() {
-        
-        System.out.println("numerical gradients");
+  }
 
-        // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2 = rigidW2TIP4P.getActiveCoordinates(gWater2.copy());
-        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
-        final double[] extCoord20 = rigidW20TIP4P.getActiveCoordinates(gWater20.copy());
-        
-        final double[] grad2W = new double[6*2];
-        final double[] grad2WDis = new double[6*2];
-        final double[] grad20W = new double[6*20];
-        final double[] grad2WAna = new double[6*2];
-        final double[] grad2WDisAna = new double[6*2];
-        final double[] grad20WAna = new double[6*20];
-        
-        // this is kinda weird, so let me explain: we need to calculate the gradient analytically to make sure
-        // that the internal caches are properly filled. yes, this is a test that relies on a specific implementation
-        // behavior but that is life
-        
-        rigidW2TIP4P.gradient(extCoord2, grad2WAna, 0);
-        final double e2 = NumericalGradients.gradientForRigidBody(gWater2,
-                rigidW2TIP4P.getCartesBackupCopy(),
-                RigidBodyCoordinates.getCOMs(extCoord2, 2),
-                RigidBodyCoordinates.getEulers(extCoord2, 2),
-                grad2W, tip4p, 0);
-        
-        rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
-        final double e2Dis = NumericalGradients.gradientForRigidBody(gWater2Distorted,
-                rigidW2DisTIP4P.getCartesBackupCopy(),
-                RigidBodyCoordinates.getCOMs(extCoord2Dis, 2),
-                RigidBodyCoordinates.getEulers(extCoord2Dis, 2),
-                grad2WDis, tip4p, 0);
-        
-        rigidW20TIP4P.gradient(extCoord20, grad20WAna, 0);
-        final double e20 = NumericalGradients.gradientForRigidBody(gWater20,
-                rigidW20TIP4P.getCartesBackupCopy(),
-                RigidBodyCoordinates.getCOMs(extCoord20, 20),
-                RigidBodyCoordinates.getEulers(extCoord20, 20),
-                grad20W, tip4p, 0);
-        
-        // from DJW
-        final double expResult2 = -0.009936231756023471;
-        final double expResult20 = -0.3325038695132564;
-        // from Phenix
-        final double expResult2Dis = -0.002495066061667801;
-        
-        assertEquals(expResult2, e2, NUMACC);
-        assertEquals(expResult2Dis, e2Dis, NUMACC);
-        assertEquals(expResult20, e20, NUMACC);
-        
-        // check numerical vs analytical gradient
-        for(int i = 0; i < 12; i++){
-            assertEquals("Failure in numerical gradient element " + i + " analytical element "
-                    + grad2WAna[i] + " ours " + grad2W[i] + " diff " + Math.abs(grad2WAna[i]-grad2W[i]),
-                    grad2WAna[i],grad2W[i],NUMACCLOOSE);
-        }
-        for(int i = 0; i < 12; i++){
-            assertEquals("Failure in numerical gradient element " + i + " analytical element "
-                    + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
-                    grad2WDisAna[i],grad2WDis[i],NUMACC);
-        }
-        for(int i = 0; i < 120; i++){
-            assertEquals("Failure in numerical gradient element " + i + " analytical element "
-                    + grad20WAna[i] + " ours " + grad20W[i] + " diff " + Math.abs(grad20WAna[i]-grad20W[i]),
-                    grad20WAna[i],grad20W[i],NUMACC);
-        }
-        
-        
-        // check the gradients vs Bernd's Phenix implementation of TIP4P
-        // and yes, since these are minimum geometries, the gradient elements SHOULD BE very small
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + gradW2Phenix[i] + " ours " + grad2W[i] + " diff " + Math.abs(gradW2Phenix[i]-grad2W[i])
-                    ,gradW2Phenix[i],grad2W[i],NUMACCLOOSE);
-        }
-                
-        // only check the translational elements as the rotational ones are different
-        for(int i = 0; i < 3; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + gradW2DisPhenix[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(gradW2DisPhenix[i]-grad2WDis[i]),
-                    gradW2DisPhenix[i],grad2WDis[i],NUMACC);
-        }
-        for(int i = 6; i < 9; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + gradW2DisPhenix[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(gradW2DisPhenix[i]-grad2WDis[i]),
-                    gradW2DisPhenix[i],grad2WDis[i],NUMACC);
-        }
-        
-        
-        // don't bother to put in individual elements...
-        for(int i = 0; i < 120; i++){
-            assertEquals("Failure in gradient element " + i + " reference element "
-                    + 0.0 + " ours " + grad20W[i] + " diff " + Math.abs(grad20W[i]),
-                    0.0,grad20W[i],NUMACC);
-        }
+  @Test
+  public void testNumericalGradientStepped() {
+
+    System.out.println("numerical gradients (stepped)");
+
+    // make sure that w2 and w20 have the right energy and gradient
+    final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
+
+    final double[] grad2WDis = new double[6 * 2];
+    final double[] grad2WDisAna = new double[6 * 2];
+    final double[] grad2WDisAna2 = new double[6 * 2];
+
+    rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
+    // do it a second time, to be sure this works identically
+    rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna2, 0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna2[i],
+          grad2WDisAna[i],
+          NUMACC,
+          "(0) Failure in second invocation gradient element "
+              + i
+              + " analytical element (new) "
+              + grad2WDisAna2[i]
+              + " analytical element (old) "
+              + grad2WDisAna[i]
+              + " diff "
+              + Math.abs(grad2WDisAna2[i] - grad2WDisAna2[i]));
     }
-    
-    @Test
-    public void testNumericalGradientStepped() {
-        
-        System.out.println("numerical gradients (stepped)");
 
-        // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2Dis = rigidW2DisTIP4P.getActiveCoordinates(gWater2Distorted.copy());
-        
-        final double[] grad2WDis = new double[6*2];
-        final double[] grad2WDisAna = new double[6*2];
-        final double[] grad2WDisAna2 = new double[6*2];
-                        
-        rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
-        // do it a second time, to be sure this works identically
-        rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna2, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(0) Failure in second invocation gradient element " + i + " analytical element (new) "
-                    + grad2WDisAna2[i] + " analytical element (old) " + grad2WDisAna[i] + " diff " + Math.abs(grad2WDisAna2[i]-grad2WDisAna2[i]),
-                    grad2WDisAna2[i],grad2WDisAna[i],NUMACC);
-        }
-        
-        final int mols = 2;
-        NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP4P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip4p, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(I) Failure in numerical gradient element " + i + " analytical element "
-                    + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
-                    grad2WDisAna[i],grad2WDis[i],NUMACC);
-        }
-        
-        // do it a second time, to be sure this works identically
-        rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna2, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(II) Failure in second invocation gradient element " + i + " analytical element (new) "
-                    + grad2WDisAna2[i] + " analytical element (old) " + grad2WDisAna[i] + " diff " + Math.abs(grad2WDisAna2[i]-grad2WDisAna2[i]),
-                    grad2WDisAna2[i],grad2WDisAna[i],NUMACC);
-        }
-        
-        NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP4P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip4p, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(III) Failure in numerical gradient element " + i + " analytical element "
-                    + grad2WDisAna2[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna2[i]-grad2WDis[i]),
-                    grad2WDisAna2[i],grad2WDis[i],NUMACC);
-        }
-        
-        // step through the COM shifts of the second water, because we can!
-        final double[] extCoord2DisBack = extCoord2Dis.clone();
-        for(int ix = 0; ix < 20; ix++){
-            extCoord2Dis[6] = ix*0.01+extCoord2DisBack[6];
-            for(int iy = 0; iy < 20; iy++){
-                extCoord2Dis[7] = iy*0.01+extCoord2DisBack[7];
-                for(int iz = 0; iz < 20; iz++){
-                    extCoord2Dis[8] = iz*0.01+extCoord2DisBack[8];
-                    
-                    final double eAna = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
-                    final double eNum = NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP4P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip4p, 0);
-        
-                    // compare
-                    boolean allFine = true;
-                    if(Math.abs(eAna-eNum) > NUMACCLOOSE){
-                            System.err.println("TRANSLATION: Failure in numerical vs analytical energy, analytical energy "
-                            + eAna + " numerical " + eNum + " diff " + Math.abs(eAna-eNum));
-                            allFine = false;
-                    }
-                    for(int i = 0; i < 12; i++){
-                        if(Math.abs(grad2WDisAna[i]-grad2WDis[i]) > NUMACCLOOSE){
-                            System.err.println("TRANSLATION: Failure in numerical vs analytical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " numerical " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]));
-                            allFine = false;
-                        }
-                        /*assertEquals("Failure in numerical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
-                        grad2WDisAna[i],grad2WDis[i],NUMACCLOOSE);*/
-                    }
-                    assertTrue("TRANSLATION: Failure in one or more gradient elements, see above for details!",allFine);
-                }
+    final int mols = 2;
+    NumericalGradients.gradientForRigidBody(
+        gWater2Distorted,
+        rigidW2DisTIP4P.getCartesBackupCopy(),
+        RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+        RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+        grad2WDis,
+        tip4p,
+        0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna[i],
+          grad2WDis[i],
+          NUMACC,
+          "(I) Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad2WDisAna[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(grad2WDisAna[i] - grad2WDis[i]));
+    }
+
+    // do it a second time, to be sure this works identically
+    rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna2, 0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna2[i],
+          grad2WDisAna[i],
+          NUMACC,
+          "(II) Failure in second invocation gradient element "
+              + i
+              + " analytical element (new) "
+              + grad2WDisAna2[i]
+              + " analytical element (old) "
+              + grad2WDisAna[i]
+              + " diff "
+              + Math.abs(grad2WDisAna2[i] - grad2WDisAna2[i]));
+    }
+
+    NumericalGradients.gradientForRigidBody(
+        gWater2Distorted,
+        rigidW2DisTIP4P.getCartesBackupCopy(),
+        RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+        RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+        grad2WDis,
+        tip4p,
+        0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna2[i],
+          grad2WDis[i],
+          NUMACC,
+          "(III) Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad2WDisAna2[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(grad2WDisAna2[i] - grad2WDis[i]));
+    }
+
+    // step through the COM shifts of the second water, because we can!
+    final double[] extCoord2DisBack = extCoord2Dis.clone();
+    for (int ix = 0; ix < 20; ix++) {
+      extCoord2Dis[6] = ix * 0.01 + extCoord2DisBack[6];
+      for (int iy = 0; iy < 20; iy++) {
+        extCoord2Dis[7] = iy * 0.01 + extCoord2DisBack[7];
+        for (int iz = 0; iz < 20; iz++) {
+          extCoord2Dis[8] = iz * 0.01 + extCoord2DisBack[8];
+
+          final double eAna = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
+          final double eNum =
+              NumericalGradients.gradientForRigidBody(
+                  gWater2Distorted,
+                  rigidW2DisTIP4P.getCartesBackupCopy(),
+                  RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+                  RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+                  grad2WDis,
+                  tip4p,
+                  0);
+
+          // compare
+          boolean allFine = true;
+          if (Math.abs(eAna - eNum) > NUMACCLOOSE) {
+            System.err.println(
+                "TRANSLATION: Failure in numerical vs analytical energy, analytical energy "
+                    + eAna
+                    + " numerical "
+                    + eNum
+                    + " diff "
+                    + Math.abs(eAna - eNum));
+            allFine = false;
+          }
+          for (int i = 0; i < 12; i++) {
+            if (Math.abs(grad2WDisAna[i] - grad2WDis[i]) > NUMACCLOOSE) {
+              System.err.println(
+                  "TRANSLATION: Failure in numerical vs analytical gradient element "
+                      + i
+                      + " analytical element "
+                      + grad2WDisAna[i]
+                      + " numerical "
+                      + grad2WDis[i]
+                      + " diff "
+                      + Math.abs(grad2WDisAna[i] - grad2WDis[i]));
+              allFine = false;
             }
+            /*assertEquals("Failure in numerical gradient element " + i + " analytical element "
+                + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
+            grad2WDisAna[i],grad2WDis[i],NUMACCLOOSE);*/
+          }
+          assertTrue(
+              allFine,
+              "TRANSLATION: Failure in one or more gradient elements, see above for details!");
         }
-        
-        
-        // here, the Euler angles are all zero. Now, we want to see what happens with analytical vs numerical gradient when
-        // we step through the allowed range of Euler angles one by one
-        
-        final double phiIncr = 2*Math.PI/20;
-        final double omegaIncr = Math.PI/20;
-        final double psiIncr = 2*Math.PI/20;
-        
-        final double phiStart = -Math.PI + 2*phiIncr;
-        final double omegaStart = -0.5*Math.PI + 2*omegaIncr;
-        final double psiStart = -Math.PI + 2*psiIncr;
-        
-        // as to not run into problems with the sanitizing (some gradient discontinuities may be expected if you go beyond the definition interval of the Eulers)
-        // we start a litte ABOVE the lower bound and stop a little BELOW the upper one.
-        
-        double phi = phiStart;
-        double omega = omegaStart;
-        double psi = psiStart;
-                
-        final double phiEnd = Math.PI-2*phiIncr;
-        final double omegaEnd = Math.PI/2-2*omegaIncr;
-        final double psiEnd = Math.PI-2*psiIncr;
-        
-        while(phi <= phiEnd){
-            while(omega <= omegaEnd){
-                while(psi <= psiEnd){
-                    
-                    // put it in (first water)
-                    extCoord2Dis[3] = phi;
-                    extCoord2Dis[4] = omega;
-                    extCoord2Dis[5] = psi;
-                                        
-                    // compute analytical and numerical
-                    final double eAna = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
-                    final double eNum = NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP4P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip4p, 0);
-                    
-                    // compare
-                    boolean allFine = true;
-                    if(Math.abs(eAna-eNum) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical energy, analytical energy "
-                            + eAna + " numerical " + eNum + " diff " + Math.abs(eAna-eNum) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                    }
-                    for(int i = 0; i < 12; i++){
-                        if(Math.abs(grad2WDisAna[i]-grad2WDis[i]) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " numerical " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                        }
-                    }
-                    assertTrue("ROTATION: Failure in one or more gradient elements, see above for details!",allFine);
-                    
-                    if(false){
-                        System.out.println("One done!");
-                    }
-                    
-                    psi += psiIncr;
-                }
-                psi = psiStart;
-                
-                omega += omegaIncr;
+      }
+    }
+
+    // here, the Euler angles are all zero. Now, we want to see what happens with analytical vs
+    // numerical gradient when
+    // we step through the allowed range of Euler angles one by one
+
+    final double phiIncr = 2 * Math.PI / 20;
+    final double omegaIncr = Math.PI / 20;
+    final double psiIncr = 2 * Math.PI / 20;
+
+    final double phiStart = -Math.PI + 2 * phiIncr;
+    final double omegaStart = -0.5 * Math.PI + 2 * omegaIncr;
+    final double psiStart = -Math.PI + 2 * psiIncr;
+
+    // as to not run into problems with the sanitizing (some gradient discontinuities may be
+    // expected if you go beyond the definition interval of the Eulers)
+    // we start a litte ABOVE the lower bound and stop a little BELOW the upper one.
+
+    double phi = phiStart;
+    double omega = omegaStart;
+    double psi = psiStart;
+
+    final double phiEnd = Math.PI - 2 * phiIncr;
+    final double omegaEnd = Math.PI / 2 - 2 * omegaIncr;
+    final double psiEnd = Math.PI - 2 * psiIncr;
+
+    while (phi <= phiEnd) {
+      while (omega <= omegaEnd) {
+        while (psi <= psiEnd) {
+
+          // put it in (first water)
+          extCoord2Dis[3] = phi;
+          extCoord2Dis[4] = omega;
+          extCoord2Dis[5] = psi;
+
+          // compute analytical and numerical
+          final double eAna = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
+          final double eNum =
+              NumericalGradients.gradientForRigidBody(
+                  gWater2Distorted,
+                  rigidW2DisTIP4P.getCartesBackupCopy(),
+                  RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+                  RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+                  grad2WDis,
+                  tip4p,
+                  0);
+
+          // compare
+          boolean allFine = true;
+          if (Math.abs(eAna - eNum) > NUMACCLOOSE) {
+            System.err.println(
+                "ROTATION: Failure in numerical vs analytical energy, analytical energy "
+                    + eAna
+                    + " numerical "
+                    + eNum
+                    + " diff "
+                    + Math.abs(eAna - eNum)
+                    + " phi "
+                    + phi
+                    + " omega "
+                    + omega
+                    + " psi "
+                    + psi);
+            allFine = false;
+          }
+          for (int i = 0; i < 12; i++) {
+            if (Math.abs(grad2WDisAna[i] - grad2WDis[i]) > NUMACCLOOSE) {
+              System.err.println(
+                  "ROTATION: Failure in numerical vs analytical gradient element "
+                      + i
+                      + " analytical element "
+                      + grad2WDisAna[i]
+                      + " numerical "
+                      + grad2WDis[i]
+                      + " diff "
+                      + Math.abs(grad2WDisAna[i] - grad2WDis[i])
+                      + " phi "
+                      + phi
+                      + " omega "
+                      + omega
+                      + " psi "
+                      + psi);
+              allFine = false;
             }
-            omega = omegaStart;
-            
-            phi += phiIncr;
+          }
+          assertTrue(
+              allFine,
+              "ROTATION: Failure in one or more gradient elements, see above for details!");
+
+          if (false) {
+            System.out.println("One done!");
+          }
+
+          psi += psiIncr;
         }
-        
-        // reset
-        phi = phiStart;
-        omega = omegaStart;
         psi = psiStart;
-        
-        while(phi <= phiEnd){
-            while(omega <= omegaEnd){
-                while(psi <= psiEnd){
-                    
-                    // put it in (second water)
-                    extCoord2Dis[9] = phi;
-                    extCoord2Dis[10] = omega;
-                    extCoord2Dis[11] = psi;
-                    
-                    // compute analytical and numerical
-                    final double eAna = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
-                    final double eNum = NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP4P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip4p, 0);
-                    
-                    // compare
-                    boolean allFine = true;
-                    if(Math.abs(eAna-eNum) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical energy, analytical energy "
-                            + eAna + " numerical " + eNum + " diff " + Math.abs(eAna-eNum) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                    }
-                    for(int i = 0; i < 12; i++){
-                        if(Math.abs(grad2WDisAna[i]-grad2WDis[i]) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " numerical " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                        }
-                    }
-                    assertTrue("ROTATION: Failure in one or more gradient elements, see above for details!",allFine);
-                    
-                    if(false){
-                        System.out.println("One done!");
-                    }
-                    
-                    psi += psiIncr;
-                }
-                psi = psiStart;
-                
-                omega += omegaIncr;
-            }
-            omega = omegaStart;
-            
-            phi += phiIncr;
-        }
-        
-    }
-    
-    
-    @Test
-    public void testNumericalGradientTIP3PStepped() {
-        
-        // a stupid copy of the TIP4P test above. it's ok though, we do not currently have anything better than this
-        System.out.println("numerical gradients TIP3P (stepped)");
 
-        // make sure that w2 and w20 have the right energy and gradient
-        final double[] extCoord2Dis = rigidW2DisTIP3P.getActiveCoordinates(gWater2Distorted.copy());
-        
-        final double[] grad2WDis = new double[6*2];
-        final double[] grad2WDisAna = new double[6*2];
-        final double[] grad2WDisAna2 = new double[6*2];
-                        
-        rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
-        // do it a second time, to be sure this works identically
-        rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna2, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(0) Failure in second invocation gradient element " + i + " analytical element (new) "
-                    + grad2WDisAna2[i] + " analytical element (old) " + grad2WDisAna[i] + " diff " + Math.abs(grad2WDisAna2[i]-grad2WDisAna2[i]),
-                    grad2WDisAna2[i],grad2WDisAna[i],NUMACC);
-        }
-        
-        final int mols = 2;
-        NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP3P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip3p, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(I) Failure in numerical gradient element " + i + " analytical element "
-                    + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
-                    grad2WDisAna[i],grad2WDis[i],NUMACC);
-        }
-        
-        // do it a second time, to be sure this works identically
-        rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna2, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(II) Failure in second invocation gradient element " + i + " analytical element (new) "
-                    + grad2WDisAna2[i] + " analytical element (old) " + grad2WDisAna[i] + " diff " + Math.abs(grad2WDisAna2[i]-grad2WDisAna2[i]),
-                    grad2WDisAna2[i],grad2WDisAna[i],NUMACC);
-        }
-        
-        NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP3P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip3p, 0);
-        
-        for(int i = 0; i < 12; i++){
-            assertEquals("(III) Failure in numerical gradient element " + i + " analytical element "
-                    + grad2WDisAna2[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna2[i]-grad2WDis[i]),
-                    grad2WDisAna2[i],grad2WDis[i],NUMACC);
-        }
-        
-        // step through the COM shifts of the second water, because we can!
-        final double[] extCoord2DisBack = extCoord2Dis.clone();
-        for(int ix = 0; ix < 20; ix++){
-            extCoord2Dis[6] = ix*0.01+extCoord2DisBack[6];
-            for(int iy = 0; iy < 20; iy++){
-                extCoord2Dis[7] = iy*0.01+extCoord2DisBack[7];
-                for(int iz = 0; iz < 20; iz++){
-                    extCoord2Dis[8] = iz*0.01+extCoord2DisBack[8];
-                    
-                    final double eAna = rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
-                    final double eNum = NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP3P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip3p, 0);
-        
-                    // compare
-                    boolean allFine = true;
-                    if(Math.abs(eAna-eNum) > NUMACCLOOSE){
-                            System.err.println("TRANSLATION: Failure in numerical vs analytical energy, analytical energy "
-                            + eAna + " numerical " + eNum + " diff " + Math.abs(eAna-eNum));
-                            allFine = false;
-                    }
-                    for(int i = 0; i < 12; i++){
-                        if(Math.abs(grad2WDisAna[i]-grad2WDis[i]) > NUMACCLOOSE){
-                            System.err.println("TRANSLATION: Failure in numerical vs analytical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " numerical " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]));
-                            allFine = false;
-                        }
-                        /*assertEquals("Failure in numerical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
-                        grad2WDisAna[i],grad2WDis[i],NUMACCLOOSE);*/
-                    }
-                    assertTrue("TRANSLATION: Failure in one or more gradient elements, see above for details!",allFine);
-                }
+        omega += omegaIncr;
+      }
+      omega = omegaStart;
+
+      phi += phiIncr;
+    }
+
+    // reset
+    phi = phiStart;
+    omega = omegaStart;
+    psi = psiStart;
+
+    while (phi <= phiEnd) {
+      while (omega <= omegaEnd) {
+        while (psi <= psiEnd) {
+
+          // put it in (second water)
+          extCoord2Dis[9] = phi;
+          extCoord2Dis[10] = omega;
+          extCoord2Dis[11] = psi;
+
+          // compute analytical and numerical
+          final double eAna = rigidW2DisTIP4P.gradient(extCoord2Dis, grad2WDisAna, 0);
+          final double eNum =
+              NumericalGradients.gradientForRigidBody(
+                  gWater2Distorted,
+                  rigidW2DisTIP4P.getCartesBackupCopy(),
+                  RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+                  RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+                  grad2WDis,
+                  tip4p,
+                  0);
+
+          // compare
+          boolean allFine = true;
+          if (Math.abs(eAna - eNum) > NUMACCLOOSE) {
+            System.err.println(
+                "ROTATION: Failure in numerical vs analytical energy, analytical energy "
+                    + eAna
+                    + " numerical "
+                    + eNum
+                    + " diff "
+                    + Math.abs(eAna - eNum)
+                    + " phi "
+                    + phi
+                    + " omega "
+                    + omega
+                    + " psi "
+                    + psi);
+            allFine = false;
+          }
+          for (int i = 0; i < 12; i++) {
+            if (Math.abs(grad2WDisAna[i] - grad2WDis[i]) > NUMACCLOOSE) {
+              System.err.println(
+                  "ROTATION: Failure in numerical vs analytical gradient element "
+                      + i
+                      + " analytical element "
+                      + grad2WDisAna[i]
+                      + " numerical "
+                      + grad2WDis[i]
+                      + " diff "
+                      + Math.abs(grad2WDisAna[i] - grad2WDis[i])
+                      + " phi "
+                      + phi
+                      + " omega "
+                      + omega
+                      + " psi "
+                      + psi);
+              allFine = false;
             }
+          }
+          assertTrue(
+              allFine,
+              "ROTATION: Failure in one or more gradient elements, see above for details!");
+
+          if (false) {
+            System.out.println("One done!");
+          }
+
+          psi += psiIncr;
         }
-        
-        
-        // here, the Euler angles are all zero. Now, we want to see what happens with analytical vs numerical gradient when
-        // we step through the allowed range of Euler angles one by one
-        
-        final double phiIncr = 2*Math.PI/20;
-        final double omegaIncr = Math.PI/20;
-        final double psiIncr = 2*Math.PI/20;
-        
-        final double phiStart = -Math.PI + 2*phiIncr;
-        final double omegaStart = -0.5*Math.PI + 2*omegaIncr;
-        final double psiStart = -Math.PI + 2*psiIncr;
-        
-        // as to not run into problems with the sanitizing (some gradient discontinuities may be expected if you go beyond the definition interval of the Eulers)
-        // we start a litte ABOVE the lower bound and stop a little BELOW the upper one.
-        
-        double phi = phiStart;
-        double omega = omegaStart;
-        double psi = psiStart;
-                
-        final double phiEnd = Math.PI-2*phiIncr;
-        final double omegaEnd = Math.PI/2-2*omegaIncr;
-        final double psiEnd = Math.PI-2*psiIncr;
-        
-        while(phi <= phiEnd){
-            while(omega <= omegaEnd){
-                while(psi <= psiEnd){
-                    
-                    // put it in (first water)
-                    extCoord2Dis[3] = phi;
-                    extCoord2Dis[4] = omega;
-                    extCoord2Dis[5] = psi;
-                                        
-                    // compute analytical and numerical
-                    final double eAna = rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
-                    final double eNum = NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP3P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip3p, 0);
-                    
-                    // compare
-                    boolean allFine = true;
-                    if(Math.abs(eAna-eNum) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical energy, analytical energy "
-                            + eAna + " numerical " + eNum + " diff " + Math.abs(eAna-eNum) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                    }
-                    for(int i = 0; i < 12; i++){
-                        if(Math.abs(grad2WDisAna[i]-grad2WDis[i]) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " numerical " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                        }
-                    }
-                    assertTrue("ROTATION: Failure in one or more gradient elements, see above for details!",allFine);
-                    
-                    if(false){
-                        System.out.println("One done!");
-                    }
-                    
-                    psi += psiIncr;
-                }
-                psi = psiStart;
-                
-                omega += omegaIncr;
-            }
-            omega = omegaStart;
-            
-            phi += phiIncr;
-        }
-        
-        // reset
-        phi = phiStart;
-        omega = omegaStart;
         psi = psiStart;
-        
-        while(phi <= phiEnd){
-            while(omega <= omegaEnd){
-                while(psi <= psiEnd){
-                    
-                    // put it in (second water)
-                    extCoord2Dis[9] = phi;
-                    extCoord2Dis[10] = omega;
-                    extCoord2Dis[11] = psi;
-                    
-                    // compute analytical and numerical
-                    final double eAna = rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
-                    final double eNum = NumericalGradients.gradientForRigidBody(gWater2Distorted, rigidW2DisTIP3P.getCartesBackupCopy(), RigidBodyCoordinates.getCOMs(extCoord2Dis, mols), RigidBodyCoordinates.getEulers(extCoord2Dis, mols), grad2WDis, tip3p, 0);
-                    
-                    // compare
-                    boolean allFine = true;
-                    if(Math.abs(eAna-eNum) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical energy, analytical energy "
-                            + eAna + " numerical " + eNum + " diff " + Math.abs(eAna-eNum) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                    }
-                    for(int i = 0; i < 12; i++){
-                        if(Math.abs(grad2WDisAna[i]-grad2WDis[i]) > NUMACCLOOSE){
-                            System.err.println("ROTATION: Failure in numerical vs analytical gradient element " + i + " analytical element "
-                            + grad2WDisAna[i] + " numerical " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]) + " phi " + phi + " omega " + omega + " psi " + psi);
-                            allFine = false;
-                        }
-                    }
-                    assertTrue("ROTATION: Failure in one or more gradient elements, see above for details!",allFine);
-                    
-                    if(false){
-                        System.out.println("One done!");
-                    }
-                    
-                    psi += psiIncr;
-                }
-                psi = psiStart;
-                
-                omega += omegaIncr;
+
+        omega += omegaIncr;
+      }
+      omega = omegaStart;
+
+      phi += phiIncr;
+    }
+  }
+
+  @Test
+  public void testNumericalGradientTIP3PStepped() {
+
+    // a stupid copy of the TIP4P test above. it's ok though, we do not currently have anything
+    // better than this
+    System.out.println("numerical gradients TIP3P (stepped)");
+
+    // make sure that w2 and w20 have the right energy and gradient
+    final double[] extCoord2Dis = rigidW2DisTIP3P.getActiveCoordinates(gWater2Distorted.copy());
+
+    final double[] grad2WDis = new double[6 * 2];
+    final double[] grad2WDisAna = new double[6 * 2];
+    final double[] grad2WDisAna2 = new double[6 * 2];
+
+    rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
+    // do it a second time, to be sure this works identically
+    rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna2, 0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna2[i],
+          grad2WDisAna[i],
+          NUMACC,
+          "(0) Failure in second invocation gradient element "
+              + i
+              + " analytical element (new) "
+              + grad2WDisAna2[i]
+              + " analytical element (old) "
+              + grad2WDisAna[i]
+              + " diff "
+              + Math.abs(grad2WDisAna2[i] - grad2WDisAna2[i]));
+    }
+
+    final int mols = 2;
+    NumericalGradients.gradientForRigidBody(
+        gWater2Distorted,
+        rigidW2DisTIP3P.getCartesBackupCopy(),
+        RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+        RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+        grad2WDis,
+        tip3p,
+        0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna[i],
+          grad2WDis[i],
+          NUMACC,
+          "(I) Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad2WDisAna[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(grad2WDisAna[i] - grad2WDis[i]));
+    }
+
+    // do it a second time, to be sure this works identically
+    rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna2, 0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna2[i],
+          grad2WDisAna[i],
+          NUMACC,
+          "(II) Failure in second invocation gradient element "
+              + i
+              + " analytical element (new) "
+              + grad2WDisAna2[i]
+              + " analytical element (old) "
+              + grad2WDisAna[i]
+              + " diff "
+              + Math.abs(grad2WDisAna2[i] - grad2WDisAna2[i]));
+    }
+
+    NumericalGradients.gradientForRigidBody(
+        gWater2Distorted,
+        rigidW2DisTIP3P.getCartesBackupCopy(),
+        RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+        RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+        grad2WDis,
+        tip3p,
+        0);
+
+    for (int i = 0; i < 12; i++) {
+      assertEquals(
+          grad2WDisAna2[i],
+          grad2WDis[i],
+          NUMACC,
+          "(III) Failure in numerical gradient element "
+              + i
+              + " analytical element "
+              + grad2WDisAna2[i]
+              + " ours "
+              + grad2WDis[i]
+              + " diff "
+              + Math.abs(grad2WDisAna2[i] - grad2WDis[i]));
+    }
+
+    // step through the COM shifts of the second water, because we can!
+    final double[] extCoord2DisBack = extCoord2Dis.clone();
+    for (int ix = 0; ix < 20; ix++) {
+      extCoord2Dis[6] = ix * 0.01 + extCoord2DisBack[6];
+      for (int iy = 0; iy < 20; iy++) {
+        extCoord2Dis[7] = iy * 0.01 + extCoord2DisBack[7];
+        for (int iz = 0; iz < 20; iz++) {
+          extCoord2Dis[8] = iz * 0.01 + extCoord2DisBack[8];
+
+          final double eAna = rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
+          final double eNum =
+              NumericalGradients.gradientForRigidBody(
+                  gWater2Distorted,
+                  rigidW2DisTIP3P.getCartesBackupCopy(),
+                  RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+                  RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+                  grad2WDis,
+                  tip3p,
+                  0);
+
+          // compare
+          boolean allFine = true;
+          if (Math.abs(eAna - eNum) > NUMACCLOOSE) {
+            System.err.println(
+                "TRANSLATION: Failure in numerical vs analytical energy, analytical energy "
+                    + eAna
+                    + " numerical "
+                    + eNum
+                    + " diff "
+                    + Math.abs(eAna - eNum));
+            allFine = false;
+          }
+          for (int i = 0; i < 12; i++) {
+            if (Math.abs(grad2WDisAna[i] - grad2WDis[i]) > NUMACCLOOSE) {
+              System.err.println(
+                  "TRANSLATION: Failure in numerical vs analytical gradient element "
+                      + i
+                      + " analytical element "
+                      + grad2WDisAna[i]
+                      + " numerical "
+                      + grad2WDis[i]
+                      + " diff "
+                      + Math.abs(grad2WDisAna[i] - grad2WDis[i]));
+              allFine = false;
             }
-            omega = omegaStart;
-            
-            phi += phiIncr;
+            /*assertEquals("Failure in numerical gradient element " + i + " analytical element "
+                + grad2WDisAna[i] + " ours " + grad2WDis[i] + " diff " + Math.abs(grad2WDisAna[i]-grad2WDis[i]),
+            grad2WDisAna[i],grad2WDis[i],NUMACCLOOSE);*/
+          }
+          assertTrue(
+              allFine,
+              "TRANSLATION: Failure in one or more gradient elements, see above for details!");
         }
-        
+      }
     }
-    
-    private static Geometry getWater2TIP4P(){
-        
-        // plug in the known global minimum structure for water 2
-        final CartesianCoordinates c = new CartesianCoordinates(6,2,new int[]{3,3});
-        final double[][] xyz = c.getAllXYZCoord();
-        xyz[0][0] = -0.1858140*ANGTOBOHR;
-        xyz[1][0] = -1.1749469*ANGTOBOHR;
-        xyz[2][0] = 0.7662596*ANGTOBOHR;
-        xyz[0][1] = -0.1285513*ANGTOBOHR;
-        xyz[1][1] = -0.8984365*ANGTOBOHR;
-        xyz[2][1] = 1.6808606*ANGTOBOHR;
-        xyz[0][2] = -0.0582782*ANGTOBOHR;
-        xyz[1][2] = -0.3702550*ANGTOBOHR;
-        xyz[2][2] = 0.2638279*ANGTOBOHR;
-        xyz[0][3] = 0.1747051*ANGTOBOHR;
-        xyz[1][3] = 1.1050002*ANGTOBOHR;
-        xyz[2][3] = -0.7244430*ANGTOBOHR;
-        xyz[0][4] = -0.5650842*ANGTOBOHR;
-        xyz[1][4] = 1.3134964*ANGTOBOHR;
-        xyz[2][4] = -1.2949455*ANGTOBOHR;
-        xyz[0][5] = 0.9282185*ANGTOBOHR;
-        xyz[1][5] = 1.0652990*ANGTOBOHR;
-        xyz[2][5] = -1.313402*ANGTOBOHR;
-        
-        final String[] atoms = c.getAllAtomTypes();
-        atoms[0] = "O";
-        atoms[1] = "H";
-        atoms[2] = "H";
-        atoms[3] = "O";
-        atoms[4] = "H";
-        atoms[5] = "H";
-        
-        c.recalcAtomNumbers();
-        
-        final int noOfMols = 2;
-        final int noOfAtoms = noOfMols*3;
-        final int[] atsPerMol = new int[noOfMols];
-        final String[] sids = new String[noOfMols];
-        final boolean[] molFlexies = new boolean[noOfMols];
-        final boolean[] molConstr = new boolean[noOfMols];
-        final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
-        final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
-        final List<boolean[][]> allFlex = new ArrayList<>();
-        for(int i = 0; i < noOfMols; i++){
-            atsPerMol[i] = 3;
-            sids[i] = "OHH";
-            molFlexies[i] = false;
-            molConstr[i] = false;
-            final int o = i*3;
-            final int h1 = i*3+1;
-            final int h2 = i*3+2;
-            bonds.setBond(o, h1, BondInfo.SINGLE);
-            bonds.setBond(o, h2, BondInfo.SINGLE);
-            allFlex.add(null);
+
+    // here, the Euler angles are all zero. Now, we want to see what happens with analytical vs
+    // numerical gradient when
+    // we step through the allowed range of Euler angles one by one
+
+    final double phiIncr = 2 * Math.PI / 20;
+    final double omegaIncr = Math.PI / 20;
+    final double psiIncr = 2 * Math.PI / 20;
+
+    final double phiStart = -Math.PI + 2 * phiIncr;
+    final double omegaStart = -0.5 * Math.PI + 2 * omegaIncr;
+    final double psiStart = -Math.PI + 2 * psiIncr;
+
+    // as to not run into problems with the sanitizing (some gradient discontinuities may be
+    // expected if you go beyond the definition interval of the Eulers)
+    // we start a litte ABOVE the lower bound and stop a little BELOW the upper one.
+
+    double phi = phiStart;
+    double omega = omegaStart;
+    double psi = psiStart;
+
+    final double phiEnd = Math.PI - 2 * phiIncr;
+    final double omegaEnd = Math.PI / 2 - 2 * omegaIncr;
+    final double psiEnd = Math.PI - 2 * psiIncr;
+
+    while (phi <= phiEnd) {
+      while (omega <= omegaEnd) {
+        while (psi <= psiEnd) {
+
+          // put it in (first water)
+          extCoord2Dis[3] = phi;
+          extCoord2Dis[4] = omega;
+          extCoord2Dis[5] = psi;
+
+          // compute analytical and numerical
+          final double eAna = rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
+          final double eNum =
+              NumericalGradients.gradientForRigidBody(
+                  gWater2Distorted,
+                  rigidW2DisTIP3P.getCartesBackupCopy(),
+                  RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+                  RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+                  grad2WDis,
+                  tip3p,
+                  0);
+
+          // compare
+          boolean allFine = true;
+          if (Math.abs(eAna - eNum) > NUMACCLOOSE) {
+            System.err.println(
+                "ROTATION: Failure in numerical vs analytical energy, analytical energy "
+                    + eAna
+                    + " numerical "
+                    + eNum
+                    + " diff "
+                    + Math.abs(eAna - eNum)
+                    + " phi "
+                    + phi
+                    + " omega "
+                    + omega
+                    + " psi "
+                    + psi);
+            allFine = false;
+          }
+          for (int i = 0; i < 12; i++) {
+            if (Math.abs(grad2WDisAna[i] - grad2WDis[i]) > NUMACCLOOSE) {
+              System.err.println(
+                  "ROTATION: Failure in numerical vs analytical gradient element "
+                      + i
+                      + " analytical element "
+                      + grad2WDisAna[i]
+                      + " numerical "
+                      + grad2WDis[i]
+                      + " diff "
+                      + Math.abs(grad2WDisAna[i] - grad2WDis[i])
+                      + " phi "
+                      + phi
+                      + " omega "
+                      + omega
+                      + " psi "
+                      + psi);
+              allFine = false;
+            }
+          }
+          assertTrue(
+              allFine,
+              "ROTATION: Failure in one or more gradient elements, see above for details!");
+
+          if (false) {
+            System.out.println("One done!");
+          }
+
+          psi += psiIncr;
         }
-        for(int i = 0; i < noOfAtoms; i++){
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-        }
-        
-        final Geometry g = new Geometry(c, 0, noOfMols, atsPerMol,
-            molFlexies, allFlex, molConstr, constrXYZ,
-            sids, bonds);
-            
-        return g;
+        psi = psiStart;
+
+        omega += omegaIncr;
+      }
+      omega = omegaStart;
+
+      phi += phiIncr;
     }
-    
-    private static Geometry getWater2TIP4PDistorted(){
-        
-        final short[] spins = new short[6];
-        final float[] charges = new float[6];
-        final int[] atsPerMol = new int[]{3,3};
-        
-        final String[] w2_distorted = new String[]{
-            "6",
-            "Energy:              -6.5508",
-            "O             -0.0053998              0.0223328              0.1261801",
-            "H             -0.9200008             -0.0273239             -0.1517969",
-            "H              0.4970319             -0.1584812             -0.6682384",
-            "O              2.1931798              2.0700218             -2.1761271",
-            "H              3.0481182              1.8086380             -1.8340878",
-            "H              1.9936879              2.8892588             -1.7230422"
+
+    // reset
+    phi = phiStart;
+    omega = omegaStart;
+    psi = psiStart;
+
+    while (phi <= phiEnd) {
+      while (omega <= omegaEnd) {
+        while (psi <= psiEnd) {
+
+          // put it in (second water)
+          extCoord2Dis[9] = phi;
+          extCoord2Dis[10] = omega;
+          extCoord2Dis[11] = psi;
+
+          // compute analytical and numerical
+          final double eAna = rigidW2DisTIP3P.gradient(extCoord2Dis, grad2WDisAna, 0);
+          final double eNum =
+              NumericalGradients.gradientForRigidBody(
+                  gWater2Distorted,
+                  rigidW2DisTIP3P.getCartesBackupCopy(),
+                  RigidBodyCoordinates.getCOMs(extCoord2Dis, mols),
+                  RigidBodyCoordinates.getEulers(extCoord2Dis, mols),
+                  grad2WDis,
+                  tip3p,
+                  0);
+
+          // compare
+          boolean allFine = true;
+          if (Math.abs(eAna - eNum) > NUMACCLOOSE) {
+            System.err.println(
+                "ROTATION: Failure in numerical vs analytical energy, analytical energy "
+                    + eAna
+                    + " numerical "
+                    + eNum
+                    + " diff "
+                    + Math.abs(eAna - eNum)
+                    + " phi "
+                    + phi
+                    + " omega "
+                    + omega
+                    + " psi "
+                    + psi);
+            allFine = false;
+          }
+          for (int i = 0; i < 12; i++) {
+            if (Math.abs(grad2WDisAna[i] - grad2WDis[i]) > NUMACCLOOSE) {
+              System.err.println(
+                  "ROTATION: Failure in numerical vs analytical gradient element "
+                      + i
+                      + " analytical element "
+                      + grad2WDisAna[i]
+                      + " numerical "
+                      + grad2WDis[i]
+                      + " diff "
+                      + Math.abs(grad2WDisAna[i] - grad2WDis[i])
+                      + " phi "
+                      + phi
+                      + " omega "
+                      + omega
+                      + " psi "
+                      + psi);
+              allFine = false;
+            }
+          }
+          assertTrue(
+              allFine,
+              "ROTATION: Failure in one or more gradient elements, see above for details!");
+
+          if (false) {
+            System.out.println("One done!");
+          }
+
+          psi += psiIncr;
+        }
+        psi = psiStart;
+
+        omega += omegaIncr;
+      }
+      omega = omegaStart;
+
+      phi += phiIncr;
+    }
+  }
+
+  private static Geometry getWater2TIP4P() {
+
+    // plug in the known global minimum structure for water 2
+    final CartesianCoordinates c = new CartesianCoordinates(6, 2, new int[] {3, 3});
+    final double[][] xyz = c.getAllXYZCoord();
+    xyz[0][0] = -0.1858140 * ANGTOBOHR;
+    xyz[1][0] = -1.1749469 * ANGTOBOHR;
+    xyz[2][0] = 0.7662596 * ANGTOBOHR;
+    xyz[0][1] = -0.1285513 * ANGTOBOHR;
+    xyz[1][1] = -0.8984365 * ANGTOBOHR;
+    xyz[2][1] = 1.6808606 * ANGTOBOHR;
+    xyz[0][2] = -0.0582782 * ANGTOBOHR;
+    xyz[1][2] = -0.3702550 * ANGTOBOHR;
+    xyz[2][2] = 0.2638279 * ANGTOBOHR;
+    xyz[0][3] = 0.1747051 * ANGTOBOHR;
+    xyz[1][3] = 1.1050002 * ANGTOBOHR;
+    xyz[2][3] = -0.7244430 * ANGTOBOHR;
+    xyz[0][4] = -0.5650842 * ANGTOBOHR;
+    xyz[1][4] = 1.3134964 * ANGTOBOHR;
+    xyz[2][4] = -1.2949455 * ANGTOBOHR;
+    xyz[0][5] = 0.9282185 * ANGTOBOHR;
+    xyz[1][5] = 1.0652990 * ANGTOBOHR;
+    xyz[2][5] = -1.313402 * ANGTOBOHR;
+
+    final String[] atoms = c.getAllAtomTypes();
+    atoms[0] = "O";
+    atoms[1] = "H";
+    atoms[2] = "H";
+    atoms[3] = "O";
+    atoms[4] = "H";
+    atoms[5] = "H";
+
+    c.recalcAtomNumbers();
+
+    final int noOfMols = 2;
+    final int noOfAtoms = noOfMols * 3;
+    final int[] atsPerMol = new int[noOfMols];
+    final String[] sids = new String[noOfMols];
+    final boolean[] molFlexies = new boolean[noOfMols];
+    final boolean[] molConstr = new boolean[noOfMols];
+    final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
+    final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
+    final List<boolean[][]> allFlex = new ArrayList<>();
+    for (int i = 0; i < noOfMols; i++) {
+      atsPerMol[i] = 3;
+      sids[i] = "OHH";
+      molFlexies[i] = false;
+      molConstr[i] = false;
+      final int o = i * 3;
+      final int h1 = i * 3 + 1;
+      final int h2 = i * 3 + 2;
+      bonds.setBond(o, h1, BondInfo.SINGLE);
+      bonds.setBond(o, h2, BondInfo.SINGLE);
+      allFlex.add(null);
+    }
+    for (int i = 0; i < noOfAtoms; i++) {
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+    }
+
+    final Geometry g =
+        new Geometry(
+            c, 0, noOfMols, atsPerMol, molFlexies, allFlex, molConstr, constrXYZ, sids, bonds);
+
+    return g;
+  }
+
+  private static Geometry getWater2TIP4PDistorted() {
+
+    final short[] spins = new short[6];
+    final float[] charges = new float[6];
+    final int[] atsPerMol = new int[] {3, 3};
+
+    final String[] w2_distorted =
+        new String[] {
+          "6",
+          "Energy:              -6.5508",
+          "O             -0.0053998              0.0223328              0.1261801",
+          "H             -0.9200008             -0.0273239             -0.1517969",
+          "H              0.4970319             -0.1584812             -0.6682384",
+          "O              2.1931798              2.0700218             -2.1761271",
+          "H              3.0481182              1.8086380             -1.8340878",
+          "H              1.9936879              2.8892588             -1.7230422"
         };
-        
-        
-        CartesianCoordinates w2 = null;
-        try{
-            w2 = Input.parseCartesFromFileData(w2_distorted, 2, atsPerMol, spins, charges);
-        } catch(Exception e){
-            throw new Error("Error to parse in known w2 distorted geometry.",e);
-        }
-        
-        final int noOfMols = 2;
-        final int noOfAtoms = noOfMols*3;
-        final String[] sids = new String[noOfMols];
-        final boolean[] molFlexies = new boolean[noOfMols];
-        final boolean[] molConstr = new boolean[noOfMols];
-        final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
-        final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
-        final List<boolean[][]> allFlex = new ArrayList<>();
-        for(int i = 0; i < noOfMols; i++){
-            atsPerMol[i] = 3;
-            sids[i] = "OHH";
-            molFlexies[i] = false;
-            molConstr[i] = false;
-            final int o = i*3;
-            final int h1 = i*3+1;
-            final int h2 = i*3+2;
-            bonds.setBond(o, h1, BondInfo.SINGLE);
-            bonds.setBond(o, h2, BondInfo.SINGLE);
-            allFlex.add(null);
-        }
-        for(int i = 0; i < noOfAtoms; i++){
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-        }
-        
-        final Geometry g = new Geometry(w2, 0, noOfMols, atsPerMol,
-            molFlexies, allFlex, molConstr, constrXYZ,
-            sids, bonds);
-            
-        return g;
+
+    CartesianCoordinates w2 = null;
+    try {
+      w2 = Input.parseCartesFromFileData(w2_distorted, 2, atsPerMol, spins, charges);
+    } catch (Exception e) {
+      throw new Error("Error to parse in known w2 distorted geometry.", e);
     }
-    
-    private static Geometry getWater20TIP4P(){
-        final short[] spins = new short[60];
-        final float[] charges = new float[60];
-        final int[] atsPerMol = new int[]{3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3};
-        
-        final String[] w20_globMin = new String[]{
-            "60",
-            "25304   Energy =     -872.9887544952  kJ/mol",
-            "O    0.3470450  -0.7178074  -0.3141646",
-            "H   -0.4987771  -0.4023865  -0.6324831",
-            "H    0.4310626  -1.5958882  -0.6858463",
-            "O    1.6727305   1.3910313  -1.4036375",
-            "H    1.3457584   0.5950317  -0.9844648",
-            "H    2.0394098   1.0910128  -2.2353629",
-            "O    2.3018465   0.3812069  -3.8845400",
-            "H    3.1099899   0.3801893  -4.3975071",
-            "H    2.0321756  -0.5368862  -3.8597484",
-            "O    0.1025673  -3.1189675  -1.5785035",
-            "H   -0.7300398  -2.8548031  -1.9699297",
-            "H   -0.1423526  -3.7271640  -0.8811203",
-            "O   -2.8168905   0.4280904   1.3812494",
-            "H   -3.4076222  -0.3195473   1.4723865",
-            "H   -1.9935236   0.1320979   1.7694340",
-            "O   -4.0874498  -2.0205216   1.5782400",
-            "H   -3.9284136  -2.5432513   0.7923054",
-            "H   -4.9531663  -2.2967179   1.8790432",
-            "O   -3.4229815  -3.5842142  -0.5206354",
-            "H   -2.6411841  -4.0554473  -0.2326002",
-            "H   -3.1633283  -3.1685169  -1.3428324",
-            "O   -0.7506626   2.3661529  -2.1609725",
-            "H   -0.9151074   3.1344968  -1.6143121",
-            "H    0.1319230   2.0846668  -1.9200570",
-            "O   -2.0420422   0.1630925  -1.2136159",
-            "H   -1.7487716   1.0099069  -1.5499635",
-            "H   -2.4304310   0.3644856  -0.3622482",
-            "O   -0.2800640   1.1040261  -4.6117443",
-            "H    0.6548920   0.9730038  -4.4538758",
-            "H   -0.5698339   1.6605327  -3.8888571",
-            "O    0.4395343   2.1254982   2.8973441",
-            "H    0.8751504   2.4986854   2.1310530",
-            "H    0.9424998   2.4534973   3.6427798",
-            "O    1.4361964   3.2411346   0.6566335",
-            "H    0.7004338   3.7381475   0.2990532",
-            "H    1.6959489   2.6531787  -0.0526398",
-            "O   -1.0265126  -4.5692310   0.4896893",
-            "H   -0.8653801  -5.4371521   0.8597992",
-            "H   -1.1597562  -4.0046194   1.2510643",
-            "O    1.3071138  -2.1277620  -3.8956797",
-            "H    0.4836151  -2.0150491  -4.3704194",
-            "H    1.0632203  -2.6034941  -3.1016854",
-            "O   -1.1385446  -1.4258139  -5.0114174",
-            "H   -0.9184261  -0.5007828  -4.9014301",
-            "H   -1.4524214  -1.4922285  -5.9132503",
-            "O   -1.9905990   3.0299735   1.8988378",
-            "H   -1.2100748   2.7681006   2.3871375",
-            "H   -2.4725335   2.2144503   1.7613859",
-            "O   -0.9695361   4.3238367  -0.2345309",
-            "H   -1.2732431   5.2313581  -0.2145549",
-            "H   -1.4117555   3.9064496   0.5046998",
-            "O   -2.2412072  -2.1731324  -2.6014442",
-            "H   -2.2859870  -1.3195776  -2.1705486",
-            "H   -1.9941113  -1.9734685  -3.5043893",
-            "O   -1.6276977  -2.9066441   2.5290618",
-            "H   -2.5203412  -2.6143057   2.3447852",
-            "H   -1.1228631  -2.0977796   2.6133951",
-            "O   -0.3997161  -0.4285041   2.2859951",
-            "H    0.0022440  -0.5697997   1.4288512",
-            "H   -0.0190375   0.3927811   2.5971324"
+
+    final int noOfMols = 2;
+    final int noOfAtoms = noOfMols * 3;
+    final String[] sids = new String[noOfMols];
+    final boolean[] molFlexies = new boolean[noOfMols];
+    final boolean[] molConstr = new boolean[noOfMols];
+    final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
+    final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
+    final List<boolean[][]> allFlex = new ArrayList<>();
+    for (int i = 0; i < noOfMols; i++) {
+      atsPerMol[i] = 3;
+      sids[i] = "OHH";
+      molFlexies[i] = false;
+      molConstr[i] = false;
+      final int o = i * 3;
+      final int h1 = i * 3 + 1;
+      final int h2 = i * 3 + 2;
+      bonds.setBond(o, h1, BondInfo.SINGLE);
+      bonds.setBond(o, h2, BondInfo.SINGLE);
+      allFlex.add(null);
+    }
+    for (int i = 0; i < noOfAtoms; i++) {
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+    }
+
+    final Geometry g =
+        new Geometry(
+            w2, 0, noOfMols, atsPerMol, molFlexies, allFlex, molConstr, constrXYZ, sids, bonds);
+
+    return g;
+  }
+
+  private static Geometry getWater20TIP4P() {
+    final short[] spins = new short[60];
+    final float[] charges = new float[60];
+    final int[] atsPerMol = new int[] {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+    final String[] w20_globMin =
+        new String[] {
+          "60",
+          "25304   Energy =     -872.9887544952  kJ/mol",
+          "O    0.3470450  -0.7178074  -0.3141646",
+          "H   -0.4987771  -0.4023865  -0.6324831",
+          "H    0.4310626  -1.5958882  -0.6858463",
+          "O    1.6727305   1.3910313  -1.4036375",
+          "H    1.3457584   0.5950317  -0.9844648",
+          "H    2.0394098   1.0910128  -2.2353629",
+          "O    2.3018465   0.3812069  -3.8845400",
+          "H    3.1099899   0.3801893  -4.3975071",
+          "H    2.0321756  -0.5368862  -3.8597484",
+          "O    0.1025673  -3.1189675  -1.5785035",
+          "H   -0.7300398  -2.8548031  -1.9699297",
+          "H   -0.1423526  -3.7271640  -0.8811203",
+          "O   -2.8168905   0.4280904   1.3812494",
+          "H   -3.4076222  -0.3195473   1.4723865",
+          "H   -1.9935236   0.1320979   1.7694340",
+          "O   -4.0874498  -2.0205216   1.5782400",
+          "H   -3.9284136  -2.5432513   0.7923054",
+          "H   -4.9531663  -2.2967179   1.8790432",
+          "O   -3.4229815  -3.5842142  -0.5206354",
+          "H   -2.6411841  -4.0554473  -0.2326002",
+          "H   -3.1633283  -3.1685169  -1.3428324",
+          "O   -0.7506626   2.3661529  -2.1609725",
+          "H   -0.9151074   3.1344968  -1.6143121",
+          "H    0.1319230   2.0846668  -1.9200570",
+          "O   -2.0420422   0.1630925  -1.2136159",
+          "H   -1.7487716   1.0099069  -1.5499635",
+          "H   -2.4304310   0.3644856  -0.3622482",
+          "O   -0.2800640   1.1040261  -4.6117443",
+          "H    0.6548920   0.9730038  -4.4538758",
+          "H   -0.5698339   1.6605327  -3.8888571",
+          "O    0.4395343   2.1254982   2.8973441",
+          "H    0.8751504   2.4986854   2.1310530",
+          "H    0.9424998   2.4534973   3.6427798",
+          "O    1.4361964   3.2411346   0.6566335",
+          "H    0.7004338   3.7381475   0.2990532",
+          "H    1.6959489   2.6531787  -0.0526398",
+          "O   -1.0265126  -4.5692310   0.4896893",
+          "H   -0.8653801  -5.4371521   0.8597992",
+          "H   -1.1597562  -4.0046194   1.2510643",
+          "O    1.3071138  -2.1277620  -3.8956797",
+          "H    0.4836151  -2.0150491  -4.3704194",
+          "H    1.0632203  -2.6034941  -3.1016854",
+          "O   -1.1385446  -1.4258139  -5.0114174",
+          "H   -0.9184261  -0.5007828  -4.9014301",
+          "H   -1.4524214  -1.4922285  -5.9132503",
+          "O   -1.9905990   3.0299735   1.8988378",
+          "H   -1.2100748   2.7681006   2.3871375",
+          "H   -2.4725335   2.2144503   1.7613859",
+          "O   -0.9695361   4.3238367  -0.2345309",
+          "H   -1.2732431   5.2313581  -0.2145549",
+          "H   -1.4117555   3.9064496   0.5046998",
+          "O   -2.2412072  -2.1731324  -2.6014442",
+          "H   -2.2859870  -1.3195776  -2.1705486",
+          "H   -1.9941113  -1.9734685  -3.5043893",
+          "O   -1.6276977  -2.9066441   2.5290618",
+          "H   -2.5203412  -2.6143057   2.3447852",
+          "H   -1.1228631  -2.0977796   2.6133951",
+          "O   -0.3997161  -0.4285041   2.2859951",
+          "H    0.0022440  -0.5697997   1.4288512",
+          "H   -0.0190375   0.3927811   2.5971324"
         };
-        
-        CartesianCoordinates w20 = null;
-        try{
-            w20 = Input.parseCartesFromFileData(w20_globMin, 20, atsPerMol, spins, charges);
-        } catch(Exception e){
-            throw new Error("Error to parse in known w20 global minimum.",e);
-        }
-        
-        final int noOfMols = 20;
-        final int noOfAtoms = noOfMols*3;
-        final String[] sids = new String[noOfMols];
-        final boolean[] molFlexies = new boolean[noOfMols];
-        final boolean[] molConstr = new boolean[noOfMols];
-        final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
-        final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
-        final List<boolean[][]> allFlex = new ArrayList<>();
-        for(int i = 0; i < noOfMols; i++){
-            atsPerMol[i] = 3;
-            sids[i] = "OHH";
-            molFlexies[i] = false;
-            molConstr[i] = false;
-            final int o = i*3;
-            final int h1 = i*3+1;
-            final int h2 = i*3+2;
-            bonds.setBond(o, h1, BondInfo.SINGLE);
-            bonds.setBond(o, h2, BondInfo.SINGLE);
-            allFlex.add(null);
-        }
-        for(int i = 0; i < noOfAtoms; i++){
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-        }
-        
-        final Geometry g = new Geometry(w20, 0, noOfMols, atsPerMol,
-            molFlexies, allFlex, molConstr, constrXYZ,
-            sids, bonds);
-            
-        return g;
+
+    CartesianCoordinates w20 = null;
+    try {
+      w20 = Input.parseCartesFromFileData(w20_globMin, 20, atsPerMol, spins, charges);
+    } catch (Exception e) {
+      throw new Error("Error to parse in known w20 global minimum.", e);
     }
-    
-    private static Geometry getNoWaterTIP4P(){
-        
-        final short[] spins = new short[1];
-        final float[] charges = new float[1];
-        final int[] atsPerMol = new int[]{1};
-        
-        final String[] lj = new String[]{
-            "1",
-            "",
-            "Ar 0.0 0.0 0.0"
-        };
-        
-        CartesianCoordinates ar = null;
-        try{
-            ar = Input.parseCartesFromFileData(lj, 1, atsPerMol, spins, charges);
-        } catch(Exception e){
-            throw new Error("Error to parse in Ar single atom.",e);
-        }
-        
-        final int noOfMols = 1;
-        final int noOfAtoms = noOfMols*1;
-        final String[] sids = new String[noOfMols];
-        final boolean[] molFlexies = new boolean[noOfMols];
-        final boolean[] molConstr = new boolean[noOfMols];
-        final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
-        final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
-        final List<boolean[][]> allFlex = new ArrayList<>();
-        for(int i = 0; i < noOfMols; i++){
-            atsPerMol[i] = 1;
-            sids[i] = "Ar";
-            molFlexies[i] = false;
-            molConstr[i] = false;
-            allFlex.add(null);
-        }
-        for(int i = 0; i < noOfAtoms; i++){
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-        }
-        
-        final Geometry g = new Geometry(ar, 0, noOfMols, atsPerMol,
-            molFlexies, allFlex, molConstr, constrXYZ,
-            sids, bonds);
-            
-        return g;
+
+    final int noOfMols = 20;
+    final int noOfAtoms = noOfMols * 3;
+    final String[] sids = new String[noOfMols];
+    final boolean[] molFlexies = new boolean[noOfMols];
+    final boolean[] molConstr = new boolean[noOfMols];
+    final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
+    final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
+    final List<boolean[][]> allFlex = new ArrayList<>();
+    for (int i = 0; i < noOfMols; i++) {
+      atsPerMol[i] = 3;
+      sids[i] = "OHH";
+      molFlexies[i] = false;
+      molConstr[i] = false;
+      final int o = i * 3;
+      final int h1 = i * 3 + 1;
+      final int h2 = i * 3 + 2;
+      bonds.setBond(o, h1, BondInfo.SINGLE);
+      bonds.setBond(o, h2, BondInfo.SINGLE);
+      allFlex.add(null);
     }
+    for (int i = 0; i < noOfAtoms; i++) {
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+    }
+
+    final Geometry g =
+        new Geometry(
+            w20, 0, noOfMols, atsPerMol, molFlexies, allFlex, molConstr, constrXYZ, sids, bonds);
+
+    return g;
+  }
+
+  private static Geometry getNoWaterTIP4P() {
+
+    final short[] spins = new short[1];
+    final float[] charges = new float[1];
+    final int[] atsPerMol = new int[] {1};
+
+    final String[] lj = new String[] {"1", "", "Ar 0.0 0.0 0.0"};
+
+    CartesianCoordinates ar = null;
+    try {
+      ar = Input.parseCartesFromFileData(lj, 1, atsPerMol, spins, charges);
+    } catch (Exception e) {
+      throw new Error("Error to parse in Ar single atom.", e);
+    }
+
+    final int noOfMols = 1;
+    final int noOfAtoms = noOfMols * 1;
+    final String[] sids = new String[noOfMols];
+    final boolean[] molFlexies = new boolean[noOfMols];
+    final boolean[] molConstr = new boolean[noOfMols];
+    final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
+    final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
+    final List<boolean[][]> allFlex = new ArrayList<>();
+    for (int i = 0; i < noOfMols; i++) {
+      atsPerMol[i] = 1;
+      sids[i] = "Ar";
+      molFlexies[i] = false;
+      molConstr[i] = false;
+      allFlex.add(null);
+    }
+    for (int i = 0; i < noOfAtoms; i++) {
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+    }
+
+    final Geometry g =
+        new Geometry(
+            ar, 0, noOfMols, atsPerMol, molFlexies, allFlex, molConstr, constrXYZ, sids, bonds);
+
+    return g;
+  }
 }

--- a/tests/org/ogolem/core/TIP4PForceFieldTest.java
+++ b/tests/org/ogolem/core/TIP4PForceFieldTest.java
@@ -1,6 +1,6 @@
-/**
+/*
 Copyright (c) 2014-2015, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,284 +37,302 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.core;
 
-import java.util.ArrayList;
-import java.util.List;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.ogolem.core.Constants.ANGTOBOHR;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
 /**
- *
  * @author Johannes Dieterich
- * @version 2016-09-03
+ * @version 2021-07-17
  */
 public class TIP4PForceFieldTest {
-    
-    private static final double NUMACC = 1e-6;
 
-    /**
-     * Test of energy method, of class TIP4PForceField.
-     */
-    @Test
-    public void testEnergy() {
-        System.out.println("energy");
-        final Geometry ref = null; // can be null
-        final List<CartesianCoordinates> cartes = new ArrayList<>();
-        final double[][] coms = new double[2][];
-        // plug in the known global minimum structure for water 2
-        final CartesianCoordinates c1 = new CartesianCoordinates(3,1,new int[]{3});
-        final double[][] xyz1 = c1.getAllXYZCoord();
-        xyz1[0][0] = -0.1858140*ANGTOBOHR;
-        xyz1[1][0] = -1.1749469*ANGTOBOHR;
-        xyz1[2][0] = 0.7662596*ANGTOBOHR;
-        xyz1[0][1] = -0.1285513*ANGTOBOHR;
-        xyz1[1][1] = -0.8984365*ANGTOBOHR;
-        xyz1[2][1] = 1.6808606*ANGTOBOHR;
-        xyz1[0][2] = -0.0582782*ANGTOBOHR;
-        xyz1[1][2] = -0.3702550*ANGTOBOHR;
-        xyz1[2][2] = 0.2638279*ANGTOBOHR;
-        final String[] atoms1 = c1.getAllAtomTypes();
-        atoms1[0] = "O";
-        atoms1[1] = "H";
-        atoms1[2] = "H";
-        c1.recalcAtomNumbers();
-        
-        final double[] com1 = c1.calculateTheCOM();
-        c1.moveCoordsToCOM();
-        coms[0] = com1.clone();
-            
-        final CartesianCoordinates c2 = new CartesianCoordinates(3,1,new int[]{3});
-        final double[][] xyz2 = c2.getAllXYZCoord();
-        xyz2[0][0] = 0.1747051*ANGTOBOHR;
-        xyz2[1][0] = 1.1050002*ANGTOBOHR;
-        xyz2[2][0] = -0.7244430*ANGTOBOHR;
-        xyz2[0][1] = -0.5650842*ANGTOBOHR;
-        xyz2[1][1] = 1.3134964*ANGTOBOHR;
-        xyz2[2][1] = -1.2949455*ANGTOBOHR;
-        xyz2[0][2] = 0.9282185*ANGTOBOHR;
-        xyz2[1][2] = 1.0652990*ANGTOBOHR;
-        xyz2[2][2] = -1.313402*ANGTOBOHR;
-        final String[] atoms2 = c2.getAllAtomTypes();
-        atoms2[0] = "O";
-        atoms2[1] = "H";
-        atoms2[2] = "H";
-        c2.recalcAtomNumbers();
-        
-        final double[] com2 = c2.calculateTheCOM();
-        c2.moveCoordsToCOM();
-        coms[1] = com2.clone();
-        
-        final TIP4PForceField instance = new TIP4PForceField();
-        final CartesianCoordinates c1Adj = instance.adjustCartesians(ref, c1, 0);
-        final CartesianCoordinates c2Adj = instance.adjustCartesians(ref, c2, 0);
-        
-        cartes.add(c1Adj);
-        cartes.add(c2Adj);
-        
-        final int counter = 0;
-        
-        final double expResult = -0.009936231756023471; // according to DJW data base
-        final double result = instance.energy(ref, cartes, coms, counter);
-        assertEquals(expResult, result, NUMACC);
-    }
-    
-    @Test
-    public void testEnergyDistorted(){
-        System.out.println("energy (distorted)");
-        // uses a distorted w2 geometry which proved cumbersome
-        
-        final short[] spins = new short[6];
-        final float[] charges = new float[6];
-        final int[] atsPerMol = new int[]{3,3};
-        
-        final String[] w2_distr = new String[]{
-            "6",
-            "Energy:             -29.3998(WRONG!)",
-            "O              0.2561280             -0.7959166              1.0388088",
-            "H             -0.4705858             -0.6439888              1.6513454",
-            "H              0.8425446             -1.2880304              1.5995301",
-            "O             -0.3597538              1.3336911             -0.6140416",
-            "H             -1.0841008              0.7575674             -1.1219294",
-            "H              0.0397342              0.5679421             -0.0935937"
+  private static final double NUMACC = 1e-6;
+
+  /** Test of energy method, of class TIP4PForceField. */
+  @Test
+  public void testEnergy() {
+    System.out.println("energy");
+    final Geometry ref = null; // can be null
+    final List<CartesianCoordinates> cartes = new ArrayList<>();
+    final double[][] coms = new double[2][];
+    // plug in the known global minimum structure for water 2
+    final CartesianCoordinates c1 = new CartesianCoordinates(3, 1, new int[] {3});
+    final double[][] xyz1 = c1.getAllXYZCoord();
+    xyz1[0][0] = -0.1858140 * ANGTOBOHR;
+    xyz1[1][0] = -1.1749469 * ANGTOBOHR;
+    xyz1[2][0] = 0.7662596 * ANGTOBOHR;
+    xyz1[0][1] = -0.1285513 * ANGTOBOHR;
+    xyz1[1][1] = -0.8984365 * ANGTOBOHR;
+    xyz1[2][1] = 1.6808606 * ANGTOBOHR;
+    xyz1[0][2] = -0.0582782 * ANGTOBOHR;
+    xyz1[1][2] = -0.3702550 * ANGTOBOHR;
+    xyz1[2][2] = 0.2638279 * ANGTOBOHR;
+    final String[] atoms1 = c1.getAllAtomTypes();
+    atoms1[0] = "O";
+    atoms1[1] = "H";
+    atoms1[2] = "H";
+    c1.recalcAtomNumbers();
+
+    final double[] com1 = c1.calculateTheCOM();
+    c1.moveCoordsToCOM();
+    coms[0] = com1.clone();
+
+    final CartesianCoordinates c2 = new CartesianCoordinates(3, 1, new int[] {3});
+    final double[][] xyz2 = c2.getAllXYZCoord();
+    xyz2[0][0] = 0.1747051 * ANGTOBOHR;
+    xyz2[1][0] = 1.1050002 * ANGTOBOHR;
+    xyz2[2][0] = -0.7244430 * ANGTOBOHR;
+    xyz2[0][1] = -0.5650842 * ANGTOBOHR;
+    xyz2[1][1] = 1.3134964 * ANGTOBOHR;
+    xyz2[2][1] = -1.2949455 * ANGTOBOHR;
+    xyz2[0][2] = 0.9282185 * ANGTOBOHR;
+    xyz2[1][2] = 1.0652990 * ANGTOBOHR;
+    xyz2[2][2] = -1.313402 * ANGTOBOHR;
+    final String[] atoms2 = c2.getAllAtomTypes();
+    atoms2[0] = "O";
+    atoms2[1] = "H";
+    atoms2[2] = "H";
+    c2.recalcAtomNumbers();
+
+    final double[] com2 = c2.calculateTheCOM();
+    c2.moveCoordsToCOM();
+    coms[1] = com2.clone();
+
+    final TIP4PForceField instance = new TIP4PForceField();
+    final CartesianCoordinates c1Adj = instance.adjustCartesians(ref, c1, 0);
+    final CartesianCoordinates c2Adj = instance.adjustCartesians(ref, c2, 0);
+
+    cartes.add(c1Adj);
+    cartes.add(c2Adj);
+
+    final int counter = 0;
+
+    final double expResult = -0.009936231756023471; // according to DJW data base
+    final double result = instance.energy(ref, cartes, coms, counter);
+    assertEquals(expResult, result, NUMACC);
+  }
+
+  @Test
+  public void testEnergyDistorted() {
+    System.out.println("energy (distorted)");
+    // uses a distorted w2 geometry which proved cumbersome
+
+    final short[] spins = new short[6];
+    final float[] charges = new float[6];
+    final int[] atsPerMol = new int[] {3, 3};
+
+    final String[] w2_distr =
+        new String[] {
+          "6",
+          "Energy:             -29.3998(WRONG!)",
+          "O              0.2561280             -0.7959166              1.0388088",
+          "H             -0.4705858             -0.6439888              1.6513454",
+          "H              0.8425446             -1.2880304              1.5995301",
+          "O             -0.3597538              1.3336911             -0.6140416",
+          "H             -1.0841008              0.7575674             -1.1219294",
+          "H              0.0397342              0.5679421             -0.0935937"
         };
-        
-        CartesianCoordinates w2Dist = null;
-        try{
-            w2Dist = Input.parseCartesFromFileData(w2_distr, 2, atsPerMol, spins, charges);
-        } catch(Exception e){
-            throw new Error("Error to parse in known w2 distorted minimum.",e);
-        }
-       
-        final TIP4PForceField instance = new TIP4PForceField();
-        
-        final int noOfMols = 2;
-        final int noOfAtoms = noOfMols*3;
-        final String[] sids = new String[noOfMols];
-        final boolean[] molFlexies = new boolean[noOfMols];
-        final boolean[] molConstr = new boolean[noOfMols];
-        final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
-        final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
-        final List<boolean[][]> allFlex = new ArrayList<>();
-        for(int i = 0; i < noOfMols; i++){
-            atsPerMol[i] = 3;
-            sids[i] = "OHH";
-            molFlexies[i] = false;
-            molConstr[i] = false;
-            final int o = i*3;
-            final int h1 = i*3+1;
-            final int h2 = i*3+2;
-            bonds.setBond(o, h1, BondInfo.SINGLE);
-            bonds.setBond(o, h2, BondInfo.SINGLE);
-            allFlex.add(null);
-        }
-        for(int i = 0; i < noOfAtoms; i++){
-            constrXYZ[0][i] = false;
-            constrXYZ[1][i] = false;
-            constrXYZ[2][i] = false;
-        }
-        
-        final Geometry ref = new Geometry(w2Dist, 0, noOfMols, atsPerMol,
-            molFlexies, allFlex, molConstr, constrXYZ,
-            sids, bonds);
-        final TIPnPParameters.StandardTIP4PParameters tip4pParams = new TIPnPParameters.StandardTIP4PParameters();
-        for(int i = 0; i < noOfMols; i++){
-            // adjust
-            instance.rigidify(ref.getMoleculeAtPosition(i));
-            
-            // check the OH ditance and H-O-H angle
-            final double[][] xyz = ref.getMoleculeAtPosition(i).getReferenceCartesians();
-            final double distOH1 = CoordTranslation.distance(xyz, 0, 1);
-            final double distOH2 = CoordTranslation.distance(xyz, 0, 2);
-            final double angHOH = CoordTranslation.calcAngle(xyz, 1, 0, 2);
-            assertEquals(distOH1,tip4pParams.getOH(),NUMACC);
-            assertEquals(distOH2,tip4pParams.getOH(),NUMACC);
-            assertEquals(angHOH,Math.toRadians(tip4pParams.getHOH()),NUMACC);
-        }
-        
-        final List<CartesianCoordinates> cartes = new ArrayList<>();
-        final double[][] coms = new double[2][];
-        final CartesianCoordinates rigidified = ref.getCartesians();
-        
-        for(int mol = 0; mol < 2; mol++){
-            final CartesianCoordinates molC = rigidified.giveMolecularCartes(mol, false);
-            final double[] com = molC.calculateTheCOM();
-            coms[mol] = com;
-            molC.moveCoordsToCOM();
-            
-            final CartesianCoordinates molCAdj = instance.adjustCartesians(null, molC, mol);
-            
-            cartes.add(molCAdj);
-        }
-        
-        final int counter = 0;
-        
-        final double expResult = -23.168783044616152*Constants.KJTOHARTREE; // according to phenix
-        final double result = instance.energy(ref, cartes, coms, counter);
-        // we want to make sure, that our implementation AT LEAST is as "high energy" as phenix for this weird case
-        assertTrue("Distorted TIP4P energy fails: " + expResult + " got " + result + " diff " + (expResult-result), (expResult-result) <= 0.0);
+
+    CartesianCoordinates w2Dist = null;
+    try {
+      w2Dist = Input.parseCartesFromFileData(w2_distr, 2, atsPerMol, spins, charges);
+    } catch (Exception e) {
+      throw new Error("Error to parse in known w2 distorted minimum.", e);
     }
-    
-    @Test
-    public void testEnergyBig(){
-        System.out.println("energy (big)");
-        // get the w20 global minimum and calculate the energy. also stresses other subsystems.
-        
-        final short[] spins = new short[60];
-        final float[] charges = new float[60];
-        final int[] atsPerMol = new int[]{3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3};
-        
-        final String[] w20_globMin = new String[]{
-            "60",
-            "25304   Energy =     -872.9887544952  kJ/mol",
-            "O    0.3470450  -0.7178074  -0.3141646",
-            "H   -0.4987771  -0.4023865  -0.6324831",
-            "H    0.4310626  -1.5958882  -0.6858463",
-            "O    1.6727305   1.3910313  -1.4036375",
-            "H    1.3457584   0.5950317  -0.9844648",
-            "H    2.0394098   1.0910128  -2.2353629",
-            "O    2.3018465   0.3812069  -3.8845400",
-            "H    3.1099899   0.3801893  -4.3975071",
-            "H    2.0321756  -0.5368862  -3.8597484",
-            "O    0.1025673  -3.1189675  -1.5785035",
-            "H   -0.7300398  -2.8548031  -1.9699297",
-            "H   -0.1423526  -3.7271640  -0.8811203",
-            "O   -2.8168905   0.4280904   1.3812494",
-            "H   -3.4076222  -0.3195473   1.4723865",
-            "H   -1.9935236   0.1320979   1.7694340",
-            "O   -4.0874498  -2.0205216   1.5782400",
-            "H   -3.9284136  -2.5432513   0.7923054",
-            "H   -4.9531663  -2.2967179   1.8790432",
-            "O   -3.4229815  -3.5842142  -0.5206354",
-            "H   -2.6411841  -4.0554473  -0.2326002",
-            "H   -3.1633283  -3.1685169  -1.3428324",
-            "O   -0.7506626   2.3661529  -2.1609725",
-            "H   -0.9151074   3.1344968  -1.6143121",
-            "H    0.1319230   2.0846668  -1.9200570",
-            "O   -2.0420422   0.1630925  -1.2136159",
-            "H   -1.7487716   1.0099069  -1.5499635",
-            "H   -2.4304310   0.3644856  -0.3622482",
-            "O   -0.2800640   1.1040261  -4.6117443",
-            "H    0.6548920   0.9730038  -4.4538758",
-            "H   -0.5698339   1.6605327  -3.8888571",
-            "O    0.4395343   2.1254982   2.8973441",
-            "H    0.8751504   2.4986854   2.1310530",
-            "H    0.9424998   2.4534973   3.6427798",
-            "O    1.4361964   3.2411346   0.6566335",
-            "H    0.7004338   3.7381475   0.2990532",
-            "H    1.6959489   2.6531787  -0.0526398",
-            "O   -1.0265126  -4.5692310   0.4896893",
-            "H   -0.8653801  -5.4371521   0.8597992",
-            "H   -1.1597562  -4.0046194   1.2510643",
-            "O    1.3071138  -2.1277620  -3.8956797",
-            "H    0.4836151  -2.0150491  -4.3704194",
-            "H    1.0632203  -2.6034941  -3.1016854",
-            "O   -1.1385446  -1.4258139  -5.0114174",
-            "H   -0.9184261  -0.5007828  -4.9014301",
-            "H   -1.4524214  -1.4922285  -5.9132503",
-            "O   -1.9905990   3.0299735   1.8988378",
-            "H   -1.2100748   2.7681006   2.3871375",
-            "H   -2.4725335   2.2144503   1.7613859",
-            "O   -0.9695361   4.3238367  -0.2345309",
-            "H   -1.2732431   5.2313581  -0.2145549",
-            "H   -1.4117555   3.9064496   0.5046998",
-            "O   -2.2412072  -2.1731324  -2.6014442",
-            "H   -2.2859870  -1.3195776  -2.1705486",
-            "H   -1.9941113  -1.9734685  -3.5043893",
-            "O   -1.6276977  -2.9066441   2.5290618",
-            "H   -2.5203412  -2.6143057   2.3447852",
-            "H   -1.1228631  -2.0977796   2.6133951",
-            "O   -0.3997161  -0.4285041   2.2859951",
-            "H    0.0022440  -0.5697997   1.4288512",
-            "H   -0.0190375   0.3927811   2.5971324"
+
+    final TIP4PForceField instance = new TIP4PForceField();
+
+    final int noOfMols = 2;
+    final int noOfAtoms = noOfMols * 3;
+    final String[] sids = new String[noOfMols];
+    final boolean[] molFlexies = new boolean[noOfMols];
+    final boolean[] molConstr = new boolean[noOfMols];
+    final boolean[][] constrXYZ = new boolean[3][noOfAtoms];
+    final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
+    final List<boolean[][]> allFlex = new ArrayList<>();
+    for (int i = 0; i < noOfMols; i++) {
+      atsPerMol[i] = 3;
+      sids[i] = "OHH";
+      molFlexies[i] = false;
+      molConstr[i] = false;
+      final int o = i * 3;
+      final int h1 = i * 3 + 1;
+      final int h2 = i * 3 + 2;
+      bonds.setBond(o, h1, BondInfo.SINGLE);
+      bonds.setBond(o, h2, BondInfo.SINGLE);
+      allFlex.add(null);
+    }
+    for (int i = 0; i < noOfAtoms; i++) {
+      constrXYZ[0][i] = false;
+      constrXYZ[1][i] = false;
+      constrXYZ[2][i] = false;
+    }
+
+    final Geometry ref =
+        new Geometry(
+            w2Dist, 0, noOfMols, atsPerMol, molFlexies, allFlex, molConstr, constrXYZ, sids, bonds);
+    final TIPnPParameters.StandardTIP4PParameters tip4pParams =
+        new TIPnPParameters.StandardTIP4PParameters();
+    for (int i = 0; i < noOfMols; i++) {
+      // adjust
+      instance.rigidify(ref.getMoleculeAtPosition(i));
+
+      // check the OH ditance and H-O-H angle
+      final double[][] xyz = ref.getMoleculeAtPosition(i).getReferenceCartesians();
+      final double distOH1 = CoordTranslation.distance(xyz, 0, 1);
+      final double distOH2 = CoordTranslation.distance(xyz, 0, 2);
+      final double angHOH = CoordTranslation.calcAngle(xyz, 1, 0, 2);
+      assertEquals(distOH1, tip4pParams.getOH(), NUMACC);
+      assertEquals(distOH2, tip4pParams.getOH(), NUMACC);
+      assertEquals(angHOH, Math.toRadians(tip4pParams.getHOH()), NUMACC);
+    }
+
+    final List<CartesianCoordinates> cartes = new ArrayList<>();
+    final double[][] coms = new double[2][];
+    final CartesianCoordinates rigidified = ref.getCartesians();
+
+    for (int mol = 0; mol < 2; mol++) {
+      final CartesianCoordinates molC = rigidified.giveMolecularCartes(mol, false);
+      final double[] com = molC.calculateTheCOM();
+      coms[mol] = com;
+      molC.moveCoordsToCOM();
+
+      final CartesianCoordinates molCAdj = instance.adjustCartesians(null, molC, mol);
+
+      cartes.add(molCAdj);
+    }
+
+    final int counter = 0;
+
+    final double expResult = -23.168783044616152 * Constants.KJTOHARTREE; // according to phenix
+    final double result = instance.energy(ref, cartes, coms, counter);
+    // we want to make sure, that our implementation AT LEAST is as "high energy" as phenix for this
+    // weird case
+    assertTrue(
+        (expResult - result) <= 0.0,
+        "Distorted TIP4P energy fails: "
+            + expResult
+            + " got "
+            + result
+            + " diff "
+            + (expResult - result));
+  }
+
+  @Test
+  public void testEnergyBig() {
+    System.out.println("energy (big)");
+    // get the w20 global minimum and calculate the energy. also stresses other subsystems.
+
+    final short[] spins = new short[60];
+    final float[] charges = new float[60];
+    final int[] atsPerMol = new int[] {3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+    final String[] w20_globMin =
+        new String[] {
+          "60",
+          "25304   Energy =     -872.9887544952  kJ/mol",
+          "O    0.3470450  -0.7178074  -0.3141646",
+          "H   -0.4987771  -0.4023865  -0.6324831",
+          "H    0.4310626  -1.5958882  -0.6858463",
+          "O    1.6727305   1.3910313  -1.4036375",
+          "H    1.3457584   0.5950317  -0.9844648",
+          "H    2.0394098   1.0910128  -2.2353629",
+          "O    2.3018465   0.3812069  -3.8845400",
+          "H    3.1099899   0.3801893  -4.3975071",
+          "H    2.0321756  -0.5368862  -3.8597484",
+          "O    0.1025673  -3.1189675  -1.5785035",
+          "H   -0.7300398  -2.8548031  -1.9699297",
+          "H   -0.1423526  -3.7271640  -0.8811203",
+          "O   -2.8168905   0.4280904   1.3812494",
+          "H   -3.4076222  -0.3195473   1.4723865",
+          "H   -1.9935236   0.1320979   1.7694340",
+          "O   -4.0874498  -2.0205216   1.5782400",
+          "H   -3.9284136  -2.5432513   0.7923054",
+          "H   -4.9531663  -2.2967179   1.8790432",
+          "O   -3.4229815  -3.5842142  -0.5206354",
+          "H   -2.6411841  -4.0554473  -0.2326002",
+          "H   -3.1633283  -3.1685169  -1.3428324",
+          "O   -0.7506626   2.3661529  -2.1609725",
+          "H   -0.9151074   3.1344968  -1.6143121",
+          "H    0.1319230   2.0846668  -1.9200570",
+          "O   -2.0420422   0.1630925  -1.2136159",
+          "H   -1.7487716   1.0099069  -1.5499635",
+          "H   -2.4304310   0.3644856  -0.3622482",
+          "O   -0.2800640   1.1040261  -4.6117443",
+          "H    0.6548920   0.9730038  -4.4538758",
+          "H   -0.5698339   1.6605327  -3.8888571",
+          "O    0.4395343   2.1254982   2.8973441",
+          "H    0.8751504   2.4986854   2.1310530",
+          "H    0.9424998   2.4534973   3.6427798",
+          "O    1.4361964   3.2411346   0.6566335",
+          "H    0.7004338   3.7381475   0.2990532",
+          "H    1.6959489   2.6531787  -0.0526398",
+          "O   -1.0265126  -4.5692310   0.4896893",
+          "H   -0.8653801  -5.4371521   0.8597992",
+          "H   -1.1597562  -4.0046194   1.2510643",
+          "O    1.3071138  -2.1277620  -3.8956797",
+          "H    0.4836151  -2.0150491  -4.3704194",
+          "H    1.0632203  -2.6034941  -3.1016854",
+          "O   -1.1385446  -1.4258139  -5.0114174",
+          "H   -0.9184261  -0.5007828  -4.9014301",
+          "H   -1.4524214  -1.4922285  -5.9132503",
+          "O   -1.9905990   3.0299735   1.8988378",
+          "H   -1.2100748   2.7681006   2.3871375",
+          "H   -2.4725335   2.2144503   1.7613859",
+          "O   -0.9695361   4.3238367  -0.2345309",
+          "H   -1.2732431   5.2313581  -0.2145549",
+          "H   -1.4117555   3.9064496   0.5046998",
+          "O   -2.2412072  -2.1731324  -2.6014442",
+          "H   -2.2859870  -1.3195776  -2.1705486",
+          "H   -1.9941113  -1.9734685  -3.5043893",
+          "O   -1.6276977  -2.9066441   2.5290618",
+          "H   -2.5203412  -2.6143057   2.3447852",
+          "H   -1.1228631  -2.0977796   2.6133951",
+          "O   -0.3997161  -0.4285041   2.2859951",
+          "H    0.0022440  -0.5697997   1.4288512",
+          "H   -0.0190375   0.3927811   2.5971324"
         };
-        
-        CartesianCoordinates w20 = null;
-        try{
-            w20 = Input.parseCartesFromFileData(w20_globMin, 20, atsPerMol, spins, charges);
-        } catch(Exception e){
-            throw new Error("Error to parse in known w20 global minimum.",e);
-        }
-       
-        final TIP4PForceField instance = new TIP4PForceField();
-        
-        final List<CartesianCoordinates> cartes = new ArrayList<>();
-        final double[][] coms = new double[20][];
-        for(int mol = 0; mol < 20; mol++){
-            final CartesianCoordinates molC = w20.giveMolecularCartes(mol, false);
-            final double[] com = molC.calculateTheCOM();
-            coms[mol] = com;
-            molC.moveCoordsToCOM();
-            
-            final CartesianCoordinates molCAdj = instance.adjustCartesians(null, molC, mol);
-            
-            cartes.add(molCAdj);
-        }
-        
-        final Geometry ref = null; // can be null
-        final int counter = 0;
-        
-        final double expResult = -0.3325038695132564; // according to DJW data base
-        final double result = instance.energy(ref, cartes, coms, counter);
-        assertEquals("Big TIP4P energy fails: " + expResult + " got " + result + " diff " + Math.abs(expResult-result),expResult, result, NUMACC);
+
+    CartesianCoordinates w20 = null;
+    try {
+      w20 = Input.parseCartesFromFileData(w20_globMin, 20, atsPerMol, spins, charges);
+    } catch (Exception e) {
+      throw new Error("Error to parse in known w20 global minimum.", e);
     }
+
+    final TIP4PForceField instance = new TIP4PForceField();
+
+    final List<CartesianCoordinates> cartes = new ArrayList<>();
+    final double[][] coms = new double[20][];
+    for (int mol = 0; mol < 20; mol++) {
+      final CartesianCoordinates molC = w20.giveMolecularCartes(mol, false);
+      final double[] com = molC.calculateTheCOM();
+      coms[mol] = com;
+      molC.moveCoordsToCOM();
+
+      final CartesianCoordinates molCAdj = instance.adjustCartesians(null, molC, mol);
+
+      cartes.add(molCAdj);
+    }
+
+    final Geometry ref = null; // can be null
+    final int counter = 0;
+
+    final double expResult = -0.3325038695132564; // according to DJW data base
+    final double result = instance.energy(ref, cartes, coms, counter);
+    assertEquals(
+        expResult,
+        result,
+        NUMACC,
+        "Big TIP4P energy fails: "
+            + expResult
+            + " got "
+            + result
+            + " diff "
+            + Math.abs(expResult - result));
+  }
 }

--- a/tests/org/ogolem/locopt/BOBYQALocOptTest.java
+++ b/tests/org/ogolem/locopt/BOBYQALocOptTest.java
@@ -1,6 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
-                2015, J. M. Dieterich and B. Hartke
+              2015-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,65 +37,70 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for BOBYQA, the bound-constraint gradient-free optimizer.
+ *
  * @author Johannes Dieterich
- * @version 2015-03-28
+ * @version 2021-07-17
  */
 public class BOBYQALocOptTest {
-    
-    /**
-     * Test of optimize method, of class PraxisLocOpt.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
-        final Random r = new Random();
-        final double a = 0.0001;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final double convergedTrust = 1e-6;
-        final double initialTrust = 1e-1;
-        final int maxIter = 9999;
-        final int noTrials = 100;
-        final int dim = 42;
-        final HarmonicFunction func = new HarmonicFunction(a,shift,b, 0.0, 42*shift);
-        
-        final double[][] bounds = new double[2][dim];
-        for(int x = 0; x < dim; x++){
-            bounds[0][x] = 0.0;
-            bounds[1][x] = 42.0+shift;
-        }
-        
-        final BOBYQALocOpt<Double,BasicOptimizableType> instance1 = new BOBYQALocOpt<>(func,maxIter,initialTrust,convergedTrust);
-        
-        for(int trial = 0; trial < noTrials; trial++){
-            final double[] gen1 = new double[dim];
-        
-            // random init
-            for(int x = 0; x < dim; x++){
-                final double d = 42.0*r.nextDouble()+shift;
-                // normalize [0.0; 42+shift]
-                gen1[x] = (d)/(42+shift);
-            }
-                    
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
-        
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
-            
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= convergedTrust);
-            //SHIT! Does not work. So does the res1Dat stuff... CRAP!;
-            
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for(int x = 0; x < dim; x++){
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x]-shift) + " in " + x, Math.abs(res1Dat[x]-shift) <= 10*convergedTrust); // make it a bit bigger
-            }
-        }
+
+  /** Test of optimize method, of class PraxisLocOpt. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
+    final Random r = new Random();
+    final double a = 0.0001;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final double convergedTrust = 1e-6;
+    final double initialTrust = 1e-1;
+    final int maxIter = 9999;
+    final int noTrials = 100;
+    final int dim = 42;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b, 0.0, 42 * shift);
+
+    final double[][] bounds = new double[2][dim];
+    for (int x = 0; x < dim; x++) {
+      bounds[0][x] = 0.0;
+      bounds[1][x] = 42.0 + shift;
     }
-    
+
+    final BOBYQALocOpt<Double, BasicOptimizableType> instance1 =
+        new BOBYQALocOpt<>(func, maxIter, initialTrust, convergedTrust);
+
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
+
+      // random init
+      for (int x = 0; x < dim; x++) {
+        final double d = 42.0 * r.nextDouble() + shift;
+        // normalize [0.0; 42+shift]
+        gen1[x] = (d) / (42 + shift);
+      }
+
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
+
+      // check
+      assertTrue(
+          Math.abs(res1.getFitness()) <= convergedTrust, "Fitness (I) wrong: " + res1.getFitness());
+
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * convergedTrust,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
+    }
+  }
 }

--- a/tests/org/ogolem/locopt/FIRELocOptTest.java
+++ b/tests/org/ogolem/locopt/FIRELocOptTest.java
@@ -1,94 +1,96 @@
-/**
- Copyright (c) 2019, M. Dittner, B. Hartke
-               2020, D. Behrens, M. Dittner, B. Hartke
- All rights reserved.
+/*
+Copyright (c) 2019, M. Dittner, B. Hartke
+              2020, D. Behrens, M. Dittner, B. Hartke
+              2021, D. Behrens, M. Dittner, J. M. Dieterich, B. Hartke
+All rights reserved.
 
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright
- notice, this list of conditions and the following disclaimer.
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
 
- * Redistributions in binary form must reproduce the above copyright
- notice, this list of conditions and the following disclaimer in the
- documentation and/or other materials provided with the distribution.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
 
- * Neither the name of the copyright holder nor the names of its
- contributors may be used to endorse or promote products derived from
- this software without specific prior written permission.
+* Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
- THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
- EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
- DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for the FIRE.
  *
  * @author Dominik Behrens
- * @version 2020-04-21
+ * @version 2021-07-17
  */
 public class FIRELocOptTest {
 
-    /**
-     * Testing the FIRE's optimize method.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
+  /** Testing the FIRE's optimize method. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
 
-        // Generate harmonic Function
-        final Random r = new Random();
-        final double a = 0.0001;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final HarmonicFunction func = new HarmonicFunction(a, shift, b);
+    // Generate harmonic Function
+    final Random r = new Random();
+    final double a = 0.0001;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b);
 
-        // Some basic FIRE setup
-        FIRELocOpt.FireConfig fc = new FIRELocOpt.FireConfig();
-        fc.iMaxIterations = 1000;
-        fc.dFMax = 1e-12;
-        fc.dMaxMove = 0.2;
-        final FIRELocOpt<Double, BasicOptimizableType> instance1 = new FIRELocOpt<>(fc, func);
+    // Some basic FIRE setup
+    FIRELocOpt.FireConfig fc = new FIRELocOpt.FireConfig();
+    fc.iMaxIterations = 1000;
+    fc.dFMax = 1e-12;
+    fc.dMaxMove = 0.2;
+    final FIRELocOpt<Double, BasicOptimizableType> instance1 = new FIRELocOpt<>(fc, func);
 
-        int noTrials = 100;
-        int dim = 42;
-        double numAcc = 1e-7;
+    int noTrials = 100;
+    int dim = 42;
+    double numAcc = 1e-7;
 
-        for (int trial = 0; trial < noTrials; trial++) {
-            final double[] gen1 = new double[dim];
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
 
-            // random init
-            for (int x = 0; x < dim; x++) {
-                gen1[x] = 42.0 * r.nextDouble() + shift;
-            }
+      // random init
+      for (int x = 0; x < dim; x++) {
+        gen1[x] = 42.0 * r.nextDouble() + shift;
+      }
 
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
 
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
 
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= numAcc);
+      // check
+      assertTrue(Math.abs(res1.getFitness()) <= numAcc, "Fitness (I) wrong: " + res1.getFitness());
 
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for (int x = 0; x < dim; x++) {
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x] - shift) + " in " + x,
-                        Math.abs(res1Dat[x] - shift) <= 10 * numAcc); // make it a bit bigger
-            }
-        }
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * numAcc,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
     }
+  }
 }

--- a/tests/org/ogolem/locopt/FleminLocOptTest.java
+++ b/tests/org/ogolem/locopt/FleminLocOptTest.java
@@ -1,5 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
+              2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,55 +37,60 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for NUMAL's Flemin optimizer.
+ *
  * @author Johannes Dieterich
- * @version 2014-12-16
+ * @version 2021-07-17
  */
 public class FleminLocOptTest {
-    
-    /**
-     * Test of optimize method, of class FleminLocOpt.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
-        final Random r = new Random();
-        final double a = 0.0001;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final double numAcc = 1e-7;
-        final int maxIter = 1000;
-        final int noTrials = 100;
-        final int dim = 42;
-        final HarmonicFunction func = new HarmonicFunction(a,shift,b);
-        
-        final FleminLocOpt<Double,BasicOptimizableType> instance1 = new FleminLocOpt<>(func,numAcc,numAcc,maxIter);
-        
-        for(int trial = 0; trial < noTrials; trial++){
-            final double[] gen1 = new double[dim];
-        
-            // random init
-            for(int x = 0; x < dim; x++){
-                gen1[x] = 42.0*r.nextDouble()+shift;
-            }
-        
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
-        
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
-            
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= numAcc);
-            
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for(int x = 0; x < dim; x++){
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x]-shift) + " in " + x, Math.abs(res1Dat[x]-shift) <= 10*numAcc); // make it a bit bigger
-            }
-        }
+
+  /** Test of optimize method, of class FleminLocOpt. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
+    final Random r = new Random();
+    final double a = 0.0001;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final double numAcc = 1e-7;
+    final int maxIter = 1000;
+    final int noTrials = 100;
+    final int dim = 42;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b);
+
+    final FleminLocOpt<Double, BasicOptimizableType> instance1 =
+        new FleminLocOpt<>(func, numAcc, numAcc, maxIter);
+
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
+
+      // random init
+      for (int x = 0; x < dim; x++) {
+        gen1[x] = 42.0 * r.nextDouble() + shift;
+      }
+
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
+
+      // check
+      assertTrue(Math.abs(res1.getFitness()) <= numAcc, "Fitness (I) wrong: " + res1.getFitness());
+
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * numAcc,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
     }
-    
+  }
 }

--- a/tests/org/ogolem/locopt/LBFGSLocOptTest.java
+++ b/tests/org/ogolem/locopt/LBFGSLocOptTest.java
@@ -1,5 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
+              2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,58 +37,63 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for RISO's L-BFGS optimizer.
+ *
  * @author Johannes Dieterich
- * @version 2014-12-16
+ * @version 2021-07-17
  */
 public class LBFGSLocOptTest {
-    
-    /**
-     * Test of optimize method, of class LBFGSLocOpt.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
-        final Random r = new Random();
-        final double a = 0.0001;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final double numAcc = 1e-7;
-        final double gtol = 0.9;
-        final int lineIter = 50;
-        final int noCorrs = 7;
-        final int maxIter = 1000;
-        final int noTrials = 100;
-        final int dim = 42;
-        final HarmonicFunction func = new HarmonicFunction(a,shift,b);
-        
-        final LBFGSLocOpt<Double,BasicOptimizableType> instance1 = new LBFGSLocOpt<>(func,noCorrs,maxIter,numAcc,gtol,lineIter,0);
-        
-        for(int trial = 0; trial < noTrials; trial++){
-            final double[] gen1 = new double[dim];
-        
-            // random init
-            for(int x = 0; x < dim; x++){
-                gen1[x] = 42.0*r.nextDouble()+shift;
-            }
-        
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
-        
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
-            
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= numAcc);
-            
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for(int x = 0; x < dim; x++){
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x]-shift) + " in " + x, Math.abs(res1Dat[x]-shift) <= 10*numAcc); // make it a bit bigger
-            }
-        }
+
+  /** Test of optimize method, of class LBFGSLocOpt. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
+    final Random r = new Random();
+    final double a = 0.0001;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final double numAcc = 1e-7;
+    final double gtol = 0.9;
+    final int lineIter = 50;
+    final int noCorrs = 7;
+    final int maxIter = 1000;
+    final int noTrials = 100;
+    final int dim = 42;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b);
+
+    final LBFGSLocOpt<Double, BasicOptimizableType> instance1 =
+        new LBFGSLocOpt<>(func, noCorrs, maxIter, numAcc, gtol, lineIter, 0);
+
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
+
+      // random init
+      for (int x = 0; x < dim; x++) {
+        gen1[x] = 42.0 * r.nextDouble() + shift;
+      }
+
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
+
+      // check
+      assertTrue(Math.abs(res1.getFitness()) <= numAcc, "Fitness (I) wrong: " + res1.getFitness());
+
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * numAcc,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
     }
-    
+  }
 }

--- a/tests/org/ogolem/locopt/NEWUOALocOptTest.java
+++ b/tests/org/ogolem/locopt/NEWUOALocOptTest.java
@@ -1,5 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
+              2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,56 +37,61 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for NUMAL's gradient-free Praxis optimizer.
+ *
  * @author Johannes Dieterich
- * @version 2014-12-16
+ * @version 2021-07-17
  */
 public class NEWUOALocOptTest {
-    
-    /**
-     * Test of optimize method, of class PraxisLocOpt.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
-        final Random r = new Random();
-        final double a = 0.0001;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final double numAcc = 1e-7;
-        final double rhoStart = 1.0;
-        final int maxIter = 9999;
-        final int noTrials = 100;
-        final int dim = 42;
-        final HarmonicFunction func = new HarmonicFunction(a,shift,b);
-        
-        final NEWUOALocOpt<Double,BasicOptimizableType> instance1 = new NEWUOALocOpt<>(func,rhoStart,numAcc,maxIter);
-        
-        for(int trial = 0; trial < noTrials; trial++){
-            final double[] gen1 = new double[dim];
-        
-            // random init
-            for(int x = 0; x < dim; x++){
-                gen1[x] = 42.0*r.nextDouble()+shift;
-            }
-        
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
-        
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
-            
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= numAcc);
-            
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for(int x = 0; x < dim; x++){
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x]-shift) + " in " + x, Math.abs(res1Dat[x]-shift) <= 10*numAcc); // make it a bit bigger
-            }
-        }
+
+  /** Test of optimize method, of class PraxisLocOpt. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
+    final Random r = new Random();
+    final double a = 0.0001;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final double numAcc = 1e-7;
+    final double rhoStart = 1.0;
+    final int maxIter = 9999;
+    final int noTrials = 100;
+    final int dim = 42;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b);
+
+    final NEWUOALocOpt<Double, BasicOptimizableType> instance1 =
+        new NEWUOALocOpt<>(func, rhoStart, numAcc, maxIter);
+
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
+
+      // random init
+      for (int x = 0; x < dim; x++) {
+        gen1[x] = 42.0 * r.nextDouble() + shift;
+      }
+
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
+
+      // check
+      assertTrue(Math.abs(res1.getFitness()) <= numAcc, "Fitness (I) wrong: " + res1.getFitness());
+
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * numAcc,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
     }
-    
+  }
 }

--- a/tests/org/ogolem/locopt/PraxisLocOptTest.java
+++ b/tests/org/ogolem/locopt/PraxisLocOptTest.java
@@ -1,6 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
-              2016, J. M. Dieterich and B. Hartke
+              2016-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,57 +37,63 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for NUMAL's gradient-free Praxis optimizer.
+ *
  * @author Johannes Dieterich
- * @version 2016-03-15
+ * @version 2021-07-17
  */
 public class PraxisLocOptTest {
-    
-    /**
-     * Test of optimize method, of class PraxisLocOpt.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
-        final Random r = new Random();
-        final double a = 0.01;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final double numAcc = 1e-3; // this is really loose, I didn't manage to make Praxis any more reliable
-        final double maxStep = 1.0;
-        final double maxScaleFac = 1.0; // numal claims that this is the best choice
-        final int maxIter = 99999;
-        final int noTrials = 100;
-        final int dim = 42;
-        final HarmonicFunction func = new HarmonicFunction(a,shift,b);
-        
-        final PraxisLocOpt<Double,BasicOptimizableType> instance1 = new PraxisLocOpt<>(func,numAcc,maxStep,maxScaleFac,maxIter);
-        
-        for(int trial = 0; trial < noTrials; trial++){
-            final double[] gen1 = new double[dim];
-        
-            // random init
-            for(int x = 0; x < dim; x++){
-                gen1[x] = 42.0*r.nextDouble()+shift;
-            }
-        
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
-        
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
-            
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= numAcc);
-            
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for(int x = 0; x < dim; x++){
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x]-shift) + " in " + x, Math.abs(res1Dat[x]-shift) <= 10*numAcc); // make it a bit bigger
-            }
-        }
+
+  /** Test of optimize method, of class PraxisLocOpt. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
+    final Random r = new Random();
+    final double a = 0.01;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final double numAcc =
+        1e-3; // this is really loose, I didn't manage to make Praxis any more reliable
+    final double maxStep = 1.0;
+    final double maxScaleFac = 1.0; // numal claims that this is the best choice
+    final int maxIter = 99999;
+    final int noTrials = 100;
+    final int dim = 42;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b);
+
+    final PraxisLocOpt<Double, BasicOptimizableType> instance1 =
+        new PraxisLocOpt<>(func, numAcc, maxStep, maxScaleFac, maxIter);
+
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
+
+      // random init
+      for (int x = 0; x < dim; x++) {
+        gen1[x] = 42.0 * r.nextDouble() + shift;
+      }
+
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
+
+      // check
+      assertTrue(Math.abs(res1.getFitness()) <= numAcc, "Fitness (I) wrong: " + res1.getFitness());
+
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * numAcc,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
     }
-    
+  }
 }

--- a/tests/org/ogolem/locopt/RNK1MinLocOptTest.java
+++ b/tests/org/ogolem/locopt/RNK1MinLocOptTest.java
@@ -1,5 +1,6 @@
-/**
+/*
 Copyright (c) 2014, J. M. Dieterich
+              2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,56 +37,61 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.locopt;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for NUMAL's RNK1Min optimizer.
+ *
  * @author Johannes Dieterich
- * @version 2014-12-16
+ * @version 2021-07-17
  */
 public class RNK1MinLocOptTest {
-    
-    /**
-     * Test of optimize method, of class RNK1MinLocOpt.
-     */
-    @Test
-    public void testOptimize() {
-        System.out.println("optimize");
-        final Random r = new Random();
-        final double a = 0.0001;
-        final double shift = 4.2;
-        final double b = 0.0;
-        final double numAcc = 1e-7;
-        final double maxStep = 0.01;
-        final int maxIter = 1000;
-        final int noTrials = 100;
-        final int dim = 42;
-        final HarmonicFunction func = new HarmonicFunction(a,shift,b);
-        
-        final RNK1MinLocOpt<Double,BasicOptimizableType> instance1 = new RNK1MinLocOpt<>(func,numAcc,numAcc,maxIter,maxStep);
-        
-        for(int trial = 0; trial < noTrials; trial++){
-            final double[] gen1 = new double[dim];
-        
-            // random init
-            for(int x = 0; x < dim; x++){
-                gen1[x] = 42.0*r.nextDouble()+shift;
-            }
-        
-            final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
-        
-            final BasicOptimizableType res1 = instance1.optimize(ind1);
-            
-            // check
-            assertTrue("Fitness (I) wrong: " + res1.getFitness(), Math.abs(res1.getFitness()) <= numAcc);
-            
-            final double[] res1Dat = res1.getGenomeAsDouble();
-            for(int x = 0; x < dim; x++){
-                assertTrue("Error (I) from correct solution: " + Math.abs(res1Dat[x]-shift) + " in " + x, Math.abs(res1Dat[x]-shift) <= 10*numAcc); // make it a bit bigger
-            }
-        }
+
+  /** Test of optimize method, of class RNK1MinLocOpt. */
+  @Test
+  public void testOptimize() {
+    System.out.println("optimize");
+    final Random r = new Random();
+    final double a = 0.0001;
+    final double shift = 4.2;
+    final double b = 0.0;
+    final double numAcc = 1e-7;
+    final double maxStep = 0.01;
+    final int maxIter = 1000;
+    final int noTrials = 100;
+    final int dim = 42;
+    final HarmonicFunction func = new HarmonicFunction(a, shift, b);
+
+    final RNK1MinLocOpt<Double, BasicOptimizableType> instance1 =
+        new RNK1MinLocOpt<>(func, numAcc, numAcc, maxIter, maxStep);
+
+    for (int trial = 0; trial < noTrials; trial++) {
+      final double[] gen1 = new double[dim];
+
+      // random init
+      for (int x = 0; x < dim; x++) {
+        gen1[x] = 42.0 * r.nextDouble() + shift;
+      }
+
+      final BasicOptimizableType ind1 = new BasicOptimizableType(gen1);
+
+      final BasicOptimizableType res1 = instance1.optimize(ind1);
+
+      // check
+      assertTrue(Math.abs(res1.getFitness()) <= numAcc, "Fitness (I) wrong: " + res1.getFitness());
+
+      final double[] res1Dat = res1.getGenomeAsDouble();
+      for (int x = 0; x < dim; x++) {
+        assertTrue(
+            Math.abs(res1Dat[x] - shift) <= 10 * numAcc,
+            "Error (I) from correct solution: "
+                + Math.abs(res1Dat[x] - shift)
+                + " in "
+                + x); // make it a bit bigger
+      }
     }
-    
+  }
 }

--- a/tests/org/ogolem/math/FastFunctionsTest.java
+++ b/tests/org/ogolem/math/FastFunctionsTest.java
@@ -1,5 +1,6 @@
-/**
+/*
 Copyright (c) 2013, J. M. Dieterich
+              2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,186 +37,175 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.math;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
 
 /**
- *
  * @author Johannes Dieterich
- * @version 2013-03-27
+ * @version 2021-07-17
  */
 public class FastFunctionsTest {
-    
-    public static final double LOWACC = 1E-3;
-    public static final double MEDACC = 5E-4;
-    public static final double MEDPLUSACC = 1E-4;
-    public static final double HIGHACC = 1E-8;
-    
-    public FastFunctionsTest() {
-    }
-    
-    /**
-     * Test of fastExp method, of class FastFunctions.
-     */
-    @Test
-    public void testFastExp() {
-        System.out.println("fastExp");
-        double x = -20.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.fastExp(x);
-            assertEquals(expResult, result, Math.max(MEDACC,Math.abs(0.05*expResult))); // maximum of 5E-4 or 2%
-            x += 0.05;
-        }
-    }
 
-    /**
-     * Test of fastExp2 method, of class FastFunctions.
-     */
-    @Test
-    public void testFastExp2() {
-        System.out.println("fastExp2");
-        double x = -20.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.fastExp2(x);
-            assertEquals(expResult, result, Math.max(MEDACC,Math.abs(0.05*expResult))); // maximum of 5E-4 or 2%
-            x += 0.05;
-        }
-    }
+  public static final double LOWACC = 1E-3;
+  public static final double MEDACC = 5E-4;
+  public static final double MEDPLUSACC = 1E-4;
+  public static final double HIGHACC = 1E-8;
 
-    /**
-     * Test of fastCorrExp method, of class FastFunctions.
-     */
-    // currently, fastCorrExp() is broken and returns Math.exp()
-    /*@Test
-    public void testFastCorrExp() {
-        System.out.println("fastCorrExp");
-        double x = 0.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.fastCorrExp(x);
-            assertEquals(expResult, result, Math.max(MEDPLUSACC,Math.abs(0.01*expResult))); // maximum of 1E-4 or 1%
-            System.out.println("fine: " + x + " " + expResult);
-            x += 0.05;
-        }
-    }
+  public FastFunctionsTest() {}
 
-    /**
-     * Test of lim128Exp method, of class FastFunctions.
-     */
-    @Test
-    public void testLim128Exp() {
-        System.out.println("lim128Exp");
-        double x = -10.0;
-        while(x < 5.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.lim128Exp(x);
-            assertEquals(expResult, result, Math.max(LOWACC,Math.abs(0.1*expResult))); // maximum of 1E-3 or 10%
-            x += 0.05;
-        }
+  /** Test of fastExp method, of class FastFunctions. */
+  @Test
+  public void testFastExp() {
+    System.out.println("fastExp");
+    double x = -20.0;
+    while (x < 10.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.fastExp(x);
+      assertEquals(
+          expResult, result, Math.max(MEDACC, Math.abs(0.05 * expResult))); // maximum of 5E-4 or 2%
+      x += 0.05;
     }
+  }
 
-    /**
-     * Test of lim256Exp method, of class FastFunctions.
-     */
-    @Test
-    public void testLim256Exp() {
-        System.out.println("lim256Exp");
-        double x = -20.0;
-        while(x < 7.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.lim256Exp(x);
-            assertEquals(expResult, result, Math.max(LOWACC,Math.abs(0.1*expResult))); // maximum of 1E-3 or 10%
-            x += 0.05;
-        }
+  /** Test of fastExp2 method, of class FastFunctions. */
+  @Test
+  public void testFastExp2() {
+    System.out.println("fastExp2");
+    double x = -20.0;
+    while (x < 10.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.fastExp2(x);
+      assertEquals(
+          expResult, result, Math.max(MEDACC, Math.abs(0.05 * expResult))); // maximum of 5E-4 or 2%
+      x += 0.05;
     }
+  }
 
-    /**
-     * Test of lim512Exp method, of class FastFunctions.
-     */
-    @Test
-    public void testLim512Exp() {
-        System.out.println("lim512Exp");
-        double x = -20.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.lim512Exp(x);
-            assertEquals(expResult, result, Math.max(LOWACC,Math.abs(0.1*expResult))); // maximum of 1E-3 or 10%
-            x += 0.05;
-        }
-    }
+  /** Test of fastCorrExp method, of class FastFunctions. */
+  // currently, fastCorrExp() is broken and returns Math.exp()
+  /*@Test
+  public void testFastCorrExp() {
+      System.out.println("fastCorrExp");
+      double x = 0.0;
+      while(x < 10.0){
+          final double expResult = Math.exp(x);
+          final double result = FastFunctions.fastCorrExp(x);
+          assertEquals(expResult, result, Math.max(MEDPLUSACC,Math.abs(0.01*expResult))); // maximum of 1E-4 or 1%
+          System.out.println("fine: " + x + " " + expResult);
+          x += 0.05;
+      }
+  }
 
-    /**
-     * Test of lim1024Exp method, of class FastFunctions.
-     */
-    @Test
-    public void testLim1024Exp() {
-        System.out.println("lim1024Exp");
-        double x = -20.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.lim1024Exp(x);
-            assertEquals(expResult, result, Math.max(MEDACC,Math.abs(0.05*expResult))); // maximum of 5E-4 or 5%
-            x += 0.05;
-        }
+  /**
+   * Test of lim128Exp method, of class FastFunctions.
+   */
+  @Test
+  public void testLim128Exp() {
+    System.out.println("lim128Exp");
+    double x = -10.0;
+    while (x < 5.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.lim128Exp(x);
+      assertEquals(
+          expResult, result, Math.max(LOWACC, Math.abs(0.1 * expResult))); // maximum of 1E-3 or 10%
+      x += 0.05;
     }
+  }
 
-    /**
-     * Test of lim2048Exp method, of class FastFunctions.
-     */
-    @Test
-    public void testLim2048Exp() {
-        System.out.println("lim2048Exp");
-        double x = -20.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.lim2048Exp(x);
-            assertEquals(expResult, result, Math.max(MEDACC,Math.abs(0.03*expResult))); // maximum of 5E-4 or 3%
-            x += 0.05;
-        }
+  /** Test of lim256Exp method, of class FastFunctions. */
+  @Test
+  public void testLim256Exp() {
+    System.out.println("lim256Exp");
+    double x = -20.0;
+    while (x < 7.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.lim256Exp(x);
+      assertEquals(
+          expResult, result, Math.max(LOWACC, Math.abs(0.1 * expResult))); // maximum of 1E-3 or 10%
+      x += 0.05;
     }
+  }
 
-    /**
-     * Test of lim4096Exp method, of class FastFunctions.
-     */
-    @Test
-    public void testLim4096Exp() {
-        System.out.println("lim4096Exp");
-        double x = -20.0;
-        while(x < 10.0){
-            final double expResult = Math.exp(x);
-            final double result = FastFunctions.lim4096Exp(x);
-            assertEquals(expResult, result, Math.max(MEDPLUSACC,Math.abs(0.02*expResult))); // maximum of 1E-4 or 2%
-            x += 0.05;
-        }
+  /** Test of lim512Exp method, of class FastFunctions. */
+  @Test
+  public void testLim512Exp() {
+    System.out.println("lim512Exp");
+    double x = -20.0;
+    while (x < 10.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.lim512Exp(x);
+      assertEquals(
+          expResult, result, Math.max(LOWACC, Math.abs(0.1 * expResult))); // maximum of 1E-3 or 10%
+      x += 0.05;
     }
+  }
 
-    /**
-     * Test of sq method, of class FastFunctions.
-     */
-    @Test
-    public void testSq() {
-        System.out.println("sq");
-        assertEquals(0.0, FastFunctions.sq(0.0), HIGHACC);
-        assertEquals(4.0, FastFunctions.sq(2.0), HIGHACC);
-        assertEquals(9.0, FastFunctions.sq(3.0), HIGHACC);
-        assertEquals(2.5*2.5, FastFunctions.sq(2.5), HIGHACC);
-        assertEquals(1.0, FastFunctions.sq(-1.0), HIGHACC);
-        assertEquals(4.0, FastFunctions.sq(-2.0), HIGHACC);
-        assertEquals(0.01, FastFunctions.sq(0.1), HIGHACC);
+  /** Test of lim1024Exp method, of class FastFunctions. */
+  @Test
+  public void testLim1024Exp() {
+    System.out.println("lim1024Exp");
+    double x = -20.0;
+    while (x < 10.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.lim1024Exp(x);
+      assertEquals(
+          expResult, result, Math.max(MEDACC, Math.abs(0.05 * expResult))); // maximum of 5E-4 or 5%
+      x += 0.05;
     }
+  }
 
-    /**
-     * Test of pow method, of class FastFunctions.
-     */
-    @Test
-    public void testPow() {
-        System.out.println("pow");
-        assertEquals(1.0, FastFunctions.pow(0.0, 0), HIGHACC);
-        assertEquals(1.0, FastFunctions.pow(1.0, 0), HIGHACC);
-        assertEquals(1.0, FastFunctions.pow(1.0, 1), HIGHACC);
-        assertEquals(4.0, FastFunctions.pow(2.0, 2), HIGHACC);
-        assertEquals(27.0, FastFunctions.pow(3.0, 3), HIGHACC);
+  /** Test of lim2048Exp method, of class FastFunctions. */
+  @Test
+  public void testLim2048Exp() {
+    System.out.println("lim2048Exp");
+    double x = -20.0;
+    while (x < 10.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.lim2048Exp(x);
+      assertEquals(
+          expResult, result, Math.max(MEDACC, Math.abs(0.03 * expResult))); // maximum of 5E-4 or 3%
+      x += 0.05;
     }
+  }
+
+  /** Test of lim4096Exp method, of class FastFunctions. */
+  @Test
+  public void testLim4096Exp() {
+    System.out.println("lim4096Exp");
+    double x = -20.0;
+    while (x < 10.0) {
+      final double expResult = Math.exp(x);
+      final double result = FastFunctions.lim4096Exp(x);
+      assertEquals(
+          expResult,
+          result,
+          Math.max(MEDPLUSACC, Math.abs(0.02 * expResult))); // maximum of 1E-4 or 2%
+      x += 0.05;
+    }
+  }
+
+  /** Test of sq method, of class FastFunctions. */
+  @Test
+  public void testSq() {
+    System.out.println("sq");
+    assertEquals(0.0, FastFunctions.sq(0.0), HIGHACC);
+    assertEquals(4.0, FastFunctions.sq(2.0), HIGHACC);
+    assertEquals(9.0, FastFunctions.sq(3.0), HIGHACC);
+    assertEquals(2.5 * 2.5, FastFunctions.sq(2.5), HIGHACC);
+    assertEquals(1.0, FastFunctions.sq(-1.0), HIGHACC);
+    assertEquals(4.0, FastFunctions.sq(-2.0), HIGHACC);
+    assertEquals(0.01, FastFunctions.sq(0.1), HIGHACC);
+  }
+
+  /** Test of pow method, of class FastFunctions. */
+  @Test
+  public void testPow() {
+    System.out.println("pow");
+    assertEquals(1.0, FastFunctions.pow(0.0, 0), HIGHACC);
+    assertEquals(1.0, FastFunctions.pow(1.0, 0), HIGHACC);
+    assertEquals(1.0, FastFunctions.pow(1.0, 1), HIGHACC);
+    assertEquals(4.0, FastFunctions.pow(2.0, 2), HIGHACC);
+    assertEquals(27.0, FastFunctions.pow(3.0, 3), HIGHACC);
+  }
 }

--- a/tests/org/ogolem/math/LAPACKInterfaceTest.java
+++ b/tests/org/ogolem/math/LAPACKInterfaceTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2015-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,58 +36,58 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.math;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import contrib.jama.Matrix;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * A test class for the LAPACK-style interface
+ *
  * @author Johannes Dieterich
- * @version 2015-03-14
+ * @version 2021-07-17
  */
 public class LAPACKInterfaceTest {
-    
-    public LAPACKInterfaceTest() {
-    }
 
-    /**
-     * Test of invertMatrix method, of class LAPACKInterface.
-     */
-    @Test
-    public void testInvertMatrix() {
-        System.out.println("invertMatrix");
-        
-        final double[] matrix = new double[]{
-            1, 0, 5,
-            2, 1, 6,
-            3, 4, 0
+  public LAPACKInterfaceTest() {}
+
+  /** Test of invertMatrix method, of class LAPACKInterface. */
+  @Test
+  public void testInvertMatrix() {
+    System.out.println("invertMatrix");
+
+    final double[] matrix =
+        new double[] {
+          1, 0, 5,
+          2, 1, 6,
+          3, 4, 0
         };
-        
-        final double[][] matJama = new double[][]{
-            new double[]{1, 2, 3},
-            new double[]{0, 1, 4},
-            new double[]{5, 6, 0}
+
+    final double[][] matJama =
+        new double[][] {
+          new double[] {1, 2, 3},
+          new double[] {0, 1, 4},
+          new double[] {5, 6, 0}
         };
-        final Matrix mat = new Matrix(matJama);
-        final Matrix inv = mat.inverse();
-        final double[][] invMat = inv.getArray();
-        
-        final int dim = 3;
-        final double[] work = new double[dim*dim];
-        final int[] piv = new int[dim];
-        
-        LAPACKInterface.invertMatrix(dim, matrix, work, piv);
-        
-        final double thresh = 1e-7;
-        assertEquals(invMat[0][0],matrix[0],thresh);
-        assertEquals(invMat[1][0],matrix[1],thresh);
-        assertEquals(invMat[2][0],matrix[2],thresh);
-        assertEquals(invMat[0][1],matrix[3],thresh);
-        assertEquals(invMat[1][1],matrix[4],thresh);
-        assertEquals(invMat[2][1],matrix[5],thresh);
-        assertEquals(invMat[0][2],matrix[6],thresh);
-        assertEquals(invMat[1][2],matrix[7],thresh);
-        assertEquals(invMat[2][2],matrix[8],thresh);
-    }
-    
+    final Matrix mat = new Matrix(matJama);
+    final Matrix inv = mat.inverse();
+    final double[][] invMat = inv.getArray();
+
+    final int dim = 3;
+    final double[] work = new double[dim * dim];
+    final int[] piv = new int[dim];
+
+    LAPACKInterface.invertMatrix(dim, matrix, work, piv);
+
+    final double thresh = 1e-7;
+    assertEquals(invMat[0][0], matrix[0], thresh);
+    assertEquals(invMat[1][0], matrix[1], thresh);
+    assertEquals(invMat[2][0], matrix[2], thresh);
+    assertEquals(invMat[0][1], matrix[3], thresh);
+    assertEquals(invMat[1][1], matrix[4], thresh);
+    assertEquals(invMat[2][1], matrix[5], thresh);
+    assertEquals(invMat[0][2], matrix[6], thresh);
+    assertEquals(invMat[1][2], matrix[7], thresh);
+    assertEquals(invMat[2][2], matrix[8], thresh);
+  }
 }

--- a/tests/org/ogolem/math/TrivialLinearAlgebraTest.java
+++ b/tests/org/ogolem/math/TrivialLinearAlgebraTest.java
@@ -1,5 +1,5 @@
-/**
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+/*
+Copyright (c) 2020-2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,53 +36,55 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.math;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import contrib.jama.Matrix;
 import java.util.Random;
-import org.junit.Test;
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for trivial linear algebra
+ *
  * @author Johannes Dieterich
- * @version 2020-03-01
+ * @version 2021-07-17
  */
 public class TrivialLinearAlgebraTest {
-    
-    @Test
-    public void testMatMult() {
-        System.out.println("matMult");
-        
-        final Matrix matA = new Matrix(3,3);
-        final Matrix matB = new Matrix(3,1000);
-        
-        final Random r = new Random(42);
-        
-        final double[][] matADat = matA.getArray();
-        final double[][] matBDat = matB.getArray();
-        
-        for(int i = 0; i < matADat.length; i++){
-            for(int j = 0; j < matADat[i].length; j++){
-                matADat[i][j] = r.nextDouble();
-            }
-        }
-        
-        for(int i = 0; i < matBDat.length; i++){
-            for(int j = 0; j < matBDat[i].length; j++){
-                matBDat[i][j] = r.nextDouble();
-            }
-        }
-        
-        // Jama reference path
-        final Matrix matC = matA.times(matB);
-        final double[][] matCDat = matC.getArray();
-        
-        // our implementation
-        final double[][] matCOurDat = TrivialLinearAlgebra.matMult(matADat, matBDat);
-        
-        assertEquals(matCDat.length, matCOurDat.length);
-        
-        for(int i = 0; i < matCOurDat.length; i++){
-            assertArrayEquals(matCDat[i], matCOurDat[i], 1e-20);
-        }
+
+  @Test
+  public void testMatMult() {
+    System.out.println("matMult");
+
+    final Matrix matA = new Matrix(3, 3);
+    final Matrix matB = new Matrix(3, 1000);
+
+    final Random r = new Random(42);
+
+    final double[][] matADat = matA.getArray();
+    final double[][] matBDat = matB.getArray();
+
+    for (int i = 0; i < matADat.length; i++) {
+      for (int j = 0; j < matADat[i].length; j++) {
+        matADat[i][j] = r.nextDouble();
+      }
     }
+
+    for (int i = 0; i < matBDat.length; i++) {
+      for (int j = 0; j < matBDat[i].length; j++) {
+        matBDat[i][j] = r.nextDouble();
+      }
+    }
+
+    // Jama reference path
+    final Matrix matC = matA.times(matB);
+    final double[][] matCDat = matC.getArray();
+
+    // our implementation
+    final double[][] matCOurDat = TrivialLinearAlgebra.matMult(matADat, matBDat);
+
+    assertEquals(matCDat.length, matCOurDat.length);
+
+    for (int i = 0; i < matCOurDat.length; i++) {
+      assertArrayEquals(matCDat[i], matCOurDat[i], 1e-20);
+    }
+  }
 }

--- a/tests/org/ogolem/random/RandomUtilsTest.java
+++ b/tests/org/ogolem/random/RandomUtilsTest.java
@@ -1,5 +1,6 @@
-/**
+/*
 Copyright (c) 2013, J. M. Dieterich
+              2021, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -36,190 +37,217 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.random;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import java.util.List;
-import static org.junit.Assert.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the random utilities.
+ *
  * @author Johannes Dieterich
  * @author Mark Dittner
- * @version 2020-01-07
+ * @version 2021-07-17
  */
 public class RandomUtilsTest {
-    
-    public RandomUtilsTest(){}
-    
-    /**
-     * Test of gaussDouble method, of class RandomUtils
-     */
-    @Test
-    public void testGaussDouble(){
-        System.out.println("gaussDouble");
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDouble(-5.0, 5.0, 2.0);
-            if(d > 5.0 || d < -5.0){fail("gaussDouble outside valid range I.");}
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDouble(-5.0, 10.0, 4.0);
-            if(d > 10.0 || d < -5.0){fail("gaussDouble outside valid range II.");}
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDouble(0.0, 5.0, 0.4);
-            if(d > 5.0 || d < 0.0){fail("gaussDouble outside valid range III.");}
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDouble(-5.0, -1.0, 1.4);
-            if(d > -1.0 || d < -5.0){fail("gaussDouble outside valid range IV.");}
-        }
+
+  public RandomUtilsTest() {}
+
+  /** Test of gaussDouble method, of class RandomUtils */
+  @Test
+  public void testGaussDouble() {
+    System.out.println("gaussDouble");
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDouble(-5.0, 5.0, 2.0);
+      if (d > 5.0 || d < -5.0) {
+        fail("gaussDouble outside valid range I.");
+      }
     }
 
-    @Test
-    public void testGaussDoubleAroundVal(){
-        System.out.println("gaussDoubleAroundVal");
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDoubleAroundVal(-5.0, 5.0, 2.0, 0.0);
-            if(d > 5.0 || d < -5.0){fail("gaussDoubleAroundVal outside valid range I.");}
-        }
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDouble(-5.0, 10.0, 4.0);
+      if (d > 10.0 || d < -5.0) {
+        fail("gaussDouble outside valid range II.");
+      }
+    }
 
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDoubleAroundVal(-5.0, 10.0, 4.0, 7.0);
-            if(d > 10.0 || d < -5.0){fail("gaussDoubleAroundVal outside valid range II.");}
-        }
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDouble(0.0, 5.0, 0.4);
+      if (d > 5.0 || d < 0.0) {
+        fail("gaussDouble outside valid range III.");
+      }
+    }
 
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDoubleAroundVal(0.0, 5.0, 0.4, 1.0);
-            if(d > 5.0 || d < 0.0){fail("gaussDoubleAroundVal outside valid range III.");}
-        }
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDouble(-5.0, -1.0, 1.4);
+      if (d > -1.0 || d < -5.0) {
+        fail("gaussDouble outside valid range IV.");
+      }
+    }
+  }
 
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.gaussDoubleAroundVal(-5.0, -1.0, 1.4, -1.42);
-            if(d > -1.0 || d < -5.0){fail("gaussDoubleAroundVal outside valid range IV.");}
-        }
+  @Test
+  public void testGaussDoubleAroundVal() {
+    System.out.println("gaussDoubleAroundVal");
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDoubleAroundVal(-5.0, 5.0, 2.0, 0.0);
+      if (d > 5.0 || d < -5.0) {
+        fail("gaussDoubleAroundVal outside valid range I.");
+      }
     }
-    
-    @Test
-    public void testHalfgaussDouble(){
-        System.out.println("halfgaussDouble");
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.halfgaussDouble(-5.0, 5.0, 2.0);
-            if(d > 5.0 || d < -5.0){fail("halfgaussDouble outside valid range I.");}
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.halfgaussDouble(-5.0, 10.0, 4.0);
-            if(d > 10.0 || d < -5.0){fail("halfgaussDouble outside valid range II.");}
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.halfgaussDouble(0.0, 5.0, 0.4);
-            if(d > 5.0 || d < 0.0){fail("halfgaussDouble outside valid range III.");}
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final double d = RandomUtils.halfgaussDouble(-5.0, -1.0, 1.4);
-            if(d > -1.0 || d < -5.0){fail("halfgaussDouble outside valid range IV.");}
-        }
+
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDoubleAroundVal(-5.0, 10.0, 4.0, 7.0);
+      if (d > 10.0 || d < -5.0) {
+        fail("gaussDoubleAroundVal outside valid range II.");
+      }
     }
-    
-    @Test
-    public void testListOfPoints(){
-        System.out.println("listOfPoints");
-        for(int it = 0; it < 100; it++){
-            final int low = 0;
-            final int high = 10;
-            final int no = 3;
-            final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
-            if(points.size() != no){
-                fail("Wrong number of points returned I. " + points.size());
-            }
-            for(final int i : points){
-                if(i < low || i >= high){
-                    fail("Wrong point inside test I." + i);
-                }
-            }
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final int low = -10;
-            final int high = -2;
-            final int no = 4;
-            final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
-            if(points.size() != no){
-                fail("Wrong number of points returned I. " + points.size());
-            }
-            for(final int i : points){
-                if(i < low || i >= high){
-                    fail("Wrong point inside test I." + i);
-                }
-            }
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final int low = -5;
-            final int high = 10;
-            final int no = 7;
-            final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
-            if(points.size() != no){
-                fail("Wrong number of points returned I. " + points.size());
-            }
-            for(final int i : points){
-                if(i < low || i >= high){
-                    fail("Wrong point inside test I." + i);
-                }
-            }
-        }
-        
-        for(int it = 0; it < 100; it++){
-            final int low = 5;
-            final int high = 10;
-            final int no = 1;
-            final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
-            if(points.size() != no){
-                fail("Wrong number of points returned I. " + points.size());
-            }
-            for(final int i : points){
-                if(i < low || i >= high){
-                    fail("Wrong point inside test I." + i);
-                }
-            }
-        }
+
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDoubleAroundVal(0.0, 5.0, 0.4, 1.0);
+      if (d > 5.0 || d < 0.0) {
+        fail("gaussDoubleAroundVal outside valid range III.");
+      }
     }
-    
-    @Test
-    public void testVector(){
-        System.out.println("testVector");
-        for(int it = 1; it < 100; it++){
-            final double[] x = new double[it];
-            RandomUtils.randomVector(x);
-            
-            // get the norm
-            double d = 0.0;
-            for(int i = 0; i < it; i++){
-                d += x[i]*x[i];
-            }
-            final double norm = Math.sqrt(d);
-            if(Math.abs(norm-1.0) > 1E-8){
-                fail("Norm of vector not one " + norm + " length " + it);
-            }
-        }
+
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.gaussDoubleAroundVal(-5.0, -1.0, 1.4, -1.42);
+      if (d > -1.0 || d < -5.0) {
+        fail("gaussDoubleAroundVal outside valid range IV.");
+      }
     }
-    
-    @Test
-    public void testEulers(){
-        System.out.println("testEulers");
-        final double[] x = new double[3];
-        for(int it = 1; it < 1000; it++){
-            RandomUtils.randomEulers(x);
-            
-            if(x[0] > Math.PI || x[0] < -Math.PI
-                    || x[1] > 0.5*Math.PI || x[1] < -0.5*Math.PI
-                    || x[2] > Math.PI || x[2] < -Math.PI){
-                fail("Something is wrong with Euler angles " + x[0] + " " + x[1] + " " + x[2]);
-            }
-        }
+  }
+
+  @Test
+  public void testHalfgaussDouble() {
+    System.out.println("halfgaussDouble");
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.halfgaussDouble(-5.0, 5.0, 2.0);
+      if (d > 5.0 || d < -5.0) {
+        fail("halfgaussDouble outside valid range I.");
+      }
     }
+
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.halfgaussDouble(-5.0, 10.0, 4.0);
+      if (d > 10.0 || d < -5.0) {
+        fail("halfgaussDouble outside valid range II.");
+      }
+    }
+
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.halfgaussDouble(0.0, 5.0, 0.4);
+      if (d > 5.0 || d < 0.0) {
+        fail("halfgaussDouble outside valid range III.");
+      }
+    }
+
+    for (int it = 0; it < 100; it++) {
+      final double d = RandomUtils.halfgaussDouble(-5.0, -1.0, 1.4);
+      if (d > -1.0 || d < -5.0) {
+        fail("halfgaussDouble outside valid range IV.");
+      }
+    }
+  }
+
+  @Test
+  public void testListOfPoints() {
+    System.out.println("listOfPoints");
+    for (int it = 0; it < 100; it++) {
+      final int low = 0;
+      final int high = 10;
+      final int no = 3;
+      final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
+      if (points.size() != no) {
+        fail("Wrong number of points returned I. " + points.size());
+      }
+      for (final int i : points) {
+        if (i < low || i >= high) {
+          fail("Wrong point inside test I." + i);
+        }
+      }
+    }
+
+    for (int it = 0; it < 100; it++) {
+      final int low = -10;
+      final int high = -2;
+      final int no = 4;
+      final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
+      if (points.size() != no) {
+        fail("Wrong number of points returned I. " + points.size());
+      }
+      for (final int i : points) {
+        if (i < low || i >= high) {
+          fail("Wrong point inside test I." + i);
+        }
+      }
+    }
+
+    for (int it = 0; it < 100; it++) {
+      final int low = -5;
+      final int high = 10;
+      final int no = 7;
+      final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
+      if (points.size() != no) {
+        fail("Wrong number of points returned I. " + points.size());
+      }
+      for (final int i : points) {
+        if (i < low || i >= high) {
+          fail("Wrong point inside test I." + i);
+        }
+      }
+    }
+
+    for (int it = 0; it < 100; it++) {
+      final int low = 5;
+      final int high = 10;
+      final int no = 1;
+      final List<Integer> points = RandomUtils.listOfPoints(no, low, high);
+      if (points.size() != no) {
+        fail("Wrong number of points returned I. " + points.size());
+      }
+      for (final int i : points) {
+        if (i < low || i >= high) {
+          fail("Wrong point inside test I." + i);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testVector() {
+    System.out.println("testVector");
+    for (int it = 1; it < 100; it++) {
+      final double[] x = new double[it];
+      RandomUtils.randomVector(x);
+
+      // get the norm
+      double d = 0.0;
+      for (int i = 0; i < it; i++) {
+        d += x[i] * x[i];
+      }
+      final double norm = Math.sqrt(d);
+      if (Math.abs(norm - 1.0) > 1E-8) {
+        fail("Norm of vector not one " + norm + " length " + it);
+      }
+    }
+  }
+
+  @Test
+  public void testEulers() {
+    System.out.println("testEulers");
+    final double[] x = new double[3];
+    for (int it = 1; it < 1000; it++) {
+      RandomUtils.randomEulers(x);
+
+      if (x[0] > Math.PI
+          || x[0] < -Math.PI
+          || x[1] > 0.5 * Math.PI
+          || x[1] < -0.5 * Math.PI
+          || x[2] > Math.PI
+          || x[2] < -Math.PI) {
+        fail("Something is wrong with Euler angles " + x[0] + " " + x[1] + " " + x[2]);
+      }
+    }
+  }
 }


### PR DESCRIPTION
For the longest time, we had a weird Junit4 and Junit5 mix going on. Remove Junit4 for good.

No functional change (assert order changed, some naming changed).