### PR TITLE
Re-enable microbenchmarks.

### DIFF
--- a/src/org/ogolem/microbenchmarks/MainMicroBenchmarks.java
+++ b/src/org/ogolem/microbenchmarks/MainMicroBenchmarks.java
@@ -36,6 +36,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.microbenchmarks;
 
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.VectorSpecies;
 import org.ogolem.helpers.StatisticUtils;
 import org.ogolem.helpers.Tuple;
 import org.slf4j.Logger;
@@ -46,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * Benchmarked functionalities should be micro - hence fast to benchmark and fundamental.
  *
  * @author Johannes Dieterich
- * @version 2021-07-21
+ * @version 2021-08-03
  */
 public class MainMicroBenchmarks {
 
@@ -71,8 +73,14 @@ public class MainMicroBenchmarks {
 
   public static void run(final String[] args) {
 
+    LOG.info("Running OGOLEM internal microbenchmarks....");
+    final VectorSpecies<Double> species = DoubleVector.SPECIES_PREFERRED;
+    LOG.info(
+        "Vectorization through incubating vectorapi is accessible with a preferred vector length of : "
+            + species.length());
+
     /* ALL BENCHMARKS MEASURING COLD AND WARM PERFORMANCE */
-    /*final MixedLJLocOptBench mixedLJLocBench = new MixedLJLocOptBench(50);
+    final MixedLJLocOptBench mixedLJLocBench = new MixedLJLocOptBench(50);
     runOneCold(mixedLJLocBench, 1);
 
     final MixedLJLocOptBench mixedLJLocBench2 = new MixedLJLocOptBench(100);
@@ -80,109 +88,109 @@ public class MainMicroBenchmarks {
 
     final MixedLJLocOptBench mixedLJLocBench3 = new MixedLJLocOptBench(150);
     runOneCold(mixedLJLocBench3, 1);
-    */
+
     /* ALL BENCHMARKS UTILIZING AN EXPLICITLY WARMED UP JIT */
-    /*
-        // run advanced CD benchmark
-        final AdvPairwiseCDBenchmark advCDBench = new AdvPairwiseCDBenchmark();
-        runOne(advCDBench, 1000);
 
-        // run advanced CD benchmark (check only)
-        final AdvPairwiseCDCheckOnlyBenchmark advCDBench2 = new AdvPairwiseCDCheckOnlyBenchmark();
-        runOne(advCDBench2, 1000);
+    // run advanced CD benchmark
+    final AdvPairwiseCDBenchmark advCDBench = new AdvPairwiseCDBenchmark();
+    runOne(advCDBench, 1000);
 
-        // run aligning benchmark
-        final AligningBench alignBench = new AligningBench();
-        runOne(alignBench, 1000);
+    // run advanced CD benchmark (check only)
+    final AdvPairwiseCDCheckOnlyBenchmark advCDBench2 = new AdvPairwiseCDCheckOnlyBenchmark();
+    runOne(advCDBench2, 1000);
 
-        // run angle benchmark
-        final AngleBench angleBench = new AngleBench();
-        runOne(angleBench, 10000);
+    // run aligning benchmark
+    final AligningBench alignBench = new AligningBench();
+    runOne(alignBench, 1000);
 
-        // run angle 2 benchmark
-        final AngleBench2 angleBench2 = new AngleBench2();
-        runOne(angleBench2, 10000);
+    // run angle benchmark
+    final AngleBench angleBench = new AngleBench();
+    runOne(angleBench, 10000);
 
-        // run dihedral benchmark
-        final DihedralBench dihedralBench = new DihedralBench();
-        runOne(dihedralBench, 10000);
+    // run angle 2 benchmark
+    final AngleBench2 angleBench2 = new AngleBench2();
+    runOne(angleBench2, 10000);
 
-        // run matrix multiplication benchmarks
-        final MatMultBenchmark matMultBench = new MatMultBenchmark(3, 3, 3);
-        runOne(matMultBench, 20000);
-        final MatMultBenchmark matMultBench0 = new MatMultBenchmark(3, 55, 3);
-        runOne(matMultBench0, 10000);
-        final MatMultBenchmark matMultBench1 = new MatMultBenchmark(3, 1000, 3);
-        runOne(matMultBench1, 1000);
-        final MatMultBenchmark matMultBench2 = new MatMultBenchmark(256, 256, 256);
-        runOne(matMultBench2, 1);
+    // run dihedral benchmark
+    final DihedralBench dihedralBench = new DihedralBench();
+    runOne(dihedralBench, 10000);
 
-        // run specialized 3x3 matrix multiplication benchmarks
-        final Mat3x3MultBenchmark mat3x3MultBench = new Mat3x3MultBenchmark(3);
-        runOne(mat3x3MultBench, 20000);
-        final Mat3x3MultBenchmark mat3x3MultBench0 = new Mat3x3MultBenchmark(55);
-        runOne(mat3x3MultBench0, 10000);
-        final Mat3x3MultBenchmark mat3x3MultBench1 = new Mat3x3MultBenchmark(1000);
-        runOne(mat3x3MultBench1, 1000);
+    // run matrix multiplication benchmarks
+    final MatMultBenchmark matMultBench = new MatMultBenchmark(3, 3, 3);
+    runOne(matMultBench, 20000);
+    final MatMultBenchmark matMultBench0 = new MatMultBenchmark(3, 55, 3);
+    runOne(matMultBench0, 10000);
+    final MatMultBenchmark matMultBench1 = new MatMultBenchmark(3, 1000, 3);
+    runOne(matMultBench1, 1000);
+    final MatMultBenchmark matMultBench2 = new MatMultBenchmark(256, 256, 256);
+    runOne(matMultBench2, 1);
 
-        // run a Norway packing mutation benchmark
-        final NorwayPackingLJBench norwayLJ38Bench = new NorwayPackingLJBench(38);
-        runOne(norwayLJ38Bench, 5);
-        final NorwayPackingLJBench norwayLJ55Bench = new NorwayPackingLJBench(55);
-        runOne(norwayLJ55Bench, 2);
+    // run specialized 3x3 matrix multiplication benchmarks
+    final Mat3x3MultBenchmark mat3x3MultBench = new Mat3x3MultBenchmark(3);
+    runOne(mat3x3MultBench, 20000);
+    final Mat3x3MultBenchmark mat3x3MultBench0 = new Mat3x3MultBenchmark(55);
+    runOne(mat3x3MultBench0, 10000);
+    final Mat3x3MultBenchmark mat3x3MultBench1 = new Mat3x3MultBenchmark(1000);
+    runOne(mat3x3MultBench1, 1000);
 
-        // run LJ benchmarks
-        final LJFFEnergyBench ljEnergyBench = new LJFFEnergyBench();
-        runOne(ljEnergyBench, 100);
-        final LJFFGradientBench ljGradientBench = new LJFFGradientBench();
-        runOne(ljGradientBench, 100);
+    // run a Norway packing mutation benchmark
+    final NorwayPackingLJBench norwayLJ38Bench = new NorwayPackingLJBench(38);
+    runOne(norwayLJ38Bench, 5);
+    final NorwayPackingLJBench norwayLJ55Bench = new NorwayPackingLJBench(55);
+    runOne(norwayLJ55Bench, 2);
 
-        // run mixed LJ benchmarks
-        final MixedLJFFEnergyBench mixedljEnergyBench = new MixedLJFFEnergyBench();
-        runOne(mixedljEnergyBench, 100);
-        final MixedLJFFGradientBench mixedljGradientBench = new MixedLJFFGradientBench();
-        runOne(mixedljGradientBench, 100);
+    // run LJ benchmarks
+    final LJFFEnergyBench ljEnergyBench = new LJFFEnergyBench();
+    runOne(ljEnergyBench, 100);
+    final LJFFGradientBench ljGradientBench = new LJFFGradientBench();
+    runOne(ljGradientBench, 100);
 
-        // run adaptive LJ benchmarks
-        final AdaptiveLJFFEnergyBench adaptiveljEnergyBench = new AdaptiveLJFFEnergyBench();
-        runOne(adaptiveljEnergyBench, 100);
-        final AdaptiveLJFFGradientBench adaptiveljGradientBench = new AdaptiveLJFFGradientBench();
-        runOne(adaptiveljGradientBench, 100);
+    // run mixed LJ benchmarks
+    final MixedLJFFEnergyBench mixedljEnergyBench = new MixedLJFFEnergyBench();
+    runOne(mixedljEnergyBench, 100);
+    final MixedLJFFGradientBench mixedljGradientBench = new MixedLJFFGradientBench();
+    runOne(mixedljGradientBench, 100);
 
-        // run TIP3P benchmarks
-        final TIP3PEnergyBench tip3pEBench = new TIP3PEnergyBench();
-        runOne(tip3pEBench, 10);
-        final TIP3PGradientBench tip3pGBench = new TIP3PGradientBench();
-        runOne(tip3pGBench, 10);
+    // run adaptive LJ benchmarks
+    final AdaptiveLJFFEnergyBench adaptiveljEnergyBench = new AdaptiveLJFFEnergyBench();
+    runOne(adaptiveljEnergyBench, 100);
+    final AdaptiveLJFFGradientBench adaptiveljGradientBench = new AdaptiveLJFFGradientBench();
+    runOne(adaptiveljGradientBench, 100);
 
-        // run TIP4P benchmarks
-        final TIP4PEnergyBench tip4pEBench = new TIP4PEnergyBench();
-        runOne(tip4pEBench, 10);
-        final TIP4PGradientBench tip4pGBench = new TIP4PGradientBench();
-        runOne(tip4pGBench, 10);
+    // run TIP3P benchmarks
+    final TIP3PEnergyBench tip3pEBench = new TIP3PEnergyBench();
+    runOne(tip3pEBench, 10);
+    final TIP3PGradientBench tip3pGBench = new TIP3PGradientBench();
+    runOne(tip3pGBench, 10);
 
-        // run small water TTM3F benchmark
-        final WaterTTM3FSmallBenchmark ttm3fSmall = new WaterTTM3FSmallBenchmark();
-        runOne(ttm3fSmall, 10);
+    // run TIP4P benchmarks
+    final TIP4PEnergyBench tip4pEBench = new TIP4PEnergyBench();
+    runOne(tip4pEBench, 10);
+    final TIP4PGradientBench tip4pGBench = new TIP4PGradientBench();
+    runOne(tip4pGBench, 10);
 
-        // run large water TTM3F benchmark
-        final WaterTTM3FLargeBenchmark ttm3fLarge = new WaterTTM3FLargeBenchmark();
-        runOne(ttm3fLarge, 10);
+    // run small water TTM3F benchmark
+    final WaterTTM3FSmallBenchmark ttm3fSmall = new WaterTTM3FSmallBenchmark();
+    runOne(ttm3fSmall, 10);
 
-        // run UFF benchmarks
-        final UFFSurfaceEnergyBenchmark uff1 = new UFFSurfaceEnergyBenchmark();
-        runOne(uff1, 10);
-        final UFFSurfaceGradientBenchmark uff2 = new UFFSurfaceGradientBenchmark();
-        runOne(uff2, 10);
-        final UFFFrozenSurfaceEnergyBenchmark uff3 = new UFFFrozenSurfaceEnergyBenchmark();
-        runOne(uff3, 10);
-        final UFFFrozenSurfaceGradientBenchmark uff4 = new UFFFrozenSurfaceGradientBenchmark();
-        runOne(uff4, 10);
-        final UFFLargeMoleculeEnergyBenchmark uff5 = new UFFLargeMoleculeEnergyBenchmark();
-        runOne(uff5, 1);
-        final UFFLargeMoleculeGradientBenchmark uff6 = new UFFLargeMoleculeGradientBenchmark();
-        runOne(uff6, 1);
-    */
+    // run large water TTM3F benchmark
+    final WaterTTM3FLargeBenchmark ttm3fLarge = new WaterTTM3FLargeBenchmark();
+    runOne(ttm3fLarge, 10);
+
+    // run UFF benchmarks
+    final UFFSurfaceEnergyBenchmark uff1 = new UFFSurfaceEnergyBenchmark();
+    runOne(uff1, 10);
+    final UFFSurfaceGradientBenchmark uff2 = new UFFSurfaceGradientBenchmark();
+    runOne(uff2, 10);
+    final UFFFrozenSurfaceEnergyBenchmark uff3 = new UFFFrozenSurfaceEnergyBenchmark();
+    runOne(uff3, 10);
+    final UFFFrozenSurfaceGradientBenchmark uff4 = new UFFFrozenSurfaceGradientBenchmark();
+    runOne(uff4, 10);
+    final UFFLargeMoleculeEnergyBenchmark uff5 = new UFFLargeMoleculeEnergyBenchmark();
+    runOne(uff5, 1);
+    final UFFLargeMoleculeGradientBenchmark uff6 = new UFFLargeMoleculeGradientBenchmark();
+    runOne(uff6, 1);
+
     /* Adaptive subsystem benchmarks */
 
     // Ackley function in 250D


### PR DESCRIPTION
While there: LOG.info the preferred vector size to better compare between platforms (or diagnose issues).