### PR TITLE
Employ symmetric matrices for bond infos

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<BugCollection version="4.4.2" sequence="0" timestamp="1635716979584" analysisTimestamp="1635716979587" release="snapshot">
+<BugCollection version="4.5.2" sequence="0" timestamp="1641609265940" analysisTimestamp="1641609265940" release="">
   <Project projectName="ogolem (spotbugsMain)">
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/familytree/VisualizationConfig.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/familytree/MainFamilyTree.class</Jar>
@@ -336,19 +336,23 @@
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/GenericLookup.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/Matrix3x3.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/TrivialLinearAlgebra.class</Jar>
+    <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BoolMatrix.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/AcosLookup.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/MathUtils.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/CosLookup.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/SinLookup.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/AbstractLookup.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/LAPACKInterface.class</Jar>
+    <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/ShortMatrix.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/ExpLookup.class</Jar>
+    <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BoolSymmetricMatrixNoDiag.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/LookupedFunction.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BLASInterface.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/Matrix.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/SymmetricMatrixNoDiag.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BLASInterface$TRANSPOSE.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/FastFunctions.class</Jar>
+    <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/ShortSymmetricMatrixNoDiag.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/ScalarProperty.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/TensorProperty.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/ExcitationEnergy.class</Jar>
@@ -740,29 +744,29 @@
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/contrib/lbfgs/LBFGS$ExceptionWithIflag.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/contrib/lbfgs/LBFGS.class</Jar>
     <Jar>/Users/jmd/workspace/ogolem-development_jmd/build/classes/java/main/contrib/lbfgs/LBFGS$Mcsrch.class</Jar>
-    <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/atomdroiduff-2.0.0.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/atomdroiduff-3.0.0.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/corrmd.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/evbqmdff.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/lionbench.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/scaTTM3F.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/workspace/ogolem-development_jmd/libs/skalevala.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.6.1/e4ba98f1d4b3c80ec46392f25e094a6a2e58fcbf/commons-math3-3.6.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-all/0.40/5ac2a28d6c9c81d2b45b9edf07dfeec35d317be0/ejml-all-0.40.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-all/0.41/f7cd6a2803432288f7d082cd06e00e7f90509c8d/ejml-all-0.41.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil.netlib/native_ref-java/1.1/408c71ffbc3646dda7bee1e22bf19101e5e9ee90/native_ref-java-1.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-ext/1.3.1/29e8262c9bce3f978b608de538f2367ae9192eb8/jgrapht-ext-1.3.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-io/1.3.1/46b561ae08b49aad5967dd2f9310b3809a3e9e19/jgrapht-io-1.3.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-core/1.3.1/2a60359a72bea12c2336400408cebd0254b63be/jgrapht-core-1.3.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.scala-lang/scala-library/2.13.6/ed7a2f528c7389ea65746c22a01031613d98ab3d/scala-library-2.13.6.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.30/e606eac955f55ecf1d8edcccba04eb8ac98088dd/slf4j-simple-1.7.30.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.30/b5a4b6d16ab13e34a88fae84c35cd5d68cac922c/slf4j-api-1.7.30.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-simple/0.40/68a97419a7cf7034d5a81db548aa525aeb2f5d80/ejml-simple-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fsparse/0.40/4a8dd52be2566057ba010e256e17dd02b5aa8a5b/ejml-fsparse-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fdense/0.40/6e53f0fd4ee160fe13555f3503c0ca6c915524da/ejml-fdense-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-dsparse/0.40/21d2d2e9acbb6808495cad63beaf0c08d8af2f9a/ejml-dsparse-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-ddense/0.40/4aa9d09074246f56b0c93675835f7462d13920b4/ejml-ddense-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-cdense/0.40/b5a752a5ae4ee1847daf7cec55131bfa7d101919/ejml-cdense-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-zdense/0.40/2c01536e07998de4ff99817ee6d753f717eeac03/ejml-zdense-0.40.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-core/0.40/b43a93d530ddd0c5d1084a86fbb38ee5ef3394ec/ejml-core-0.40.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/1.7.32/321ffafb5123a91a71737dbff38ebe273e771e5b/slf4j-simple-1.7.32.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/1.7.32/cdcff33940d9f2de763bc41ea05a0be5941176c3/slf4j-api-1.7.32.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-simple/0.41/c3b36475a6a380c2d17c160a687a929555b886da/ejml-simple-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fsparse/0.41/69f6f700bd7a87a0d011addd8dd32c5158568751/ejml-fsparse-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fdense/0.41/bf1300827846352d3981502fcbec6b9b824c8ff3/ejml-fdense-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-dsparse/0.41/a9f9d7a36a233736cf28998b2473e98df9e9f69/ejml-dsparse-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-ddense/0.41/782c80d4c3c8a3432c4641f24c177f336a360f9c/ejml-ddense-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-cdense/0.41/64e8604e2a93ceab09ebc3acdf98748765c1afaf/ejml-cdense-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-zdense/0.41/cb70da15c6d91d5c1960c2090bc263fa4aa32d84/ejml-zdense-0.41.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-core/0.41/92ac2bee332a5697c42e576b94d563ba8c25877c/ejml-core-0.41.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil/jniloader/1.1/4840f897eeb54d67ee14e478f8a45cc9937f3ce1/jniloader-1.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil.netlib/core/1.1/839e9b8107e43741810e6cf66798ef15543e9f98/core-1.1.jar</AuxClasspathEntry>
     <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/net.sourceforge.f2j/arpack_combined_all/0.1/225619a060b42605b4d9fd4af11815664abf26eb/arpack_combined_all-0.1.jar</AuxClasspathEntry>
@@ -884,7 +888,7 @@
       <Message>In class contrib.edu.princeton.eac.Grid</Message>
     </Class>
     <Method classname="contrib.edu.princeton.eac.Grid" name="clone" signature="()Lcontrib/edu/princeton/eac/Grid;" isStatic="false" primary="true">
-      <SourceLine classname="contrib.edu.princeton.eac.Grid" start="138" end="138" startBytecode="0" endBytecode="68" sourcefile="Grid.java" sourcepath="contrib/edu/princeton/eac/Grid.java" relSourcepath="contrib/edu/princeton/eac/Grid.java"/>
+      <SourceLine classname="contrib.edu.princeton.eac.Grid" start="138" end="138" startBytecode="0" endBytecode="68" sourcefile="Grid.java" sourcepath="contrib/edu/princeton/eac/Grid.java" relSourcepath="contrib/edu/princeton/eac/Grid.java" synthetic="true"/>
       <Message>In method contrib.edu.princeton.eac.Grid.clone()</Message>
     </Method>
     <SourceLine classname="contrib.edu.princeton.eac.Grid" start="138" end="138" startBytecode="0" endBytecode="68" sourcefile="Grid.java" sourcepath="contrib/edu/princeton/eac/Grid.java" relSourcepath="contrib/edu/princeton/eac/Grid.java" synthetic="true">
@@ -1087,7 +1091,7 @@
       <Message>In class contrib.jama.Matrix</Message>
     </Class>
     <Method classname="contrib.jama.Matrix" name="clone" signature="()Lcontrib/jama/Matrix;" isStatic="false" primary="true">
-      <SourceLine classname="contrib.jama.Matrix" start="197" end="197" startBytecode="0" endBytecode="46" sourcefile="Matrix.java" sourcepath="contrib/jama/Matrix.java" relSourcepath="contrib/jama/Matrix.java"/>
+      <SourceLine classname="contrib.jama.Matrix" start="197" end="197" startBytecode="0" endBytecode="46" sourcefile="Matrix.java" sourcepath="contrib/jama/Matrix.java" relSourcepath="contrib/jama/Matrix.java" synthetic="true"/>
       <Message>In method contrib.jama.Matrix.clone()</Message>
     </Method>
     <SourceLine classname="contrib.jama.Matrix" start="197" end="197" startBytecode="0" endBytecode="46" sourcefile="Matrix.java" sourcepath="contrib/jama/Matrix.java" relSourcepath="contrib/jama/Matrix.java" synthetic="true">
@@ -1464,7 +1468,7 @@
       <Message>In class contrib.jama.test.TestMatrix</Message>
     </Class>
     <Method classname="contrib.jama.test.TestMatrix" name="print" signature="([DII)V" isStatic="true" primary="true">
-      <SourceLine classname="contrib.jama.test.TestMatrix" start="938" end="941" startBytecode="0" endBytecode="103" sourcefile="TestMatrix.java" sourcepath="contrib/jama/test/TestMatrix.java" relSourcepath="contrib/jama/test/TestMatrix.java"/>
+      <SourceLine classname="contrib.jama.test.TestMatrix" start="938" end="941" startBytecode="0" endBytecode="103" sourcefile="TestMatrix.java" sourcepath="contrib/jama/test/TestMatrix.java" relSourcepath="contrib/jama/test/TestMatrix.java" synthetic="true"/>
       <Message>In method contrib.jama.test.TestMatrix.print(double[], int, int)</Message>
     </Method>
     <SourceLine classname="contrib.jama.test.TestMatrix" start="938" end="941" startBytecode="0" endBytecode="103" sourcefile="TestMatrix.java" sourcepath="contrib/jama/test/TestMatrix.java" relSourcepath="contrib/jama/test/TestMatrix.java" synthetic="true">
@@ -1960,13 +1964,13 @@
     <ShortMessage>Non-transient non-serializable instance field in serializable class</ShortMessage>
     <LongMessage>Class org.ogolem.adaptive.AdaptiveSkalevalaCaller defines non-transient non-serializable instance field c</LongMessage>
     <Class classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="433" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
-        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-433]</Message>
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="479" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-479]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.AdaptiveSkalevalaCaller</Message>
     </Class>
     <Field classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" name="c" signature="Lorg/ogolem/skalevala/CartesianCoordinates;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" synthetic="true">
         <Message>In AdaptiveSkalevalaCaller.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.adaptive.AdaptiveSkalevalaCaller.c</Message>
@@ -1985,13 +1989,13 @@
     <ShortMessage>Non-transient non-serializable instance field in serializable class</ShortMessage>
     <LongMessage>Class org.ogolem.adaptive.AdaptiveSkalevalaCaller defines non-transient non-serializable instance field p</LongMessage>
     <Class classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="433" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
-        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-433]</Message>
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="479" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-479]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.AdaptiveSkalevalaCaller</Message>
     </Class>
     <Field classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" name="p" signature="Lorg/ogolem/skalevala/Parameters;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" synthetic="true">
         <Message>In AdaptiveSkalevalaCaller.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.adaptive.AdaptiveSkalevalaCaller.p</Message>
@@ -2010,13 +2014,13 @@
     <ShortMessage>Non-transient non-serializable instance field in serializable class</ShortMessage>
     <LongMessage>Class org.ogolem.adaptive.AdaptiveSkalevalaCaller defines non-transient non-serializable instance field runot</LongMessage>
     <Class classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="433" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
-        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-433]</Message>
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="479" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-479]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.AdaptiveSkalevalaCaller</Message>
     </Class>
     <Field classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" name="runot" signature="Lorg/ogolem/skalevala/Runot;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" synthetic="true">
         <Message>In AdaptiveSkalevalaCaller.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.adaptive.AdaptiveSkalevalaCaller.runot</Message>
@@ -2035,8 +2039,8 @@
     <ShortMessage>Non-serializable value stored into instance field of a serializable class</ShortMessage>
     <LongMessage>org.ogolem.skalevala.Vainamoinen stored into non-transient field AdaptiveSkalevalaCaller.runot</LongMessage>
     <Class classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="433" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
-        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-433]</Message>
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveSkalevalaCaller" start="60" end="479" sourcefile="AdaptiveSkalevalaCaller.java" sourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" relSourcepath="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java">
+        <Message>At AdaptiveSkalevalaCaller.java:[lines 60-479]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.AdaptiveSkalevalaCaller</Message>
     </Class>
@@ -2181,7 +2185,7 @@
     <ShortMessage>Class names shouldn&apos;t shadow simple name of superclass</ShortMessage>
     <LongMessage>The class name org.ogolem.adaptive.FixedValues shadows the simple name of the superclass org.ogolem.core.FixedValues</LongMessage>
     <Class classname="org.ogolem.adaptive.FixedValues" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.FixedValues" start="47" end="48" sourcefile="FixedValues.java" sourcepath="org/ogolem/adaptive/FixedValues.java" relSourcepath="org/ogolem/adaptive/FixedValues.java">
+      <SourceLine classname="org.ogolem.adaptive.FixedValues" start="47" end="48" sourcefile="FixedValues.java" sourcepath="org/ogolem/adaptive/FixedValues.java" relSourcepath="org/ogolem/adaptive/FixedValues.java" synthetic="true">
         <Message>At FixedValues.java:[lines 47-48]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.FixedValues</Message>
@@ -2297,7 +2301,7 @@
     <ShortMessage>Class names shouldn&apos;t shadow simple name of superclass</ShortMessage>
     <LongMessage>The class name org.ogolem.adaptive.NumericalGradients shadows the simple name of the superclass org.ogolem.core.NumericalGradients</LongMessage>
     <Class classname="org.ogolem.adaptive.NumericalGradients" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.NumericalGradients" start="54" end="250" sourcefile="NumericalGradients.java" sourcepath="org/ogolem/adaptive/NumericalGradients.java" relSourcepath="org/ogolem/adaptive/NumericalGradients.java">
+      <SourceLine classname="org.ogolem.adaptive.NumericalGradients" start="54" end="250" sourcefile="NumericalGradients.java" sourcepath="org/ogolem/adaptive/NumericalGradients.java" relSourcepath="org/ogolem/adaptive/NumericalGradients.java" synthetic="true">
         <Message>At NumericalGradients.java:[lines 54-250]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.NumericalGradients</Message>
@@ -2814,34 +2818,34 @@
     <ShortMessage>Boxed value is unboxed and then immediately reboxed</ShortMessage>
     <LongMessage>Boxed value is unboxed and then immediately reboxed in org.ogolem.core.AdvancedGraphBasedDirMut.mutate(Geometry)</LongMessage>
     <Class classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true">
-      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="62" end="609" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
-        <Message>At AdvancedGraphBasedDirMut.java:[lines 62-609]</Message>
+      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="63" end="612" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
+        <Message>At AdvancedGraphBasedDirMut.java:[lines 63-612]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.AdvancedGraphBasedDirMut</Message>
     </Class>
     <Method classname="org.ogolem.core.AdvancedGraphBasedDirMut" name="mutate" signature="(Lorg/ogolem/core/Geometry;)Lorg/ogolem/core/Geometry;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="188" end="591" startBytecode="0" endBytecode="4557" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java"/>
+      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="189" end="594" startBytecode="0" endBytecode="4531" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java"/>
       <Message>In method org.ogolem.core.AdvancedGraphBasedDirMut.mutate(Geometry)</Message>
     </Method>
     <Method classname="java.lang.Integer" name="valueOf" signature="(I)Ljava/lang/Integer;" isStatic="true" role="METHOD_CALLED">
       <SourceLine classname="java.lang.Integer" start="1079" end="1081" startBytecode="0" endBytecode="90" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
       <Message>Called method Integer.valueOf(int)</Message>
     </Method>
-    <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true" start="340" end="340" startBytecode="908" endBytecode="908" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
-      <Message>At AdvancedGraphBasedDirMut.java:[line 340]</Message>
+    <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true" start="343" end="343" startBytecode="908" endBytecode="908" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
+      <Message>At AdvancedGraphBasedDirMut.java:[line 343]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="414aae9a875b24493ecde97b49a200a1" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new org.ogolem.core.AdvancedGraphBasedDirMut(AdvancedGraphBasedDirMut$GDMConfiguration, CollisionDetectionEngine, GenericLocOpt, double, double, boolean, boolean, DirMutPointProviders$PointProvider, DirMutOptStrategies$PointOptStrategy, boolean) may expose internal representation by storing an externally mutable object into AdvancedGraphBasedDirMut.pointProv</LongMessage>
     <Class classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true">
-      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="62" end="609" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
-        <Message>At AdvancedGraphBasedDirMut.java:[lines 62-609]</Message>
+      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="63" end="612" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
+        <Message>At AdvancedGraphBasedDirMut.java:[lines 63-612]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.AdvancedGraphBasedDirMut</Message>
     </Class>
     <Method classname="org.ogolem.core.AdvancedGraphBasedDirMut" name="&lt;init&gt;" signature="(Lorg/ogolem/core/AdvancedGraphBasedDirMut$GDMConfiguration;Lorg/ogolem/core/CollisionDetectionEngine;Lorg/ogolem/generic/GenericLocOpt;DDZZLorg/ogolem/core/DirMutPointProviders$PointProvider;Lorg/ogolem/core/DirMutOptStrategies$PointOptStrategy;Z)V" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="110" end="134" startBytecode="0" endBytecode="523" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java"/>
+      <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" start="111" end="135" startBytecode="0" endBytecode="523" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java"/>
       <Message>In method new org.ogolem.core.AdvancedGraphBasedDirMut(AdvancedGraphBasedDirMut$GDMConfiguration, CollisionDetectionEngine, GenericLocOpt, double, double, boolean, boolean, DirMutPointProviders$PointProvider, DirMutOptStrategies$PointOptStrategy, boolean)</Message>
     </Method>
     <Field classname="org.ogolem.core.AdvancedGraphBasedDirMut" name="pointProv" signature="Lorg/ogolem/core/DirMutPointProviders$PointProvider;" isStatic="false" primary="true">
@@ -2853,8 +2857,8 @@
     <LocalVariable name="provider" register="10" pc="7" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named provider</Message>
     </LocalVariable>
-    <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true" start="111" end="111" startBytecode="7" endBytecode="7" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
-      <Message>At AdvancedGraphBasedDirMut.java:[line 111]</Message>
+    <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true" start="112" end="112" startBytecode="7" endBytecode="7" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
+      <Message>At AdvancedGraphBasedDirMut.java:[line 112]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="DLS_DEAD_LOCAL_STORE" priority="2" rank="17" abbrev="DLS" category="STYLE" instanceHash="f004d1e8d928933051bc84b3785e890b" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="563">
@@ -3360,7 +3364,7 @@
       <Message>In class org.ogolem.core.CartesianToRigidCoordinates</Message>
     </Class>
     <Field classname="org.ogolem.core.CartesianToRigidCoordinates" name="gradObj" signature="Lorg/ogolem/core/Gradient;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.CartesianToRigidCoordinates" sourcefile="CartesianToRigidCoordinates.java" sourcepath="org/ogolem/core/CartesianToRigidCoordinates.java" relSourcepath="org/ogolem/core/CartesianToRigidCoordinates.java">
+      <SourceLine classname="org.ogolem.core.CartesianToRigidCoordinates" sourcefile="CartesianToRigidCoordinates.java" sourcepath="org/ogolem/core/CartesianToRigidCoordinates.java" relSourcepath="org/ogolem/core/CartesianToRigidCoordinates.java" synthetic="true">
         <Message>In CartesianToRigidCoordinates.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.CartesianToRigidCoordinates.gradObj</Message>
@@ -3555,7 +3559,7 @@
       <Message>In class org.ogolem.core.DirMutPointProviders$AverageCOMDistProvider</Message>
     </Class>
     <Field classname="org.ogolem.core.DirMutPointProviders$AverageCOMDistProvider" name="trialPIter" signature="Ljava/util/Iterator;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.DirMutPointProviders$AverageCOMDistProvider" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java">
+      <SourceLine classname="org.ogolem.core.DirMutPointProviders$AverageCOMDistProvider" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java" synthetic="true">
         <Message>In DirMutPointProviders.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.DirMutPointProviders$AverageCOMDistProvider.trialPIter</Message>
@@ -3606,7 +3610,7 @@
       <Message>In class org.ogolem.core.DirMutPointProviders$COMOnlyCoordGrid</Message>
     </Class>
     <Field classname="org.ogolem.core.DirMutPointProviders$COMOnlyCoordGrid" name="trialPIter" signature="Ljava/util/Iterator;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.DirMutPointProviders$COMOnlyCoordGrid" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java">
+      <SourceLine classname="org.ogolem.core.DirMutPointProviders$COMOnlyCoordGrid" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java" synthetic="true">
         <Message>In DirMutPointProviders.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.DirMutPointProviders$COMOnlyCoordGrid.trialPIter</Message>
@@ -3657,7 +3661,7 @@
       <Message>In class org.ogolem.core.DirMutPointProviders$FullExternalCoordGrid</Message>
     </Class>
     <Field classname="org.ogolem.core.DirMutPointProviders$FullExternalCoordGrid" name="trialPIter" signature="Ljava/util/Iterator;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.DirMutPointProviders$FullExternalCoordGrid" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java">
+      <SourceLine classname="org.ogolem.core.DirMutPointProviders$FullExternalCoordGrid" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java" synthetic="true">
         <Message>In DirMutPointProviders.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.DirMutPointProviders$FullExternalCoordGrid.trialPIter</Message>
@@ -3730,7 +3734,7 @@
       <Message>In class org.ogolem.core.DirMutPointProviders$WaterSpecificProvider</Message>
     </Class>
     <Field classname="org.ogolem.core.DirMutPointProviders$WaterSpecificProvider" name="trialPIter" signature="Ljava/util/Iterator;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.DirMutPointProviders$WaterSpecificProvider" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java">
+      <SourceLine classname="org.ogolem.core.DirMutPointProviders$WaterSpecificProvider" sourcefile="DirMutPointProviders.java" sourcepath="org/ogolem/core/DirMutPointProviders.java" relSourcepath="org/ogolem/core/DirMutPointProviders.java" synthetic="true">
         <Message>In DirMutPointProviders.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.DirMutPointProviders$WaterSpecificProvider.trialPIter</Message>
@@ -3755,7 +3759,7 @@
       <Message>In class org.ogolem.core.EnvironmentCartesCoordinates</Message>
     </Class>
     <Field classname="org.ogolem.core.EnvironmentCartesCoordinates" name="grad" signature="Lorg/ogolem/core/Gradient;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.EnvironmentCartesCoordinates" sourcefile="EnvironmentCartesCoordinates.java" sourcepath="org/ogolem/core/EnvironmentCartesCoordinates.java" relSourcepath="org/ogolem/core/EnvironmentCartesCoordinates.java">
+      <SourceLine classname="org.ogolem.core.EnvironmentCartesCoordinates" sourcefile="EnvironmentCartesCoordinates.java" sourcepath="org/ogolem/core/EnvironmentCartesCoordinates.java" relSourcepath="org/ogolem/core/EnvironmentCartesCoordinates.java" synthetic="true">
         <Message>In EnvironmentCartesCoordinates.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.EnvironmentCartesCoordinates.grad</Message>
@@ -3780,7 +3784,7 @@
       <Message>In class org.ogolem.core.FullyCartesianCoordinates</Message>
     </Class>
     <Field classname="org.ogolem.core.FullyCartesianCoordinates" name="grad" signature="Lorg/ogolem/core/Gradient;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.FullyCartesianCoordinates" sourcefile="FullyCartesianCoordinates.java" sourcepath="org/ogolem/core/FullyCartesianCoordinates.java" relSourcepath="org/ogolem/core/FullyCartesianCoordinates.java">
+      <SourceLine classname="org.ogolem.core.FullyCartesianCoordinates" sourcefile="FullyCartesianCoordinates.java" sourcepath="org/ogolem/core/FullyCartesianCoordinates.java" relSourcepath="org/ogolem/core/FullyCartesianCoordinates.java" synthetic="true">
         <Message>In FullyCartesianCoordinates.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.FullyCartesianCoordinates.grad</Message>
@@ -4109,8 +4113,8 @@
     <ShortMessage>Unread field: should this field be static?</ShortMessage>
     <LongMessage>Unread field: org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.initialTrust; should this field be static?</LongMessage>
     <Class classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true">
-      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1376" end="1384" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-        <Message>At GraphBasedDirMut.java:[lines 1376-1384]</Message>
+      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1377" end="1385" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+        <Message>At GraphBasedDirMut.java:[lines 1377-1385]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig</Message>
     </Class>
@@ -4120,16 +4124,16 @@
       </SourceLine>
       <Message>Field org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.initialTrust</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1381" end="1381" startBytecode="8" endBytecode="8" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-      <Message>At GraphBasedDirMut.java:[line 1381]</Message>
+    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1382" end="1382" startBytecode="8" endBytecode="8" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+      <Message>At GraphBasedDirMut.java:[line 1382]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SS_SHOULD_BE_STATIC" priority="2" rank="18" abbrev="SS" category="PERFORMANCE" instanceHash="7d717cd6c6c0ed6364a092a4f5548c36" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Unread field: should this field be static?</ShortMessage>
     <LongMessage>Unread field: org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.interPoints; should this field be static?</LongMessage>
     <Class classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true">
-      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1376" end="1384" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-        <Message>At GraphBasedDirMut.java:[lines 1376-1384]</Message>
+      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1377" end="1385" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+        <Message>At GraphBasedDirMut.java:[lines 1377-1385]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig</Message>
     </Class>
@@ -4139,16 +4143,16 @@
       </SourceLine>
       <Message>Field org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.interPoints</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1384" end="1384" startBytecode="28" endBytecode="28" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-      <Message>At GraphBasedDirMut.java:[line 1384]</Message>
+    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1385" end="1385" startBytecode="28" endBytecode="28" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+      <Message>At GraphBasedDirMut.java:[line 1385]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SS_SHOULD_BE_STATIC" priority="2" rank="18" abbrev="SS" category="PERFORMANCE" instanceHash="92ab9e23c17dcdac84f8bc46cc64d799" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Unread field: should this field be static?</ShortMessage>
     <LongMessage>Unread field: org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.maxIter; should this field be static?</LongMessage>
     <Class classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true">
-      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1376" end="1384" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-        <Message>At GraphBasedDirMut.java:[lines 1376-1384]</Message>
+      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1377" end="1385" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+        <Message>At GraphBasedDirMut.java:[lines 1377-1385]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig</Message>
     </Class>
@@ -4158,16 +4162,16 @@
       </SourceLine>
       <Message>Field org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.maxIter</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1383" end="1383" startBytecode="22" endBytecode="22" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-      <Message>At GraphBasedDirMut.java:[line 1383]</Message>
+    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1384" end="1384" startBytecode="22" endBytecode="22" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+      <Message>At GraphBasedDirMut.java:[line 1384]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SS_SHOULD_BE_STATIC" priority="2" rank="18" abbrev="SS" category="PERFORMANCE" instanceHash="f05c28c0e2f45782741cc43ddca67547" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Unread field: should this field be static?</ShortMessage>
     <LongMessage>Unread field: org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.stoppingTrust; should this field be static?</LongMessage>
     <Class classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true">
-      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1376" end="1384" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-        <Message>At GraphBasedDirMut.java:[lines 1376-1384]</Message>
+      <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" start="1377" end="1385" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+        <Message>At GraphBasedDirMut.java:[lines 1377-1385]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig</Message>
     </Class>
@@ -4177,8 +4181,8 @@
       </SourceLine>
       <Message>Field org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig.stoppingTrust</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1382" end="1382" startBytecode="15" endBytecode="15" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
-      <Message>At GraphBasedDirMut.java:[line 1382]</Message>
+    <SourceLine classname="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" primary="true" start="1383" end="1383" startBytecode="15" endBytecode="15" sourcefile="GraphBasedDirMut.java" sourcepath="org/ogolem/core/GraphBasedDirMut.java" relSourcepath="org/ogolem/core/GraphBasedDirMut.java">
+      <Message>At GraphBasedDirMut.java:[line 1383]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="DLS_DEAD_LOCAL_STORE" priority="2" rank="17" abbrev="DLS" category="STYLE" instanceHash="6351e0165629a6527a3d172c5f0f8f38" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="563">
@@ -5081,46 +5085,46 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>org.ogolem.core.SimpleBondInfo.getBondInformation() may expose internal representation by returning SimpleBondInfo.bondTypes</LongMessage>
     <Class classname="org.ogolem.core.SimpleBondInfo" primary="true">
-      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="46" end="150" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
-        <Message>At SimpleBondInfo.java:[lines 46-150]</Message>
+      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="50" end="145" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
+        <Message>At SimpleBondInfo.java:[lines 50-145]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.SimpleBondInfo</Message>
     </Class>
-    <Method classname="org.ogolem.core.SimpleBondInfo" name="getBondInformation" signature="()[[S" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="150" end="150" startBytecode="0" endBytecode="46" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java"/>
+    <Method classname="org.ogolem.core.SimpleBondInfo" name="getBondInformation" signature="()Lorg/ogolem/math/ShortSymmetricMatrixNoDiag;" isStatic="false" primary="true">
+      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="145" end="145" startBytecode="0" endBytecode="46" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java"/>
       <Message>In method org.ogolem.core.SimpleBondInfo.getBondInformation()</Message>
     </Method>
-    <Field classname="org.ogolem.core.SimpleBondInfo" name="bondTypes" signature="[[S" isStatic="false" primary="true">
+    <Field classname="org.ogolem.core.SimpleBondInfo" name="bondTypes" signature="Lorg/ogolem/math/ShortSymmetricMatrixNoDiag;" isStatic="false" primary="true">
       <SourceLine classname="org.ogolem.core.SimpleBondInfo" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
         <Message>In SimpleBondInfo.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.SimpleBondInfo.bondTypes</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.SimpleBondInfo" primary="true" start="150" end="150" startBytecode="4" endBytecode="4" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
-      <Message>At SimpleBondInfo.java:[line 150]</Message>
+    <SourceLine classname="org.ogolem.core.SimpleBondInfo" primary="true" start="145" end="145" startBytecode="4" endBytecode="4" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
+      <Message>At SimpleBondInfo.java:[line 145]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="59a23be9c12aebca78bd93a41e0650c5" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>org.ogolem.core.SimpleBondInfo.getFullBondMatrix() may expose internal representation by returning SimpleBondInfo.bonds</LongMessage>
     <Class classname="org.ogolem.core.SimpleBondInfo" primary="true">
-      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="46" end="150" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
-        <Message>At SimpleBondInfo.java:[lines 46-150]</Message>
+      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="50" end="145" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
+        <Message>At SimpleBondInfo.java:[lines 50-145]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.SimpleBondInfo</Message>
     </Class>
-    <Method classname="org.ogolem.core.SimpleBondInfo" name="getFullBondMatrix" signature="()[[Z" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="135" end="135" startBytecode="0" endBytecode="46" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java"/>
+    <Method classname="org.ogolem.core.SimpleBondInfo" name="getFullBondMatrix" signature="()Lorg/ogolem/math/BoolSymmetricMatrixNoDiag;" isStatic="false" primary="true">
+      <SourceLine classname="org.ogolem.core.SimpleBondInfo" start="130" end="130" startBytecode="0" endBytecode="46" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java"/>
       <Message>In method org.ogolem.core.SimpleBondInfo.getFullBondMatrix()</Message>
     </Method>
-    <Field classname="org.ogolem.core.SimpleBondInfo" name="bonds" signature="[[Z" isStatic="false" primary="true">
+    <Field classname="org.ogolem.core.SimpleBondInfo" name="bonds" signature="Lorg/ogolem/math/BoolSymmetricMatrixNoDiag;" isStatic="false" primary="true">
       <SourceLine classname="org.ogolem.core.SimpleBondInfo" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
         <Message>In SimpleBondInfo.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.SimpleBondInfo.bonds</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.SimpleBondInfo" primary="true" start="135" end="135" startBytecode="4" endBytecode="4" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
-      <Message>At SimpleBondInfo.java:[line 135]</Message>
+    <SourceLine classname="org.ogolem.core.SimpleBondInfo" primary="true" start="130" end="130" startBytecode="4" endBytecode="4" sourcefile="SimpleBondInfo.java" sourcepath="org/ogolem/core/SimpleBondInfo.java" relSourcepath="org/ogolem/core/SimpleBondInfo.java">
+      <Message>At SimpleBondInfo.java:[line 130]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="69a8d4efa6255dd2a014d096705b7bd3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
@@ -5179,7 +5183,7 @@
       <Message>In class org.ogolem.core.SingleGeomSpectralFitnessFunction</Message>
     </Class>
     <Field classname="org.ogolem.core.SingleGeomSpectralFitnessFunction" name="traj" signature="Lorg/ogolem/md/InMemoryTrajectory;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.SingleGeomSpectralFitnessFunction" sourcefile="SingleGeomSpectralFitnessFunction.java" sourcepath="org/ogolem/core/SingleGeomSpectralFitnessFunction.java" relSourcepath="org/ogolem/core/SingleGeomSpectralFitnessFunction.java">
+      <SourceLine classname="org.ogolem.core.SingleGeomSpectralFitnessFunction" sourcefile="SingleGeomSpectralFitnessFunction.java" sourcepath="org/ogolem/core/SingleGeomSpectralFitnessFunction.java" relSourcepath="org/ogolem/core/SingleGeomSpectralFitnessFunction.java" synthetic="true">
         <Message>In SingleGeomSpectralFitnessFunction.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.core.SingleGeomSpectralFitnessFunction.traj</Message>
@@ -5328,23 +5332,23 @@
     <ShortMessage>Possible null pointer dereference due to return value of called method</ShortMessage>
     <LongMessage>Possible null pointer dereference in org.ogolem.core.TinkerMDCaller.cartesToCartes(long, CartesianCoordinates, boolean[][], boolean, BondInfo) due to return value of called method</LongMessage>
     <Class classname="org.ogolem.core.TinkerMDCaller" primary="true">
-      <SourceLine classname="org.ogolem.core.TinkerMDCaller" start="51" end="478" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java">
-        <Message>At TinkerMDCaller.java:[lines 51-478]</Message>
+      <SourceLine classname="org.ogolem.core.TinkerMDCaller" start="51" end="474" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java">
+        <Message>At TinkerMDCaller.java:[lines 51-474]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.TinkerMDCaller</Message>
     </Class>
     <Method classname="org.ogolem.core.TinkerMDCaller" name="cartesToCartes" signature="(JLorg/ogolem/core/CartesianCoordinates;[[ZZLorg/ogolem/core/BondInfo;)Lorg/ogolem/core/CartesianCoordinates;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.TinkerMDCaller" start="202" end="409" startBytecode="0" endBytecode="2511" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java"/>
+      <SourceLine classname="org.ogolem.core.TinkerMDCaller" start="198" end="405" startBytecode="0" endBytecode="2511" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java"/>
       <Message>In method org.ogolem.core.TinkerMDCaller.cartesToCartes(long, CartesianCoordinates, boolean[][], boolean, BondInfo)</Message>
     </Method>
     <LocalVariable name="fileList" register="22" pc="797" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from fileList</Message>
     </LocalVariable>
-    <SourceLine classname="org.ogolem.core.TinkerMDCaller" primary="true" start="356" end="356" startBytecode="799" endBytecode="799" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java" role="SOURCE_LINE_DEREF">
-      <Message>Dereferenced at TinkerMDCaller.java:[line 356]</Message>
+    <SourceLine classname="org.ogolem.core.TinkerMDCaller" primary="true" start="352" end="352" startBytecode="799" endBytecode="799" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java" role="SOURCE_LINE_DEREF">
+      <Message>Dereferenced at TinkerMDCaller.java:[line 352]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.core.TinkerMDCaller" start="354" end="354" startBytecode="785" endBytecode="785" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java" role="SOURCE_LINE_KNOWN_NULL">
-      <Message>Known null at TinkerMDCaller.java:[line 354]</Message>
+    <SourceLine classname="org.ogolem.core.TinkerMDCaller" start="350" end="350" startBytecode="785" endBytecode="785" sourcefile="TinkerMDCaller.java" sourcepath="org/ogolem/core/TinkerMDCaller.java" relSourcepath="org/ogolem/core/TinkerMDCaller.java" role="SOURCE_LINE_KNOWN_NULL">
+      <Message>Known null at TinkerMDCaller.java:[line 350]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="61fafc49e8db871b09f7a5c4870f91e1" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
@@ -6614,7 +6618,7 @@
       <Message>In class org.ogolem.freqs.Frequencies$Frequency</Message>
     </Class>
     <Method classname="org.ogolem.freqs.Frequencies$Frequency" name="compareTo" signature="(Lorg/ogolem/freqs/Frequencies$Frequency;)I" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.freqs.Frequencies$Frequency" start="199" end="202" startBytecode="0" endBytecode="97" sourcefile="Frequencies.java" sourcepath="org/ogolem/freqs/Frequencies.java" relSourcepath="org/ogolem/freqs/Frequencies.java"/>
+      <SourceLine classname="org.ogolem.freqs.Frequencies$Frequency" start="199" end="202" startBytecode="0" endBytecode="97" sourcefile="Frequencies.java" sourcepath="org/ogolem/freqs/Frequencies.java" relSourcepath="org/ogolem/freqs/Frequencies.java" synthetic="true"/>
       <Message>In method org.ogolem.freqs.Frequencies$Frequency.compareTo(Frequencies$Frequency)</Message>
     </Method>
     <SourceLine classname="org.ogolem.freqs.Frequencies$Frequency" start="199" end="202" startBytecode="0" endBytecode="97" sourcefile="Frequencies.java" sourcepath="org/ogolem/freqs/Frequencies.java" relSourcepath="org/ogolem/freqs/Frequencies.java" synthetic="true">
@@ -7280,7 +7284,7 @@
       <Message>In class org.ogolem.generic.genericpool.GenericPool</Message>
     </Class>
     <Field classname="org.ogolem.generic.genericpool.GenericPool" name="diversity" signature="Lorg/ogolem/generic/genericpool/DiversityChecker;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java">
+      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java" synthetic="true">
         <Message>In GenericPool.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.generic.genericpool.GenericPool.diversity</Message>
@@ -7299,7 +7303,7 @@
       <Message>In class org.ogolem.generic.genericpool.GenericPool</Message>
     </Class>
     <Field classname="org.ogolem.generic.genericpool.GenericPool" name="nicher" signature="Lorg/ogolem/generic/genericpool/Nicher;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java">
+      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java" synthetic="true">
         <Message>In GenericPool.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.generic.genericpool.GenericPool.nicher</Message>
@@ -7318,7 +7322,7 @@
       <Message>In class org.ogolem.generic.genericpool.GenericPool</Message>
     </Class>
     <Field classname="org.ogolem.generic.genericpool.GenericPool" name="selector" signature="Lorg/ogolem/generic/genericpool/ParentSelector;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java">
+      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java" synthetic="true">
         <Message>In GenericPool.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.generic.genericpool.GenericPool.selector</Message>
@@ -7337,7 +7341,7 @@
       <Message>In class org.ogolem.generic.genericpool.GenericPool</Message>
     </Class>
     <Field classname="org.ogolem.generic.genericpool.GenericPool" name="stats" signature="Lorg/ogolem/generic/genericpool/GenericStatistics;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java">
+      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java" synthetic="true">
         <Message>In GenericPool.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.generic.genericpool.GenericPool.stats</Message>
@@ -7356,7 +7360,7 @@
       <Message>In class org.ogolem.generic.genericpool.GenericPool</Message>
     </Class>
     <Field classname="org.ogolem.generic.genericpool.GenericPool" name="writer" signature="Lorg/ogolem/generic/IndividualWriter;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java">
+      <SourceLine classname="org.ogolem.generic.genericpool.GenericPool" sourcefile="GenericPool.java" sourcepath="org/ogolem/generic/genericpool/GenericPool.java" relSourcepath="org/ogolem/generic/genericpool/GenericPool.java" synthetic="true">
         <Message>In GenericPool.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.generic.genericpool.GenericPool.writer</Message>
@@ -8452,6 +8456,29 @@
       <Message>At AbstractLookup.java:[line 53]</Message>
     </SourceLine>
   </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="9c82fe5df97a9dc8c4f1c6bc0d8f663f" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
+    <LongMessage>org.ogolem.math.BoolSymmetricMatrixNoDiag.underlyingStorageBuffer() may expose internal representation by returning BoolSymmetricMatrixNoDiag.buffer</LongMessage>
+    <Class classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" primary="true">
+      <SourceLine classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" start="45" end="124" sourcefile="BoolSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java">
+        <Message>At BoolSymmetricMatrixNoDiag.java:[lines 45-124]</Message>
+      </SourceLine>
+      <Message>In class org.ogolem.math.BoolSymmetricMatrixNoDiag</Message>
+    </Class>
+    <Method classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" name="underlyingStorageBuffer" signature="()[Z" isStatic="false" primary="true">
+      <SourceLine classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" start="124" end="124" startBytecode="0" endBytecode="46" sourcefile="BoolSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java"/>
+      <Message>In method org.ogolem.math.BoolSymmetricMatrixNoDiag.underlyingStorageBuffer()</Message>
+    </Method>
+    <Field classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" name="buffer" signature="[Z" isStatic="false" primary="true">
+      <SourceLine classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" sourcefile="BoolSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java">
+        <Message>In BoolSymmetricMatrixNoDiag.java</Message>
+      </SourceLine>
+      <Message>Field org.ogolem.math.BoolSymmetricMatrixNoDiag.buffer</Message>
+    </Field>
+    <SourceLine classname="org.ogolem.math.BoolSymmetricMatrixNoDiag" primary="true" start="124" end="124" startBytecode="4" endBytecode="4" sourcefile="BoolSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/BoolSymmetricMatrixNoDiag.java">
+      <Message>At BoolSymmetricMatrixNoDiag.java:[line 124]</Message>
+    </SourceLine>
+  </BugInstance>
   <BugInstance type="UR_UNINIT_READ_CALLED_FROM_SUPER_CONSTRUCTOR" priority="1" rank="8" abbrev="UR" category="CORRECTNESS" instanceHash="da836d8068b1a414311fff894f0f7a87" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Uninitialized read of field method called from constructor of superclass</ShortMessage>
     <LongMessage>func isn&apos;t initialized in org.ogolem.math.GenericLookup.func(double) when invoked from constructor for superclass</LongMessage>
@@ -8489,17 +8516,40 @@
       <Message>At GenericLookup.java:[line 91]</Message>
     </SourceLine>
   </BugInstance>
+  <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="836a465727ebcfaa847affdc89e78b98" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
+    <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
+    <LongMessage>org.ogolem.math.ShortSymmetricMatrixNoDiag.underlyingStorageBuffer() may expose internal representation by returning ShortSymmetricMatrixNoDiag.buffer</LongMessage>
+    <Class classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" primary="true">
+      <SourceLine classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" start="45" end="124" sourcefile="ShortSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java">
+        <Message>At ShortSymmetricMatrixNoDiag.java:[lines 45-124]</Message>
+      </SourceLine>
+      <Message>In class org.ogolem.math.ShortSymmetricMatrixNoDiag</Message>
+    </Class>
+    <Method classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" name="underlyingStorageBuffer" signature="()[S" isStatic="false" primary="true">
+      <SourceLine classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" start="124" end="124" startBytecode="0" endBytecode="46" sourcefile="ShortSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java"/>
+      <Message>In method org.ogolem.math.ShortSymmetricMatrixNoDiag.underlyingStorageBuffer()</Message>
+    </Method>
+    <Field classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" name="buffer" signature="[S" isStatic="false" primary="true">
+      <SourceLine classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" sourcefile="ShortSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java">
+        <Message>In ShortSymmetricMatrixNoDiag.java</Message>
+      </SourceLine>
+      <Message>Field org.ogolem.math.ShortSymmetricMatrixNoDiag.buffer</Message>
+    </Field>
+    <SourceLine classname="org.ogolem.math.ShortSymmetricMatrixNoDiag" primary="true" start="124" end="124" startBytecode="4" endBytecode="4" sourcefile="ShortSymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/ShortSymmetricMatrixNoDiag.java">
+      <Message>At ShortSymmetricMatrixNoDiag.java:[line 124]</Message>
+    </SourceLine>
+  </BugInstance>
   <BugInstance type="EI_EXPOSE_REP" priority="2" rank="18" abbrev="EI" category="MALICIOUS_CODE" instanceHash="63a758abb370b80b0c3526e4e6c206c" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>org.ogolem.math.SymmetricMatrixNoDiag.underlyingStorageBuffer() may expose internal representation by returning SymmetricMatrixNoDiag.buffer</LongMessage>
     <Class classname="org.ogolem.math.SymmetricMatrixNoDiag" primary="true">
-      <SourceLine classname="org.ogolem.math.SymmetricMatrixNoDiag" start="45" end="105" sourcefile="SymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java">
-        <Message>At SymmetricMatrixNoDiag.java:[lines 45-105]</Message>
+      <SourceLine classname="org.ogolem.math.SymmetricMatrixNoDiag" start="45" end="124" sourcefile="SymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java">
+        <Message>At SymmetricMatrixNoDiag.java:[lines 45-124]</Message>
       </SourceLine>
       <Message>In class org.ogolem.math.SymmetricMatrixNoDiag</Message>
     </Class>
     <Method classname="org.ogolem.math.SymmetricMatrixNoDiag" name="underlyingStorageBuffer" signature="()[D" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.math.SymmetricMatrixNoDiag" start="105" end="105" startBytecode="0" endBytecode="46" sourcefile="SymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java"/>
+      <SourceLine classname="org.ogolem.math.SymmetricMatrixNoDiag" start="124" end="124" startBytecode="0" endBytecode="46" sourcefile="SymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java"/>
       <Message>In method org.ogolem.math.SymmetricMatrixNoDiag.underlyingStorageBuffer()</Message>
     </Method>
     <Field classname="org.ogolem.math.SymmetricMatrixNoDiag" name="buffer" signature="[D" isStatic="false" primary="true">
@@ -8508,8 +8558,8 @@
       </SourceLine>
       <Message>Field org.ogolem.math.SymmetricMatrixNoDiag.buffer</Message>
     </Field>
-    <SourceLine classname="org.ogolem.math.SymmetricMatrixNoDiag" primary="true" start="105" end="105" startBytecode="4" endBytecode="4" sourcefile="SymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java">
-      <Message>At SymmetricMatrixNoDiag.java:[line 105]</Message>
+    <SourceLine classname="org.ogolem.math.SymmetricMatrixNoDiag" primary="true" start="124" end="124" startBytecode="4" endBytecode="4" sourcefile="SymmetricMatrixNoDiag.java" sourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java" relSourcepath="org/ogolem/math/SymmetricMatrixNoDiag.java">
+      <Message>At SymmetricMatrixNoDiag.java:[line 124]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="DMI_RANDOM_USED_ONLY_ONCE" priority="1" rank="14" abbrev="DMI" category="BAD_PRACTICE" instanceHash="4366acd1ca73cfc076efa261221a5b33" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="440">
@@ -8913,7 +8963,7 @@
     <ShortMessage>Class names shouldn&apos;t shadow simple name of superclass</ShortMessage>
     <LongMessage>The class name org.ogolem.molecules.FixedValues shadows the simple name of the superclass org.ogolem.core.FixedValues</LongMessage>
     <Class classname="org.ogolem.molecules.FixedValues" primary="true">
-      <SourceLine classname="org.ogolem.molecules.FixedValues" start="49" end="50" sourcefile="FixedValues.java" sourcepath="org/ogolem/molecules/FixedValues.java" relSourcepath="org/ogolem/molecules/FixedValues.java">
+      <SourceLine classname="org.ogolem.molecules.FixedValues" start="49" end="50" sourcefile="FixedValues.java" sourcepath="org/ogolem/molecules/FixedValues.java" relSourcepath="org/ogolem/molecules/FixedValues.java" synthetic="true">
         <Message>At FixedValues.java:[lines 49-50]</Message>
       </SourceLine>
       <Message>In class org.ogolem.molecules.FixedValues</Message>
@@ -9320,7 +9370,7 @@
       <Message>In class org.ogolem.rmi.GenericProxyJob</Message>
     </Class>
     <Field classname="org.ogolem.rmi.GenericProxyJob" name="aliveCheck" signature="Lorg/ogolem/rmi/AliveCheck;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.rmi.GenericProxyJob" sourcefile="GenericProxyJob.java" sourcepath="org/ogolem/rmi/GenericProxyJob.java" relSourcepath="org/ogolem/rmi/GenericProxyJob.java">
+      <SourceLine classname="org.ogolem.rmi.GenericProxyJob" sourcefile="GenericProxyJob.java" sourcepath="org/ogolem/rmi/GenericProxyJob.java" relSourcepath="org/ogolem/rmi/GenericProxyJob.java" synthetic="true">
         <Message>In GenericProxyJob.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.rmi.GenericProxyJob.aliveCheck</Message>
@@ -9345,7 +9395,7 @@
       <Message>In class org.ogolem.rmi.GenericProxyJob</Message>
     </Class>
     <Field classname="org.ogolem.rmi.GenericProxyJob" name="serverComm" signature="Lorg/ogolem/rmi/RMICommunication;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.rmi.GenericProxyJob" sourcefile="GenericProxyJob.java" sourcepath="org/ogolem/rmi/GenericProxyJob.java" relSourcepath="org/ogolem/rmi/GenericProxyJob.java">
+      <SourceLine classname="org.ogolem.rmi.GenericProxyJob" sourcefile="GenericProxyJob.java" sourcepath="org/ogolem/rmi/GenericProxyJob.java" relSourcepath="org/ogolem/rmi/GenericProxyJob.java" synthetic="true">
         <Message>In GenericProxyJob.java</Message>
       </SourceLine>
       <Message>Field org.ogolem.rmi.GenericProxyJob.serverComm</Message>
@@ -9784,7 +9834,7 @@
       <Message>In class org.ogolem.spectral.Peak</Message>
     </Class>
     <Method classname="org.ogolem.spectral.Peak" name="compareTo" signature="(Lorg/ogolem/spectral/Peak;)I" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.spectral.Peak" start="88" end="95" startBytecode="0" endBytecode="121" sourcefile="Peak.java" sourcepath="org/ogolem/spectral/Peak.java" relSourcepath="org/ogolem/spectral/Peak.java"/>
+      <SourceLine classname="org.ogolem.spectral.Peak" start="88" end="95" startBytecode="0" endBytecode="121" sourcefile="Peak.java" sourcepath="org/ogolem/spectral/Peak.java" relSourcepath="org/ogolem/spectral/Peak.java" synthetic="true"/>
       <Message>In method org.ogolem.spectral.Peak.compareTo(Peak)</Message>
     </Method>
     <SourceLine classname="org.ogolem.spectral.Peak" start="88" end="95" startBytecode="0" endBytecode="121" sourcefile="Peak.java" sourcepath="org/ogolem/spectral/Peak.java" relSourcepath="org/ogolem/spectral/Peak.java" synthetic="true">
@@ -10815,1473 +10865,168 @@ closed.</p>
   <Errors errors="0" missingClasses="1">
     <MissingClass>jdk.incubator.foreign.LibraryLookup</MissingClass>
   </Errors>
-  <FindBugsSummary timestamp="Sun, 31 Oct 2021 16:49:39 -0500" total_classes="738" referenced_classes="1008" total_bugs="398" total_size="65978" num_packages="49" java_version="17.0.1" vm_version="17.0.1+12" cpu_seconds="43.79" clock_seconds="17.86" peak_mbytes="682.24" alloc_mbytes="512.00" gc_seconds="0.65" priority_2="350" priority_1="48">
-    <FileStats path="contrib/bobyqa/AbstractBOBYQAMethod.java" bugCount="0" size="33"/>
-    <FileStats path="contrib/bobyqa/BOBYQAMethod.java" bugCount="0" size="5"/>
-    <FileStats path="contrib/bobyqa/BOBYQAOptimizer.java" bugCount="5" size="1766" bugHash="02df92db8a0d632e485370f73e6e1b33"/>
-    <FileStats path="contrib/edu/princeton/eac/Grid.java" bugCount="5" size="137" bugHash="251eb162a72e2566121eefb876ee6d55"/>
-    <FileStats path="contrib/jama/CholeskyDecomposition.java" bugCount="1" size="50" bugHash="41d37c4a6cddaa062ff3ee500d7f0d16"/>
-    <FileStats path="contrib/jama/EigenvalueDecomposition.java" bugCount="3" size="538" bugHash="e85f17394ac825a376badd80f4bc9cb0"/>
-    <FileStats path="contrib/jama/LUDecomposition.java" bugCount="1" size="100" bugHash="2eddbcf35d071bdd723a580865367dba"/>
-    <FileStats path="contrib/jama/Matrix.java" bugCount="7" size="404" bugHash="89bc77b9b83dbfb0defe6129ac729905"/>
-    <FileStats path="contrib/jama/QRDecomposition.java" bugCount="0" size="94"/>
-    <FileStats path="contrib/jama/SingularValueDecomposition.java" bugCount="3" size="272" bugHash="fe455f3e47c78f262cef159696391903"/>
-    <FileStats path="contrib/jama/test/TestMatrix.java" bugCount="8" size="658" bugHash="ce2f1d8eb13041f55fbfea7b1dec9606"/>
-    <FileStats path="contrib/jama/util/Maths.java" bugCount="0" size="12"/>
-    <FileStats path="contrib/lbfgs/LBFGS.java" bugCount="2" size="484" bugHash="ab3e7aed1d2a3a25823e7b9409414e04"/>
-    <FileStats path="contrib/newuoa/NEWUOAMethod.java" bugCount="0" size="2"/>
-    <FileStats path="contrib/newuoa/NEWUOAOptimizer.java" bugCount="1" size="1148" bugHash="296db4da1b5fc70a1451aa33993ecea1"/>
-    <FileStats path="contrib/newuoa/TestNewUO.java" bugCount="0" size="43"/>
-    <FileStats path="numal/AP_linemin_method.java" bugCount="0" size="2"/>
-    <FileStats path="numal/AP_praxis_method.java" bugCount="0" size="2"/>
-    <FileStats path="numal/Analytic_problems.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/adaptive/AbstractAdaptivable.java" bugCount="0" size="81"/>
-    <FileStats path="org/ogolem/adaptive/AbstractAdaptiveBackend.java" bugCount="0" size="66"/>
-    <FileStats path="org/ogolem/adaptive/Adaptivable.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveAmberAngleTerm.java" bugCount="0" size="256"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveAmberDihedralTerm.java" bugCount="0" size="295"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveAmberFF.java" bugCount="1" size="354" bugHash="4b227dd68bdd180d5fd9a9ab533f0bc3"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveAmberLJTerm.java" bugCount="3" size="371" bugHash="6799109d7c76449a4fa2ffdc256b40c8"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveBackend.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveBondedHarmonicTerm.java" bugCount="0" size="273"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveCachedBondTerm.java" bugCount="0" size="104"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveConf.java" bugCount="1" size="1958" bugHash="f32b3ff8d1baed2e2bc7040749d95bd0"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveCustomSpillage.java" bugCount="1" size="199" bugHash="3e092946378c0fa266a76092a65a44dd"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveCustomSpillage2.java" bugCount="1" size="127" bugHash="476f9d90c3d2b94b7f6fa23af2080f22"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveExternalCaller.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveGUPTA.java" bugCount="3" size="348" bugHash="82b1c2c209ff0632d3bcb8cd0585adbd"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveGateway.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveInteractionTerm.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveLJFF.java" bugCount="1" size="715" bugHash="ad7b33751f95937e233d4eb8b818380b"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveMopacCaller.java" bugCount="0" size="387"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveMorse.java" bugCount="1" size="264" bugHash="bc8bfbae6b6c8399b2cc64ca809c38f4"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveMorseTerm.java" bugCount="0" size="290"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveNewton.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveOrcaCaller.java" bugCount="0" size="348"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveParameters.java" bugCount="5" size="310" bugHash="1bf6412bc0df85ea1d7b1bdb962b4d47"/>
-    <FileStats path="org/ogolem/adaptive/AdaptivePolaris.java" bugCount="0" size="213"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveSWG2BodyTerm.java" bugCount="0" size="206"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveSWG3BodyTerm.java" bugCount="0" size="378"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveSWGFF.java" bugCount="1" size="167" bugHash="e8418a28106055fac84dea9b28c0fe6f"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" bugCount="4" size="208" bugHash="ef101583b7fe14d885b1d14863c9c0af"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveTotalEnergyShifter.java" bugCount="0" size="90"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveUFF.java" bugCount="1" size="262" bugHash="8e89c0fd0db8e1e73a345bca50a01be1"/>
-    <FileStats path="org/ogolem/adaptive/Analytics.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/adaptive/ArcticAdaptiveCrossover.java" bugCount="0" size="58"/>
-    <FileStats path="org/ogolem/adaptive/BenchAckley.java" bugCount="0" size="141"/>
-    <FileStats path="org/ogolem/adaptive/BenchBerndGauss10D.java" bugCount="1" size="88" bugHash="35669d04df369d38e30ef81a293ccd0a"/>
-    <FileStats path="org/ogolem/adaptive/BenchGriewangkRosenbrock.java" bugCount="0" size="68"/>
-    <FileStats path="org/ogolem/adaptive/BenchLunacek.java" bugCount="0" size="160"/>
-    <FileStats path="org/ogolem/adaptive/BenchRastrigin.java" bugCount="0" size="108"/>
-    <FileStats path="org/ogolem/adaptive/BenchSchaffer.java" bugCount="0" size="156"/>
-    <FileStats path="org/ogolem/adaptive/BenchSchafferF6.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/adaptive/BenchSchwefels.java" bugCount="0" size="112"/>
-    <FileStats path="org/ogolem/adaptive/DoubleMorse.java" bugCount="0" size="274"/>
-    <FileStats path="org/ogolem/adaptive/DummyFitness.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/adaptive/ExternalLocOpt.java" bugCount="0" size="80"/>
-    <FileStats path="org/ogolem/adaptive/FMProfessPseudoPotential.java" bugCount="3" size="1156" bugHash="3842a8c4a33109fe9ccc5e32768ac7a3"/>
-    <FileStats path="org/ogolem/adaptive/FitFuncToBackend.java" bugCount="0" size="73"/>
-    <FileStats path="org/ogolem/adaptive/FixedValues.java" bugCount="1" size="5" bugHash="bf5633c8a55ec8f0f769c8e7fd632c6a"/>
-    <FileStats path="org/ogolem/adaptive/GenericCaller.java" bugCount="4" size="379" bugHash="7250c920f0700943c2932aad41c6208d"/>
-    <FileStats path="org/ogolem/adaptive/GenericNativeCaller.java" bugCount="1" size="93" bugHash="bab6bc17b6d78b2568588106939b3f5a"/>
-    <FileStats path="org/ogolem/adaptive/GenericParameterDarwin.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/adaptive/Input.java" bugCount="0" size="53"/>
-    <FileStats path="org/ogolem/adaptive/MainOgoAdaptive.java" bugCount="0" size="220"/>
-    <FileStats path="org/ogolem/adaptive/NumericalGradients.java" bugCount="1" size="101" bugHash="9e1c6c2e9ec5016913db1e9e6c4d7ca6"/>
-    <FileStats path="org/ogolem/adaptive/Output.java" bugCount="0" size="370"/>
-    <FileStats path="org/ogolem/adaptive/ParamGlobOptFactory.java" bugCount="3" size="108" bugHash="df04433f81800c2befba9325d9b062c9"/>
-    <FileStats path="org/ogolem/adaptive/ParamLocOptFactory.java" bugCount="0" size="31"/>
-    <FileStats path="org/ogolem/adaptive/ParameterDiversityCheckers.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/adaptive/ParameterGradient.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/adaptive/ParameterInit.java" bugCount="0" size="47"/>
-    <FileStats path="org/ogolem/adaptive/ParameterReader.java" bugCount="0" size="36"/>
-    <FileStats path="org/ogolem/adaptive/ParameterSanityCheck.java" bugCount="2" size="33" bugHash="c5295bc7a34bd588707b20af611bce09"/>
-    <FileStats path="org/ogolem/adaptive/ParameterWriter.java" bugCount="0" size="30"/>
-    <FileStats path="org/ogolem/adaptive/RangedFitFuncToBackend.java" bugCount="0" size="139"/>
-    <FileStats path="org/ogolem/adaptive/ReferencePointLibrary.java" bugCount="0" size="33"/>
-    <FileStats path="org/ogolem/adaptive/SearchspaceCapturer.java" bugCount="0" size="122"/>
-    <FileStats path="org/ogolem/adaptive/StaticGridNiches.java" bugCount="0" size="58"/>
-    <FileStats path="org/ogolem/adaptive/UnaryGaussianMutation.java" bugCount="0" size="97"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/BatchedPropertyCalculator.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/EnergyCalculator.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/FitnessTermConfig.java" bugCount="0" size="141"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/GenericFitnessFunction.java" bugCount="2" size="122" bugHash="41790b15ab0b7fa2a7a45357860276d2"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/GenericFitnessTerm.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/GenericReferencePoint.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/PropertyCalculator.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/PseudoPropertyCalculator.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/RefBulkModulusData.java" bugCount="0" size="37"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/RefCellVolumeData.java" bugCount="0" size="33"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceDeltaGaugeData.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceDensityData.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceDummyData.java" bugCount="0" size="18"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceEnergyOrderData.java" bugCount="2" size="34" bugHash="de59de99384372514221a54bf47044f9"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceForcesData.java" bugCount="0" size="23"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceGenericMatrixData.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceGenericScalarData.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceGenericTensorData.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceGenericVectorData.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceGeomData.java" bugCount="0" size="24"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceInputData.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferencePoint.java" bugCount="0" size="44"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceStressTensorData.java" bugCount="0" size="23"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/SerialBatchedPropertyCalculator.java" bugCount="2" size="90" bugHash="d077c70271bfd1dc2713934569eee5e6"/>
-    <FileStats path="org/ogolem/adaptive/genericfitness/SerialGenericFitnessTerm.java" bugCount="1" size="259" bugHash="e876cbb8beeca69d2c237d1596cc8a6c"/>
-    <FileStats path="org/ogolem/atom2ogo/MainAtom2Ogo.java" bugCount="0" size="48"/>
-    <FileStats path="org/ogolem/atom2ogo/MainOgo2Atom.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/beswitched/MainBeswitched.java" bugCount="0" size="67"/>
-    <FileStats path="org/ogolem/clusters/ClusterAnalyzation.java" bugCount="2" size="166" bugHash="6668d1917380dda7977eea533e64cf58"/>
-    <FileStats path="org/ogolem/clusters/MainClusters.java" bugCount="0" size="388"/>
-    <FileStats path="org/ogolem/clusters/MainThreadingClusterGlobOpt.java" bugCount="2" size="81" bugHash="2e3dbc32a658d59504b5210e8bc9ce37"/>
-    <FileStats path="org/ogolem/core/ADFCaller.java" bugCount="1" size="127" bugHash="7cf9a36c86b5178bc223c098b97befc3"/>
-    <FileStats path="org/ogolem/core/AbstractBondInfo.java" bugCount="0" size="23"/>
-    <FileStats path="org/ogolem/core/AbstractCollisionInfo.java" bugCount="0" size="30"/>
-    <FileStats path="org/ogolem/core/AbstractGradient.java" bugCount="3" size="35" bugHash="1b8a134fc1ffdc70baa39f0dcbc60c8b"/>
-    <FileStats path="org/ogolem/core/AbstractLocOpt.java" bugCount="0" size="142"/>
-    <FileStats path="org/ogolem/core/AdditivePenaltyFunction.java" bugCount="0" size="7"/>
-    <FileStats path="org/ogolem/core/AdvancedGraphBasedDirMut.java" bugCount="2" size="324" bugHash="a9bbdc62b7f38a5678794bb9d899a2be"/>
-    <FileStats path="org/ogolem/core/AdvancedPairWise.java" bugCount="0" size="182"/>
-    <FileStats path="org/ogolem/core/AlandGeometryXOver.java" bugCount="2" size="156" bugHash="f4b789e3083bbba04200ea2ba263bb4d"/>
-    <FileStats path="org/ogolem/core/AllowedSpace.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/core/AmberCaller.java" bugCount="0" size="195"/>
-    <FileStats path="org/ogolem/core/Atom.java" bugCount="0" size="80"/>
-    <FileStats path="org/ogolem/core/AtomConfig.java" bugCount="0" size="37"/>
-    <FileStats path="org/ogolem/core/AtomicProperties.java" bugCount="0" size="826"/>
-    <FileStats path="org/ogolem/core/BackendFactory.java" bugCount="2" size="376" bugHash="dc759bb64f6398f23b9fe277ee9f1760"/>
-    <FileStats path="org/ogolem/core/BondInfo.java" bugCount="0" size="21"/>
-    <FileStats path="org/ogolem/core/CP2KCaller.java" bugCount="0" size="233"/>
-    <FileStats path="org/ogolem/core/CPMDCaller.java" bugCount="0" size="333"/>
-    <FileStats path="org/ogolem/core/CartesianCoordinates.java" bugCount="15" size="654" bugHash="5e96798307218e592f67dc512f13ac7d"/>
-    <FileStats path="org/ogolem/core/CartesianFullBackend.java" bugCount="0" size="7"/>
-    <FileStats path="org/ogolem/core/CartesianToRigidCoordinates.java" bugCount="2" size="278" bugHash="4d9f18bac2872a7fc70670bd1e4f3325"/>
-    <FileStats path="org/ogolem/core/CastException.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/core/ChainedCartesianFullBackend.java" bugCount="0" size="73"/>
-    <FileStats path="org/ogolem/core/ChainedNicheComp.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/core/CollisionDetection.java" bugCount="0" size="154"/>
-    <FileStats path="org/ogolem/core/CollisionDetectionEngine.java" bugCount="0" size="8"/>
-    <FileStats path="org/ogolem/core/CollisionInfo.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/core/CollisionStrengthComputer.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/core/CompressionMutation.java" bugCount="0" size="67"/>
-    <FileStats path="org/ogolem/core/Constants.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/core/ConvergenceException.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/core/CoordRepresentationsNotCompatibleException.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/core/CoordTranslation.java" bugCount="0" size="1146"/>
-    <FileStats path="org/ogolem/core/CoordinateRepresentation.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/core/CoulombMatrixNicheComp.java" bugCount="0" size="53"/>
-    <FileStats path="org/ogolem/core/DFTBplusCaller.java" bugCount="0" size="263"/>
-    <FileStats path="org/ogolem/core/Darwin.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/core/DirMutOptStrategies.java" bugCount="6" size="285" bugHash="d930ae57125307958f97eb20a964b6a3"/>
-    <FileStats path="org/ogolem/core/DirMutPointProviders.java" bugCount="10" size="708" bugHash="bc794c3a534d23d5db86541c8f3ade10"/>
-    <FileStats path="org/ogolem/core/DirectedMutation.java" bugCount="0" size="196"/>
-    <FileStats path="org/ogolem/core/DissociationDetection.java" bugCount="0" size="78"/>
-    <FileStats path="org/ogolem/core/DistanceCalc.java" bugCount="0" size="71"/>
-    <FileStats path="org/ogolem/core/DummyCollisionStrengthComputer.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/core/DummyLocOpt.java" bugCount="0" size="21"/>
-    <FileStats path="org/ogolem/core/ElectrostaticTerm.java" bugCount="0" size="107"/>
-    <FileStats path="org/ogolem/core/Environment.java" bugCount="0" size="31"/>
-    <FileStats path="org/ogolem/core/EnvironmentCartesCoordinates.java" bugCount="1" size="141" bugHash="5d11936f9b8d67814025e36b6fc2f9a7"/>
-    <FileStats path="org/ogolem/core/EnvironmentFactory.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/core/ExternalLocOpt.java" bugCount="0" size="30"/>
-    <FileStats path="org/ogolem/core/FFEngineWrapper.java" bugCount="0" size="134"/>
-    <FileStats path="org/ogolem/core/FinlandGeometryMutation.java" bugCount="0" size="170"/>
-    <FileStats path="org/ogolem/core/FirstInCenterPenalty.java" bugCount="0" size="54"/>
-    <FileStats path="org/ogolem/core/FitnessFunctionFactory.java" bugCount="0" size="56"/>
-    <FileStats path="org/ogolem/core/FixedValues.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/core/FoehrGeometryMutation.java" bugCount="0" size="85"/>
-    <FileStats path="org/ogolem/core/FoehrGeometryXOver.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/core/FullyCartesianCoordinates.java" bugCount="1" size="109" bugHash="ad29db0f49034b25b89a0307c1208579"/>
-    <FileStats path="org/ogolem/core/GenericGeometryDarwin.java" bugCount="0" size="66"/>
-    <FileStats path="org/ogolem/core/Geometry.java" bugCount="2" size="634" bugHash="99cbd9981b68b7373f20579947a15712"/>
-    <FileStats path="org/ogolem/core/GeometryConfig.java" bugCount="0" size="55"/>
-    <FileStats path="org/ogolem/core/GeometryInit.java" bugCount="0" size="78"/>
-    <FileStats path="org/ogolem/core/GeometryInitialization.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/core/GeometryInitializationToGenericAdaptor.java" bugCount="1" size="50" bugHash="7d5dc30350db7877a7f3fd37b025665e"/>
-    <FileStats path="org/ogolem/core/GeometryReader.java" bugCount="0" size="48"/>
-    <FileStats path="org/ogolem/core/GeometrySanityCheck.java" bugCount="0" size="101"/>
-    <FileStats path="org/ogolem/core/GeometryWriter.java" bugCount="0" size="55"/>
-    <FileStats path="org/ogolem/core/GermanyGeometryMutation.java" bugCount="0" size="63"/>
-    <FileStats path="org/ogolem/core/GermanyGeometryXOver.java" bugCount="0" size="59"/>
-    <FileStats path="org/ogolem/core/GermanyMoleculeMutation.java" bugCount="0" size="130"/>
-    <FileStats path="org/ogolem/core/GermanyMoleculeXOver.java" bugCount="0" size="151"/>
-    <FileStats path="org/ogolem/core/GlobOptAlgoFactory.java" bugCount="2" size="1076" bugHash="a5412ca381753f4e879f499fdf17d3a5"/>
-    <FileStats path="org/ogolem/core/GlobOptAtomics.java" bugCount="2" size="156" bugHash="0b4fe53f3bc6cf9fcdd8f704901a39a0"/>
-    <FileStats path="org/ogolem/core/GlobOptStatistics.java" bugCount="0" size="20"/>
-    <FileStats path="org/ogolem/core/GlobalConfig.java" bugCount="3" size="524" bugHash="f7e048eae720cce80cd6dcd9d8a13a32"/>
-    <FileStats path="org/ogolem/core/GlobalOptimization.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/core/Gradient.java" bugCount="3" size="111" bugHash="b381ba47e2c3bf581e24d323edae32c2"/>
-    <FileStats path="org/ogolem/core/GraphBasedDirMut.java" bugCount="4" size="699" bugHash="dbb0576cfdd1ff19911415e4b3511ccd"/>
-    <FileStats path="org/ogolem/core/GraphDiversityCheck.java" bugCount="4" size="52" bugHash="7859ebb25e25b9e2d62eee64783b69e8"/>
-    <FileStats path="org/ogolem/core/GridCollisionDetection.java" bugCount="1" size="339" bugHash="021915ab1d78d8f9d778ebf46e1cb33f"/>
-    <FileStats path="org/ogolem/core/GromacsCaller.java" bugCount="0" size="227"/>
-    <FileStats path="org/ogolem/core/GulpCaller.java" bugCount="1" size="88" bugHash="f1b5eb5b2926fa5be6f26977d11b629a"/>
-    <FileStats path="org/ogolem/core/HackySurfaceAdsorptionBiaser.java" bugCount="0" size="71"/>
-    <FileStats path="org/ogolem/core/HalfSphereSpace.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/core/HydrogenBondNicheComp.java" bugCount="0" size="86"/>
-    <FileStats path="org/ogolem/core/IcelandGeometryXOver.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/core/InitIOException.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/core/Input.java" bugCount="1" size="1771" bugHash="05707eb1ba0dc146bedcadc2499df227"/>
-    <FileStats path="org/ogolem/core/InputSanityCheck.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/core/InteractionTerm.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/core/InteriorMoleculeNicheComp.java" bugCount="0" size="33"/>
-    <FileStats path="org/ogolem/core/InverseNewtonAdapter.java" bugCount="1" size="72" bugHash="df75f2ea9acd9a583e606f1170e1a25f"/>
-    <FileStats path="org/ogolem/core/LJNeighborNicheComp.java" bugCount="7" size="185" bugHash="c3973b2ff01fa512ad9e4f4bf1b63cab"/>
-    <FileStats path="org/ogolem/core/LJProjNicheComp.java" bugCount="1" size="127" bugHash="bb6312127105e6b18e5fe8344ebab35d"/>
-    <FileStats path="org/ogolem/core/LaplandGeometryXOver.java" bugCount="0" size="125"/>
-    <FileStats path="org/ogolem/core/LennardJonesFF.java" bugCount="0" size="252"/>
-    <FileStats path="org/ogolem/core/LocOptFactory.java" bugCount="2" size="559" bugHash="09d2d38c5998592ae2000d75684a5a8a"/>
-    <FileStats path="org/ogolem/core/LocalHeatGeometryMutation.java" bugCount="0" size="44"/>
-    <FileStats path="org/ogolem/core/LocalHeatLocOpt.java" bugCount="0" size="52"/>
-    <FileStats path="org/ogolem/core/LotriffCaller.java" bugCount="0" size="78"/>
-    <FileStats path="org/ogolem/core/MNDOCaller.java" bugCount="0" size="250"/>
-    <FileStats path="org/ogolem/core/MainOGOLEM.java" bugCount="0" size="159"/>
-    <FileStats path="org/ogolem/core/MergingPhenoXOver.java" bugCount="0" size="475"/>
-    <FileStats path="org/ogolem/core/MixedLJForceField.java" bugCount="0" size="294"/>
-    <FileStats path="org/ogolem/core/Molecule.java" bugCount="4" size="578" bugHash="b23876898cc3044f2423079f1ad41246"/>
-    <FileStats path="org/ogolem/core/MoleculeConfig.java" bugCount="0" size="133"/>
-    <FileStats path="org/ogolem/core/MoleculeUntangler.java" bugCount="0" size="117"/>
-    <FileStats path="org/ogolem/core/MolproCaller.java" bugCount="0" size="379"/>
-    <FileStats path="org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation.java" bugCount="0" size="97"/>
-    <FileStats path="org/ogolem/core/MonteCarloExtOnlyGeometryMutation.java" bugCount="0" size="99"/>
-    <FileStats path="org/ogolem/core/MonteCarloGeometryMutation.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/core/MonteCarloMoleculeMutation.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/core/MonteCarloMutation.java" bugCount="0" size="179"/>
-    <FileStats path="org/ogolem/core/MopacCaller.java" bugCount="0" size="208"/>
-    <FileStats path="org/ogolem/core/MultiCollisionInfo.java" bugCount="0" size="17"/>
-    <FileStats path="org/ogolem/core/NAMDCaller.java" bugCount="0" size="136"/>
-    <FileStats path="org/ogolem/core/Newton.java" bugCount="0" size="11"/>
-    <FileStats path="org/ogolem/core/NewtonAdaptor.java" bugCount="0" size="53"/>
-    <FileStats path="org/ogolem/core/NorrbottenGeometryXOver.java" bugCount="0" size="317"/>
-    <FileStats path="org/ogolem/core/NorwayGeometryMutation.java" bugCount="0" size="253"/>
-    <FileStats path="org/ogolem/core/NumericalGradients.java" bugCount="0" size="79"/>
-    <FileStats path="org/ogolem/core/OpenBabelCaller.java" bugCount="0" size="173"/>
-    <FileStats path="org/ogolem/core/OrbitSpace.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/core/Output.java" bugCount="0" size="64"/>
-    <FileStats path="org/ogolem/core/PackingInit.java" bugCount="0" size="13"/>
-    <FileStats path="org/ogolem/core/ParallelepipedSpace.java" bugCount="0" size="67"/>
-    <FileStats path="org/ogolem/core/PenaltyLocOpt.java" bugCount="0" size="52"/>
-    <FileStats path="org/ogolem/core/PeriodicCoordTranslator.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/core/PeriodicCoordinates.java" bugCount="13" size="147" bugHash="1d6e15e013fbd02e19be29e4eeba007b"/>
-    <FileStats path="org/ogolem/core/PhenotypeGeometryXOver.java" bugCount="0" size="240"/>
-    <FileStats path="org/ogolem/core/PluggableDirMut.java" bugCount="2" size="128" bugHash="871c442a69b068905e380571450c49eb"/>
-    <FileStats path="org/ogolem/core/PortugalGeometryXOver.java" bugCount="0" size="58"/>
-    <FileStats path="org/ogolem/core/PortugalMoleculeXOver.java" bugCount="0" size="79"/>
-    <FileStats path="org/ogolem/core/QuantumEspressoCaller.java" bugCount="0" size="69"/>
-    <FileStats path="org/ogolem/core/RandomizedGeomInit.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/core/RigidBodyBackend.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/core/RigidBodyCoordinates.java" bugCount="1" size="245" bugHash="c70aaa7b339ccdd9dde017d65b750a63"/>
-    <FileStats path="org/ogolem/core/ScaTTM3FBackend.java" bugCount="0" size="250"/>
-    <FileStats path="org/ogolem/core/SerialException.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/core/SigmoidCollisionStrengthComputer.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/core/SimpleBondInfo.java" bugCount="2" size="61" bugHash="9edabc7313ed877dd69416dd71123664"/>
-    <FileStats path="org/ogolem/core/SimpleEnvironment.java" bugCount="1" size="405" bugHash="6c6a93aafd17dac9291c73ee5f4ea5cd"/>
-    <FileStats path="org/ogolem/core/SimpleSeedingInit.java" bugCount="0" size="91"/>
-    <FileStats path="org/ogolem/core/SimpleSurface.java" bugCount="0" size="71"/>
-    <FileStats path="org/ogolem/core/SingleCollisionInfo.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/core/SingleGeomSpectralFitnessFunction.java" bugCount="2" size="285" bugHash="1f8977969eab840dbff6d58d37418bc7"/>
-    <FileStats path="org/ogolem/core/SkalevalaCaller.java" bugCount="0" size="59"/>
-    <FileStats path="org/ogolem/core/SnaefellsjoekullGeometryXOver.java" bugCount="2" size="546" bugHash="c1ddbd7c2d8f534e54c11a8331ee4530"/>
-    <FileStats path="org/ogolem/core/SphereSpace.java" bugCount="0" size="36"/>
-    <FileStats path="org/ogolem/core/SphericalCoordinates.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/core/StreamGobbler.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/core/StructuralData.java" bugCount="0" size="12"/>
-    <FileStats path="org/ogolem/core/Surface.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/core/SurfaceDetection.java" bugCount="3" size="35" bugHash="039ece6a27c90dfd780c9b3dfc0c9382"/>
-    <FileStats path="org/ogolem/core/SurfaceDetectionEngine.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/core/SurfaceDirectedMutation.java" bugCount="1" size="215" bugHash="0bf3f642475be1a96bac77d0a0a60d77"/>
-    <FileStats path="org/ogolem/core/SwedenGeometryXOver.java" bugCount="0" size="50"/>
-    <FileStats path="org/ogolem/core/TIP3PForceField.java" bugCount="0" size="404"/>
-    <FileStats path="org/ogolem/core/TIP4PForceField.java" bugCount="0" size="470"/>
-    <FileStats path="org/ogolem/core/TIPnPHelpers.java" bugCount="0" size="43"/>
-    <FileStats path="org/ogolem/core/TIPnPParameters.java" bugCount="0" size="71"/>
-    <FileStats path="org/ogolem/core/TinkerCaller.java" bugCount="0" size="321"/>
-    <FileStats path="org/ogolem/core/TinkerMDCaller.java" bugCount="1" size="251" bugHash="e5e9e6d3743ec2e5451b03c75b7823d9"/>
-    <FileStats path="org/ogolem/core/Topology.java" bugCount="33" size="448" bugHash="786ce2458ac0ba7bc8f1e5bea014e44e"/>
-    <FileStats path="org/ogolem/core/TwoStepLocOpt.java" bugCount="0" size="67"/>
-    <FileStats path="org/ogolem/core/UNGlobOpt.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/core/UniversalFF.java" bugCount="0" size="125"/>
-    <FileStats path="org/ogolem/core/VASPCaller.java" bugCount="0" size="226"/>
-    <FileStats path="org/ogolem/core/VinlandGeometryXOver.java" bugCount="1" size="147" bugHash="46c5d57668b498497b143ff4cf830821"/>
-    <FileStats path="org/ogolem/core/WaterAngleNicheComp.java" bugCount="0" size="100"/>
-    <FileStats path="org/ogolem/core/WeightedGraph.java" bugCount="0" size="73"/>
-    <FileStats path="org/ogolem/core/XChangeGeometryMutation.java" bugCount="0" size="61"/>
-    <FileStats path="org/ogolem/core/ZMatrix.java" bugCount="14" size="160" bugHash="fab4db437974bce461fe46fd6d3b41b5"/>
-    <FileStats path="org/ogolem/dimeranalyzer/MainDimerAnalyzer.java" bugCount="1" size="89" bugHash="9b22e33007125793bfe4a40110d515b3"/>
-    <FileStats path="org/ogolem/dimerizer/DimerizerConfig.java" bugCount="0" size="74"/>
-    <FileStats path="org/ogolem/dimerizer/DimerizerCore.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/dimerizer/MainDimerizer.java" bugCount="0" size="62"/>
-    <FileStats path="org/ogolem/familytree/GeneticRecord.java" bugCount="0" size="39"/>
-    <FileStats path="org/ogolem/familytree/GeneticRecordComparator.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/familytree/MainFamilyTree.java" bugCount="0" size="180"/>
-    <FileStats path="org/ogolem/familytree/VisualizationConfig.java" bugCount="0" size="104"/>
-    <FileStats path="org/ogolem/fft/MainFFTInterface.java" bugCount="0" size="63"/>
-    <FileStats path="org/ogolem/fft/Padder.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/freqs/Frequencies.java" bugCount="3" size="97" bugHash="62fef1dc4772171057b2b71008924b98"/>
-    <FileStats path="org/ogolem/freqs/FrequencyMethod.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/freqs/HarmonicFrequencyCalculator.java" bugCount="2" size="33" bugHash="82faffff93546344c2d159af60477a31"/>
-    <FileStats path="org/ogolem/freqs/MainFreqs.java" bugCount="0" size="55"/>
-    <FileStats path="org/ogolem/freqs/MainPowerSpec.java" bugCount="0" size="57"/>
-    <FileStats path="org/ogolem/freqs/MinimumDecider.java" bugCount="0" size="22"/>
-    <FileStats path="org/ogolem/freqs/NumericalHessianCalculator.java" bugCount="0" size="85"/>
-    <FileStats path="org/ogolem/general/MainOgolem.java" bugCount="0" size="180"/>
-    <FileStats path="org/ogolem/generic/AbstractDefaultConfig.java" bugCount="1" size="76" bugHash="ac3227fca1970d2aabe909370ff044ab"/>
-    <FileStats path="org/ogolem/generic/AbstractProblem.java" bugCount="0" size="44"/>
-    <FileStats path="org/ogolem/generic/BoundedGenericMutation.java" bugCount="2" size="52" bugHash="8c55bfcc973f17bf01d56034a7e20809"/>
-    <FileStats path="org/ogolem/generic/BoundedInitializer.java" bugCount="2" size="49" bugHash="c1bd19ca508fecfc1d01f7bd6149081a"/>
-    <FileStats path="org/ogolem/generic/Configuration.java" bugCount="0" size="17"/>
-    <FileStats path="org/ogolem/generic/ContinuousProblem.java" bugCount="0" size="15"/>
-    <FileStats path="org/ogolem/generic/Copyable.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/generic/DiscreteProblem.java" bugCount="0" size="13"/>
-    <FileStats path="org/ogolem/generic/DummyIndividualReader.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/generic/EmptySanityCheck.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/generic/GenericAbsolutePrescreeningLocOpt.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/generic/GenericAbstractDarwin.java" bugCount="1" size="139" bugHash="4f1a97a1ac8346e5adb510b0b7fff311"/>
-    <FileStats path="org/ogolem/generic/GenericAbstractGradFreeLocOpt.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/generic/GenericAbstractLocOpt.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/generic/GenericBackend.java" bugCount="0" size="15"/>
-    <FileStats path="org/ogolem/generic/GenericChainedFitnessFunc.java" bugCount="1" size="44" bugHash="ee15b8d534e0e5bcf268144c243aab4b"/>
-    <FileStats path="org/ogolem/generic/GenericChainedMutation.java" bugCount="2" size="46" bugHash="0da9c82db96761d66789db8248c8fdb3"/>
-    <FileStats path="org/ogolem/generic/GenericChainedXOver.java" bugCount="2" size="48" bugHash="33d1f75873bb4650351b99de00ab7964"/>
-    <FileStats path="org/ogolem/generic/GenericCrossover.java" bugCount="0" size="7"/>
-    <FileStats path="org/ogolem/generic/GenericDarwin.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/generic/GenericFitnessBackend.java" bugCount="0" size="23"/>
-    <FileStats path="org/ogolem/generic/GenericFitnessFunction.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/generic/GenericFitnessFunctionBackendWrapper.java" bugCount="3" size="59" bugHash="33b9501ff635601ba3b7aaeca642cd2a"/>
-    <FileStats path="org/ogolem/generic/GenericGermanyCrossover.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/generic/GenericGlobalOptimization.java" bugCount="0" size="7"/>
-    <FileStats path="org/ogolem/generic/GenericGlobalOptimizationFactory.java" bugCount="0" size="147"/>
-    <FileStats path="org/ogolem/generic/GenericHollandCrossover.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/generic/GenericInitializer.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/generic/GenericLocOpt.java" bugCount="0" size="7"/>
-    <FileStats path="org/ogolem/generic/GenericMultipleGlobOpt.java" bugCount="1" size="56" bugHash="d338a4dd0063c09a91956b62c49a33a2"/>
-    <FileStats path="org/ogolem/generic/GenericMutation.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/generic/GenericMutationAsXOver.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/generic/GenericNoLocOpt.java" bugCount="0" size="26"/>
-    <FileStats path="org/ogolem/generic/GenericOperator.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/generic/GenericPortugalCrossover.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/generic/GenericRelativePrescreeningLocOpt.java" bugCount="1" size="42" bugHash="964beea0b1d0bfb3dccce0b5338d140c"/>
-    <FileStats path="org/ogolem/generic/GenericSanityCheck.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/generic/GenericStepChangingMut.java" bugCount="1" size="49" bugHash="7738b209a1cd52b7669628c8db4918fc"/>
-    <FileStats path="org/ogolem/generic/GenericStepChangingXOver.java" bugCount="1" size="54" bugHash="5fc0c557a49da3187a951fd4ae90e300"/>
-    <FileStats path="org/ogolem/generic/IndividualReader.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/generic/IndividualWriter.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/generic/MultipleMutationWrapper.java" bugCount="1" size="53" bugHash="695242c17d2171df43d659ddf119ddcf"/>
-    <FileStats path="org/ogolem/generic/MultipleXOverWrapper.java" bugCount="1" size="57" bugHash="b5ae805ae8f6256e29896bbdbb2b9ee0"/>
-    <FileStats path="org/ogolem/generic/NoCrossover.java" bugCount="0" size="17"/>
-    <FileStats path="org/ogolem/generic/NoMutation.java" bugCount="0" size="12"/>
-    <FileStats path="org/ogolem/generic/Optimizable.java" bugCount="0" size="16"/>
-    <FileStats path="org/ogolem/generic/SimpleGenericDarwin.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/generic/generichistory/GenericHistory.java" bugCount="1" size="159" bugHash="84bcd7d0f9aa3c99806b0948966d1aa9"/>
-    <FileStats path="org/ogolem/generic/generichistory/GenericHistoryConfig.java" bugCount="0" size="21"/>
-    <FileStats path="org/ogolem/generic/generichistory/GeneticRecord.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/generic/genericpool/AbstractNicher.java" bugCount="1" size="59" bugHash="f0d4a33882257bb70222033cdaf748e4"/>
-    <FileStats path="org/ogolem/generic/genericpool/DiversityChecker.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/generic/genericpool/GenericDiversityCheckers.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/generic/genericpool/GenericParentSelectors.java" bugCount="0" size="207"/>
-    <FileStats path="org/ogolem/generic/genericpool/GenericPool.java" bugCount="7" size="465" bugHash="ffdfd0638436308a531b49b8fe17a508"/>
-    <FileStats path="org/ogolem/generic/genericpool/GenericPoolConfig.java" bugCount="6" size="149" bugHash="68d9e650fec16a8682d048ab66132763"/>
-    <FileStats path="org/ogolem/generic/genericpool/GenericPoolEntry.java" bugCount="2" size="19" bugHash="fdf2cd7a04a44fd938abf7f86a45d7c5"/>
-    <FileStats path="org/ogolem/generic/genericpool/GenericStatistics.java" bugCount="0" size="97"/>
-    <FileStats path="org/ogolem/generic/genericpool/Niche.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/generic/genericpool/NicheComputer.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/generic/genericpool/Nicher.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/generic/genericpool/ParentSelector.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/generic/genericpool/SimpleNicher.java" bugCount="1" size="54" bugHash="be5e897cf3e412ea7fbc78a3052a4f6b"/>
-    <FileStats path="org/ogolem/generic/mpi/GenericMPIOptimization.java" bugCount="1" size="126" bugHash="47d96b15cb152ffa93d3437a8d95e28e"/>
-    <FileStats path="org/ogolem/generic/mpi/MPIInterface.java" bugCount="6" size="241" bugHash="e81f187009dea43b12badc24e37a2d17"/>
-    <FileStats path="org/ogolem/generic/stats/BasicDetailedBackend.java" bugCount="1" size="45" bugHash="48f6bf8cc61698154d74bec10ae51dfa"/>
-    <FileStats path="org/ogolem/generic/stats/DetailedStatistics.java" bugCount="0" size="13"/>
-    <FileStats path="org/ogolem/generic/stats/DummyDetailedStats.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/generic/stats/GenericDetailStatistics.java" bugCount="0" size="84"/>
-    <FileStats path="org/ogolem/generic/threading/GenericGlobOptTask.java" bugCount="0" size="82"/>
-    <FileStats path="org/ogolem/generic/threading/GenericInitTask.java" bugCount="0" size="60"/>
-    <FileStats path="org/ogolem/generic/threading/GenericOGOLEMOptimization.java" bugCount="5" size="196" bugHash="9830887e0538a9d94140f73911bb4543"/>
-    <FileStats path="org/ogolem/generic/threading/GenericSeedTask.java" bugCount="4" size="95" bugHash="23b4d58a48ec1942cf1fa5fec86cee12"/>
-    <FileStats path="org/ogolem/generic/threading/GenericThreadDispatcher.java" bugCount="2" size="84" bugHash="8a39c2590fa60f5f5f4d208b9ded5518"/>
-    <FileStats path="org/ogolem/generic/threading/ObjectCache.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/generic/threading/TaskFactory.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/heat/LocalHeatPulses.java" bugCount="0" size="279"/>
-    <FileStats path="org/ogolem/heat/MainLocalHeat.java" bugCount="0" size="42"/>
-    <FileStats path="org/ogolem/helpers/CopyableTuple.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/helpers/Fortune.java" bugCount="1" size="10" bugHash="7968b303821278d04652dbf660b86a4a"/>
-    <FileStats path="org/ogolem/helpers/IndexSort.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/helpers/Machine.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/helpers/StatisticUtils.java" bugCount="0" size="79"/>
-    <FileStats path="org/ogolem/helpers/Tuple.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/helpers/Tuple3D.java" bugCount="0" size="12"/>
-    <FileStats path="org/ogolem/helpers/Tuple4D.java" bugCount="0" size="12"/>
-    <FileStats path="org/ogolem/interfaces/GenericInterface.java" bugCount="0" size="77"/>
-    <FileStats path="org/ogolem/interfaces/OrcaCaller.java" bugCount="0" size="321"/>
-    <FileStats path="org/ogolem/interfaces/XTBCaller.java" bugCount="0" size="311"/>
-    <FileStats path="org/ogolem/io/FileFilter.java" bugCount="0" size="22"/>
-    <FileStats path="org/ogolem/io/FixedValues.java" bugCount="0" size="4"/>
-    <FileStats path="org/ogolem/io/InputPrimitives.java" bugCount="0" size="45"/>
-    <FileStats path="org/ogolem/io/InquiryPrimitives.java" bugCount="0" size="30"/>
-    <FileStats path="org/ogolem/io/ManipulationPrimitives.java" bugCount="2" size="71" bugHash="4143145ed83dc45b7b4f21eae7d78568"/>
-    <FileStats path="org/ogolem/io/OutputPrimitives.java" bugCount="0" size="88"/>
-    <FileStats path="org/ogolem/ljreferences/LittleHelpers.java" bugCount="0" size="8"/>
-    <FileStats path="org/ogolem/ljreferences/MainLJRefs.java" bugCount="0" size="69"/>
-    <FileStats path="org/ogolem/ljreferences/Molpro.java" bugCount="0" size="75"/>
-    <FileStats path="org/ogolem/ljreferences/Orca.java" bugCount="0" size="39"/>
-    <FileStats path="org/ogolem/ljreferences/TwoBodyTerm.java" bugCount="0" size="39"/>
-    <FileStats path="org/ogolem/locopt/AbstractLocOptFactory.java" bugCount="0" size="312"/>
-    <FileStats path="org/ogolem/locopt/BOBYQALocOpt.java" bugCount="0" size="68"/>
-    <FileStats path="org/ogolem/locopt/CGLocOpt.java" bugCount="0" size="63"/>
-    <FileStats path="org/ogolem/locopt/FIRELocOpt.java" bugCount="0" size="300"/>
-    <FileStats path="org/ogolem/locopt/FleminLocOpt.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/locopt/GenericChainedLocalOpt.java" bugCount="1" size="50" bugHash="2190027f79220169ccd6f9ab4beef854"/>
-    <FileStats path="org/ogolem/locopt/LBFGSLocOpt.java" bugCount="0" size="81"/>
-    <FileStats path="org/ogolem/locopt/NEWUOALocOpt.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/locopt/PraxisLocOpt.java" bugCount="0" size="59"/>
-    <FileStats path="org/ogolem/locopt/RNK1MinLocOpt.java" bugCount="0" size="54"/>
-    <FileStats path="org/ogolem/locopt/apachehelpers/MultivariateToEnergyProvider.java" bugCount="2" size="30" bugHash="8cf6ccafa67fce5d8f19856994480c24"/>
-    <FileStats path="org/ogolem/locopt/apachehelpers/MultivariateToGradientProvider.java" bugCount="2" size="22" bugHash="3e46436ff8e6aa5b30058df6eed03abd"/>
-    <FileStats path="org/ogolem/locopt/numalhelpers/NumalFitnessWrapper.java" bugCount="1" size="15" bugHash="72be53b63c4b4e38fc08f50a381e322c"/>
-    <FileStats path="org/ogolem/locopt/numalhelpers/NumalGradientWrapper.java" bugCount="1" size="18" bugHash="d3375d17d2a24ba2334f874c4f2c5e7c"/>
-    <FileStats path="org/ogolem/macrobenchmarks/AdaptiveBenchmarkRunner.java" bugCount="1" size="62" bugHash="943a797a2bca2fe0a2a911a1af0d13db"/>
-    <FileStats path="org/ogolem/macrobenchmarks/BenchmarkRunner.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/macrobenchmarks/ClusterBenchmarkRunner.java" bugCount="5" size="83" bugHash="7202e10000700411da5e5ec699e78e5a"/>
-    <FileStats path="org/ogolem/macrobenchmarks/Helpers.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/macrobenchmarks/MainMacroBenchmarks.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/math/AbstractLookup.java" bugCount="1" size="86" bugHash="4cfc27bcee2452f96cac49cab417d3d8"/>
-    <FileStats path="org/ogolem/math/AcosLookup.java" bugCount="0" size="42"/>
-    <FileStats path="org/ogolem/math/BLASInterface.java" bugCount="0" size="58"/>
-    <FileStats path="org/ogolem/math/CosLookup.java" bugCount="0" size="37"/>
-    <FileStats path="org/ogolem/math/ExpLookup.java" bugCount="0" size="19"/>
-    <FileStats path="org/ogolem/math/FastFunctions.java" bugCount="0" size="70"/>
-    <FileStats path="org/ogolem/math/GenericLookup.java" bugCount="1" size="26" bugHash="8512e5f1b55988782746200a3f6f9cff"/>
-    <FileStats path="org/ogolem/math/LAPACKInterface.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/math/LookupedFunction.java" bugCount="0" size="5"/>
-    <FileStats path="org/ogolem/math/MathUtils.java" bugCount="0" size="8"/>
-    <FileStats path="org/ogolem/math/Matrix.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/math/Matrix3x3.java" bugCount="0" size="22"/>
-    <FileStats path="org/ogolem/math/SinLookup.java" bugCount="0" size="37"/>
-    <FileStats path="org/ogolem/math/SymmetricMatrixNoDiag.java" bugCount="1" size="30" bugHash="49a1120c97a37cde2d9400f16abd8b2c"/>
-    <FileStats path="org/ogolem/math/TrivialLinearAlgebra.java" bugCount="0" size="197"/>
-    <FileStats path="org/ogolem/microbenchmarks/AckleyBench.java" bugCount="1" size="22" bugHash="ead17f79fea5c85a05993597e00419fa"/>
-    <FileStats path="org/ogolem/microbenchmarks/AckleyGradBench.java" bugCount="1" size="24" bugHash="44846ce50ba367db8be9b7a79c3747e6"/>
-    <FileStats path="org/ogolem/microbenchmarks/AdaptiveLJFFEnergyBench.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/microbenchmarks/AdaptiveLJFFGradientBench.java" bugCount="0" size="40"/>
-    <FileStats path="org/ogolem/microbenchmarks/AdvPairwiseCDBenchmark.java" bugCount="0" size="18"/>
-    <FileStats path="org/ogolem/microbenchmarks/AdvPairwiseCDCheckOnlyBenchmark.java" bugCount="0" size="16"/>
-    <FileStats path="org/ogolem/microbenchmarks/AligningBench.java" bugCount="0" size="13"/>
-    <FileStats path="org/ogolem/microbenchmarks/AngleBench.java" bugCount="0" size="11"/>
-    <FileStats path="org/ogolem/microbenchmarks/AngleBench2.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/microbenchmarks/CartesianCoordinatesLibrary.java" bugCount="8" size="104" bugHash="72ae1230fb8d24a79addaa3ca3c14110"/>
-    <FileStats path="org/ogolem/microbenchmarks/DihedralBench.java" bugCount="0" size="11"/>
-    <FileStats path="org/ogolem/microbenchmarks/LJFFEnergyBench.java" bugCount="0" size="21"/>
-    <FileStats path="org/ogolem/microbenchmarks/LJFFGradientBench.java" bugCount="0" size="23"/>
-    <FileStats path="org/ogolem/microbenchmarks/LunacekBench.java" bugCount="1" size="22" bugHash="f42d5ddae0aa74876a7daed6112c0afb"/>
-    <FileStats path="org/ogolem/microbenchmarks/LunacekGradBench.java" bugCount="1" size="24" bugHash="0d8fa043f6abb5ba7a94f6555d0d1b0f"/>
-    <FileStats path="org/ogolem/microbenchmarks/MainMicroBenchmarks.java" bugCount="0" size="175"/>
-    <FileStats path="org/ogolem/microbenchmarks/Mat3x3MultBenchmark.java" bugCount="1" size="27" bugHash="549c3c3edb14196b96401502ee42a1b5"/>
-    <FileStats path="org/ogolem/microbenchmarks/MatMultBenchmark.java" bugCount="1" size="34" bugHash="d9e35f93640ef7c8cd0427d6aef4487f"/>
-    <FileStats path="org/ogolem/microbenchmarks/MixedLJFFEnergyBench.java" bugCount="0" size="26"/>
-    <FileStats path="org/ogolem/microbenchmarks/MixedLJFFGradientBench.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/microbenchmarks/MixedLJLocOptBench.java" bugCount="0" size="56"/>
-    <FileStats path="org/ogolem/microbenchmarks/NorwayPackingLJBench.java" bugCount="0" size="44"/>
-    <FileStats path="org/ogolem/microbenchmarks/RastriginBench.java" bugCount="1" size="22" bugHash="43246fe94d88de2b287fac992db72965"/>
-    <FileStats path="org/ogolem/microbenchmarks/RastriginGradBench.java" bugCount="1" size="24" bugHash="d26298b31dc7944ed9aea563206bea30"/>
-    <FileStats path="org/ogolem/microbenchmarks/SchafferF7Bench.java" bugCount="1" size="22" bugHash="6e838732c26fe7289982f44b9bdfed17"/>
-    <FileStats path="org/ogolem/microbenchmarks/SchafferF7GradBench.java" bugCount="1" size="24" bugHash="b932145db59c0d57019ad731df00d16b"/>
-    <FileStats path="org/ogolem/microbenchmarks/SchwefelBench.java" bugCount="1" size="22" bugHash="779ac927581f86bc2f7935887cdf60dc"/>
-    <FileStats path="org/ogolem/microbenchmarks/SchwefelGradBench.java" bugCount="1" size="24" bugHash="21d8dc1c21f089a66263d0dc73be766a"/>
-    <FileStats path="org/ogolem/microbenchmarks/SingleMicroBenchmark.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/microbenchmarks/TIP3PEnergyBench.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/microbenchmarks/TIP3PGradientBench.java" bugCount="0" size="40"/>
-    <FileStats path="org/ogolem/microbenchmarks/TIP4PEnergyBench.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/microbenchmarks/TIP4PGradientBench.java" bugCount="0" size="40"/>
-    <FileStats path="org/ogolem/microbenchmarks/UFFFrozenSurfaceEnergyBenchmark.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/microbenchmarks/UFFFrozenSurfaceGradientBenchmark.java" bugCount="0" size="39"/>
-    <FileStats path="org/ogolem/microbenchmarks/UFFLargeMoleculeEnergyBenchmark.java" bugCount="0" size="31"/>
-    <FileStats path="org/ogolem/microbenchmarks/UFFLargeMoleculeGradientBenchmark.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/microbenchmarks/UFFSurfaceEnergyBenchmark.java" bugCount="0" size="38"/>
-    <FileStats path="org/ogolem/microbenchmarks/UFFSurfaceGradientBenchmark.java" bugCount="0" size="39"/>
-    <FileStats path="org/ogolem/microbenchmarks/WaterTTM3FLargeBenchmark.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/microbenchmarks/WaterTTM3FSmallBenchmark.java" bugCount="0" size="29"/>
-    <FileStats path="org/ogolem/molecules/FixedValues.java" bugCount="1" size="7" bugHash="ec601e685efc4f4ce4ed0568ca770bf8"/>
-    <FileStats path="org/ogolem/parameters/MainParameters.java" bugCount="0" size="102"/>
-    <FileStats path="org/ogolem/properties/BulkModulus.java" bugCount="0" size="28"/>
-    <FileStats path="org/ogolem/properties/CellVolume.java" bugCount="0" size="30"/>
-    <FileStats path="org/ogolem/properties/DegreeOfFreedom.java" bugCount="1" size="43" bugHash="fec6292573c41e8c244e6f1260c0df18"/>
-    <FileStats path="org/ogolem/properties/DeltaGauge.java" bugCount="0" size="24"/>
-    <FileStats path="org/ogolem/properties/Density.java" bugCount="0" size="79"/>
-    <FileStats path="org/ogolem/properties/Dipole.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/properties/DipoleMoment.java" bugCount="1" size="34" bugHash="59eb1c113424230705da3f928a61882b"/>
-    <FileStats path="org/ogolem/properties/Energy.java" bugCount="0" size="24"/>
-    <FileStats path="org/ogolem/properties/EnergyOrder.java" bugCount="1" size="113" bugHash="81598fc4916d91608650be053416e84d"/>
-    <FileStats path="org/ogolem/properties/ExcitationDifference.java" bugCount="0" size="24"/>
-    <FileStats path="org/ogolem/properties/ExcitationEnergy.java" bugCount="0" size="24"/>
-    <FileStats path="org/ogolem/properties/Forces.java" bugCount="0" size="49"/>
-    <FileStats path="org/ogolem/properties/GenericMatrixProperty.java" bugCount="0" size="43"/>
-    <FileStats path="org/ogolem/properties/GenericScalarProperty.java" bugCount="0" size="31"/>
-    <FileStats path="org/ogolem/properties/GenericTensorProperty.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/properties/GenericVectorProperty.java" bugCount="0" size="40"/>
-    <FileStats path="org/ogolem/properties/MatrixProperty.java" bugCount="0" size="69"/>
-    <FileStats path="org/ogolem/properties/Property.java" bugCount="0" size="10"/>
-    <FileStats path="org/ogolem/properties/ScalarProperty.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/properties/Spectrum.java" bugCount="0" size="24"/>
-    <FileStats path="org/ogolem/properties/Stability.java" bugCount="0" size="31"/>
-    <FileStats path="org/ogolem/properties/StressTensor.java" bugCount="0" size="43"/>
-    <FileStats path="org/ogolem/properties/TensorProperty.java" bugCount="0" size="80"/>
-    <FileStats path="org/ogolem/properties/VectorProperty.java" bugCount="0" size="57"/>
-    <FileStats path="org/ogolem/random/Lottery.java" bugCount="1" size="43" bugHash="032c7eb9748ba256b70f4fb5ba2306de"/>
-    <FileStats path="org/ogolem/random/RNGenerator.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/random/RandomUtils.java" bugCount="0" size="158"/>
-    <FileStats path="org/ogolem/random/StandardRNG.java" bugCount="0" size="25"/>
-    <FileStats path="org/ogolem/rmi/AliveCheck.java" bugCount="2" size="36" bugHash="1ebb2b68d0f9ea6cfa99d0ab5af8e6b3"/>
-    <FileStats path="org/ogolem/rmi/ClientList.java" bugCount="0" size="99"/>
-    <FileStats path="org/ogolem/rmi/DummyTask.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/rmi/EmptyJob.java" bugCount="0" size="18"/>
-    <FileStats path="org/ogolem/rmi/GenericGlobOptJob.java" bugCount="5" size="374" bugHash="884a3aeeba47381c1310bc416ed55be6"/>
-    <FileStats path="org/ogolem/rmi/GenericGlobOptTask.java" bugCount="0" size="26"/>
-    <FileStats path="org/ogolem/rmi/GenericInitTask.java" bugCount="1" size="23" bugHash="3bb4930d30a38b0989aa08dec9870305"/>
-    <FileStats path="org/ogolem/rmi/GenericProxyJob.java" bugCount="6" size="390" bugHash="2abf9ec0c14a61934a0e17e9388614fd"/>
-    <FileStats path="org/ogolem/rmi/GenericSeedTask.java" bugCount="2" size="30" bugHash="1ddfeb56a25805cb80b6258a457eaad6"/>
-    <FileStats path="org/ogolem/rmi/GenericThreadingClientBackend.java" bugCount="2" size="337" bugHash="d67d87c666f5f9dd74e15216890a7d46"/>
-    <FileStats path="org/ogolem/rmi/Job.java" bugCount="0" size="8"/>
-    <FileStats path="org/ogolem/rmi/JobFactory.java" bugCount="0" size="129"/>
-    <FileStats path="org/ogolem/rmi/MainOgolemRMI.java" bugCount="0" size="91"/>
-    <FileStats path="org/ogolem/rmi/MainRMIClient.java" bugCount="2" size="142" bugHash="a184606b1c3d904776b3b0b0a0b14c2e"/>
-    <FileStats path="org/ogolem/rmi/MainRMIProxy.java" bugCount="2" size="153" bugHash="141fcffe9f3562132063772784bfeee0"/>
-    <FileStats path="org/ogolem/rmi/MainRMIThreader.java" bugCount="2" size="137" bugHash="2c23a4806088a39c9a396e935e7e27f1"/>
-    <FileStats path="org/ogolem/rmi/RMICodes.java" bugCount="0" size="15"/>
-    <FileStats path="org/ogolem/rmi/RMICommImpl.java" bugCount="0" size="90"/>
-    <FileStats path="org/ogolem/rmi/RMICommunication.java" bugCount="0" size="11"/>
-    <FileStats path="org/ogolem/rmi/Result.java" bugCount="0" size="33"/>
-    <FileStats path="org/ogolem/rmi/SwitchGlobOptJob.java" bugCount="2" size="170" bugHash="b24b45967470f11302076ba51fd28e4f"/>
-    <FileStats path="org/ogolem/rmi/SwitchGlobOptTask.java" bugCount="1" size="25" bugHash="887e92aa6a05d2fac5f91d4945c1937a"/>
-    <FileStats path="org/ogolem/rmi/SwitchInitTask.java" bugCount="0" size="27"/>
-    <FileStats path="org/ogolem/rmi/Task.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/rmi/TaskQueue.java" bugCount="0" size="21"/>
-    <FileStats path="org/ogolem/rmi/ThreadingClientFactory.java" bugCount="0" size="31"/>
-    <FileStats path="org/ogolem/scanalyzer/Analyzer.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/scanalyzer/MainScAnalyzer.java" bugCount="0" size="52"/>
-    <FileStats path="org/ogolem/scanner/MainScanner.java" bugCount="0" size="53"/>
-    <FileStats path="org/ogolem/scanner/ScannerConfig.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/scanner/ScannerCore.java" bugCount="0" size="75"/>
-    <FileStats path="org/ogolem/scanner/ScannerDoF.java" bugCount="0" size="51"/>
-    <FileStats path="org/ogolem/spectral/FullSpectrum.java" bugCount="3" size="192" bugHash="c601d40b1011e75a3686d06d040f1ca8"/>
-    <FileStats path="org/ogolem/spectral/Peak.java" bugCount="1" size="36" bugHash="dd496e9a7e0ddacbd516ba2628134cfc"/>
-    <FileStats path="org/ogolem/spectral/Spectrum.java" bugCount="0" size="9"/>
-    <FileStats path="org/ogolem/spectral/SpectrumConfig.java" bugCount="1" size="6" bugHash="f3e56561bf1cc8474567d4593788124b"/>
-    <FileStats path="org/ogolem/switches/Backbone.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/switches/Color.java" bugCount="0" size="37"/>
-    <FileStats path="org/ogolem/switches/ColorPalette.java" bugCount="1" size="37" bugHash="739417c87f9651c85c5d9aff78256eb8"/>
-    <FileStats path="org/ogolem/switches/Excitor.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/switches/ExcitorGateway.java" bugCount="0" size="56"/>
-    <FileStats path="org/ogolem/switches/FitnessFunction.java" bugCount="0" size="128"/>
-    <FileStats path="org/ogolem/switches/FixedValues.java" bugCount="0" size="6"/>
-    <FileStats path="org/ogolem/switches/GermanyGlobOpt.java" bugCount="0" size="62"/>
-    <FileStats path="org/ogolem/switches/GlobOptAtomics.java" bugCount="1" size="38" bugHash="0eb750f6e878f3aa6f15089736017253"/>
-    <FileStats path="org/ogolem/switches/GlobalOptimization.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/switches/GugaCI.java" bugCount="0" size="104"/>
-    <FileStats path="org/ogolem/switches/LittleHelpers.java" bugCount="0" size="14"/>
-    <FileStats path="org/ogolem/switches/LocalOpt.java" bugCount="0" size="34"/>
-    <FileStats path="org/ogolem/switches/LocalOptimization.java" bugCount="0" size="2"/>
-    <FileStats path="org/ogolem/switches/MagicGlue.java" bugCount="0" size="306"/>
-    <FileStats path="org/ogolem/switches/MainSwitches.java" bugCount="0" size="81"/>
-    <FileStats path="org/ogolem/switches/MopacExcitor.java" bugCount="0" size="70"/>
-    <FileStats path="org/ogolem/switches/MopacLocOpt.java" bugCount="0" size="76"/>
-    <FileStats path="org/ogolem/switches/OpenBabelLocOpt.java" bugCount="0" size="132"/>
-    <FileStats path="org/ogolem/switches/OrcaExcitor.java" bugCount="1" size="82" bugHash="8e18d2be89356f726a907b76a81367be"/>
-    <FileStats path="org/ogolem/switches/Output.java" bugCount="0" size="270"/>
-    <FileStats path="org/ogolem/switches/Sidechain.java" bugCount="0" size="32"/>
-    <FileStats path="org/ogolem/switches/SidechainInter.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/switches/Switch.java" bugCount="2" size="162" bugHash="0c53eadc6b92c5ecf4423df108877a08"/>
-    <FileStats path="org/ogolem/switches/SwitchWriter.java" bugCount="2" size="29" bugHash="23f4fd3f95a2d898c5ebea7f0c08985c"/>
-    <FileStats path="org/ogolem/switches/SwitchesConfig.java" bugCount="3" size="200" bugHash="8ffd6fbb2f37d260b2fbeb58265e7c49"/>
-    <FileStats path="org/ogolem/switches/SwitchesDarwin.java" bugCount="0" size="3"/>
-    <FileStats path="org/ogolem/switches/SwitchesGlobOpt.java" bugCount="0" size="12"/>
-    <FileStats path="org/ogolem/switches/SwitchesInput.java" bugCount="1" size="552" bugHash="f4316f59cd0fc03e3133071ad5032ffc"/>
-    <FileStats path="org/ogolem/switches/Taboos.java" bugCount="1" size="19" bugHash="7c432d69c7bd5cc76f10c7e2955ebd05"/>
-    <FileStats path="org/ogolem/switches/ThreadingGlobOpt.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/switches/ThreadingInits.java" bugCount="0" size="35"/>
-    <FileStats path="org/ogolem/switches/TinkerLocOpt.java" bugCount="1" size="115" bugHash="37e9bbc4b679850db7514524bd91af1e"/>
-    <FileStats path="org/ogolem/switches/Tupel.java" bugCount="0" size="16"/>
-    <FileStats path="org/ogolem/switches/backbones/BrABBackbone.java" bugCount="0" size="41"/>
-    <FileStats path="org/ogolem/switches/sidechains/AldehydeSide.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/switches/sidechains/AminoSide.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/switches/sidechains/CarboxylSide.java" bugCount="0" size="55"/>
-    <FileStats path="org/ogolem/switches/sidechains/ChlorideSide.java" bugCount="0" size="26"/>
-    <FileStats path="org/ogolem/switches/sidechains/HydrogenSide.java" bugCount="0" size="26"/>
-    <FileStats path="org/ogolem/switches/sidechains/HydroxylSide.java" bugCount="0" size="33"/>
-    <FileStats path="org/ogolem/switches/sidechains/MethylSide.java" bugCount="0" size="55"/>
-    <FileStats path="org/ogolem/switches/sidechains/NitroSide.java" bugCount="0" size="46"/>
-    <FileStats path="org/ogolem/switches/sidechains/ThiolSide.java" bugCount="0" size="33"/>
-    <FileStats path="org/ogolem/tests/MainTests.java" bugCount="0" size="107"/>
-    <PackageStats package="contrib.bobyqa" total_bugs="5" total_types="6" total_size="1804" priority_2="4" priority_1="1">
-      <ClassStats class="contrib.bobyqa.AbstractBOBYQAMethod" sourceFile="AbstractBOBYQAMethod.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="contrib.bobyqa.BOBYQAMethod" sourceFile="BOBYQAMethod.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="contrib.bobyqa.BOBYQAOptimizer" sourceFile="BOBYQAOptimizer.java" interface="false" size="1729" bugs="5" priority_2="4" priority_1="1"/>
-      <ClassStats class="contrib.bobyqa.BOBYQAOptimizer$DoubleRef" sourceFile="BOBYQAOptimizer.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="contrib.bobyqa.BOBYQAOptimizer$IntRef" sourceFile="BOBYQAOptimizer.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="contrib.bobyqa.BOBYQAOptimizer$ScopedPtr" sourceFile="BOBYQAOptimizer.java" interface="false" size="25" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="contrib.edu.princeton.eac" total_bugs="5" total_types="1" total_size="137" priority_2="5">
-      <ClassStats class="contrib.edu.princeton.eac.Grid" sourceFile="Grid.java" interface="false" size="137" bugs="5" priority_2="5"/>
-    </PackageStats>
-    <PackageStats package="contrib.jama" total_bugs="15" total_types="6" total_size="1458" priority_2="9" priority_1="6">
-      <ClassStats class="contrib.jama.CholeskyDecomposition" sourceFile="CholeskyDecomposition.java" interface="false" size="50" bugs="1" priority_2="1"/>
-      <ClassStats class="contrib.jama.EigenvalueDecomposition" sourceFile="EigenvalueDecomposition.java" interface="false" size="538" bugs="3" priority_2="2" priority_1="1"/>
-      <ClassStats class="contrib.jama.LUDecomposition" sourceFile="LUDecomposition.java" interface="false" size="100" bugs="1" priority_1="1"/>
-      <ClassStats class="contrib.jama.Matrix" sourceFile="Matrix.java" interface="false" size="404" bugs="7" priority_2="4" priority_1="3"/>
-      <ClassStats class="contrib.jama.QRDecomposition" sourceFile="QRDecomposition.java" interface="false" size="94" bugs="0"/>
-      <ClassStats class="contrib.jama.SingularValueDecomposition" sourceFile="SingularValueDecomposition.java" interface="false" size="272" bugs="3" priority_2="2" priority_1="1"/>
-    </PackageStats>
-    <PackageStats package="contrib.jama.test" total_bugs="8" total_types="1" total_size="658" priority_2="4" priority_1="4">
-      <ClassStats class="contrib.jama.test.TestMatrix" sourceFile="TestMatrix.java" interface="false" size="658" bugs="8" priority_2="4" priority_1="4"/>
-    </PackageStats>
-    <PackageStats package="contrib.jama.util" total_bugs="0" total_types="1" total_size="12">
-      <ClassStats class="contrib.jama.util.Maths" sourceFile="Maths.java" interface="false" size="12" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="contrib.lbfgs" total_bugs="2" total_types="3" total_size="484" priority_2="2">
-      <ClassStats class="contrib.lbfgs.LBFGS" sourceFile="LBFGS.java" interface="false" size="242" bugs="2" priority_2="2"/>
-      <ClassStats class="contrib.lbfgs.LBFGS$ExceptionWithIflag" sourceFile="LBFGS.java" interface="false" size="9" bugs="0"/>
-      <ClassStats class="contrib.lbfgs.LBFGS$Mcsrch" sourceFile="LBFGS.java" interface="false" size="233" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="contrib.newuoa" total_bugs="1" total_types="5" total_size="1193" priority_2="1">
-      <ClassStats class="contrib.newuoa.ChebyQuad" sourceFile="TestNewUO.java" interface="false" size="26" bugs="0"/>
-      <ClassStats class="contrib.newuoa.NEWUOAMethod" sourceFile="NEWUOAMethod.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="contrib.newuoa.NEWUOAOptimizer" sourceFile="NEWUOAOptimizer.java" interface="false" size="1127" bugs="1" priority_2="1"/>
-      <ClassStats class="contrib.newuoa.NEWUOAOptimizer$ScopedPtr" sourceFile="NEWUOAOptimizer.java" interface="false" size="21" bugs="0"/>
-      <ClassStats class="contrib.newuoa.TestNewUO" sourceFile="TestNewUO.java" interface="false" size="17" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="numal" total_bugs="0" total_types="3" total_size="13">
-      <ClassStats class="numal.AP_linemin_method" sourceFile="AP_linemin_method.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="numal.AP_praxis_method" sourceFile="AP_praxis_method.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="numal.Analytic_problems" sourceFile="Analytic_problems.java" interface="false" size="9" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.adaptive" total_bugs="39" total_types="88" total_size="12995" priority_2="36" priority_1="3">
-      <ClassStats class="org.ogolem.adaptive.AbstractAdaptivable" sourceFile="AbstractAdaptivable.java" interface="false" size="81" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AbstractAdaptiveBackend" sourceFile="AbstractAdaptiveBackend.java" interface="false" size="66" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.Adaptivable" sourceFile="Adaptivable.java" interface="true" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveAmberAngleTerm" sourceFile="AdaptiveAmberAngleTerm.java" interface="false" size="256" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveAmberDihedralTerm" sourceFile="AdaptiveAmberDihedralTerm.java" interface="false" size="295" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveAmberFF" sourceFile="AdaptiveAmberFF.java" interface="false" size="188" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveAmberFF$AmberMath" sourceFile="AdaptiveAmberFF.java" interface="false" size="166" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveAmberLJTerm" sourceFile="AdaptiveAmberLJTerm.java" interface="false" size="371" bugs="3" priority_2="2" priority_1="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveBackend" sourceFile="AdaptiveBackend.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveBondedHarmonicTerm" sourceFile="AdaptiveBondedHarmonicTerm.java" interface="false" size="273" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveCachedBondTerm" sourceFile="AdaptiveCachedBondTerm.java" interface="false" size="104" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveConf" sourceFile="AdaptiveConf.java" interface="false" size="1946" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveConf$StructureDataType" sourceFile="AdaptiveConf.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveCustomSpillage" sourceFile="AdaptiveCustomSpillage.java" interface="false" size="191" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveCustomSpillage$WfnFilter" sourceFile="AdaptiveCustomSpillage.java" interface="false" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveCustomSpillage2" sourceFile="AdaptiveCustomSpillage2.java" interface="false" size="127" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveExternalCaller" sourceFile="AdaptiveExternalCaller.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveGUPTA" sourceFile="AdaptiveGUPTA.java" interface="false" size="348" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveGateway" sourceFile="AdaptiveGateway.java" interface="false" size="25" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveInteractionTerm" sourceFile="AdaptiveInteractionTerm.java" interface="true" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveLJFF" sourceFile="AdaptiveLJFF.java" interface="false" size="715" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveMopacCaller" sourceFile="AdaptiveMopacCaller.java" interface="false" size="387" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveMorse" sourceFile="AdaptiveMorse.java" interface="false" size="264" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveMorseTerm" sourceFile="AdaptiveMorseTerm.java" interface="false" size="290" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveNewton" sourceFile="AdaptiveNewton.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveOrcaCaller" sourceFile="AdaptiveOrcaCaller.java" interface="false" size="348" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveParameters" sourceFile="AdaptiveParameters.java" interface="false" size="310" bugs="5" priority_2="5"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptivePolaris" sourceFile="AdaptivePolaris.java" interface="false" size="213" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveSWG2BodyTerm" sourceFile="AdaptiveSWG2BodyTerm.java" interface="false" size="206" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveSWG3BodyTerm" sourceFile="AdaptiveSWG3BodyTerm.java" interface="false" size="378" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveSWGFF" sourceFile="AdaptiveSWGFF.java" interface="false" size="167" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveSkalevalaCaller" sourceFile="AdaptiveSkalevalaCaller.java" interface="false" size="208" bugs="4" priority_2="4"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveTotalEnergyShifter" sourceFile="AdaptiveTotalEnergyShifter.java" interface="false" size="90" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.AdaptiveUFF" sourceFile="AdaptiveUFF.java" interface="false" size="262" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.Analytics" sourceFile="Analytics.java" interface="false" size="41" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ArcticAdaptiveCrossover" sourceFile="ArcticAdaptiveCrossover.java" interface="false" size="58" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchAckley" sourceFile="BenchAckley.java" interface="false" size="141" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchBerndGauss10D" sourceFile="BenchBerndGauss10D.java" interface="false" size="88" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.BenchGriewangkRosenbrock" sourceFile="BenchGriewangkRosenbrock.java" interface="false" size="68" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchLunacek" sourceFile="BenchLunacek.java" interface="false" size="160" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchRastrigin" sourceFile="BenchRastrigin.java" interface="false" size="108" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchSchaffer" sourceFile="BenchSchaffer.java" interface="false" size="156" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchSchafferF6" sourceFile="BenchSchafferF6.java" interface="false" size="51" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.BenchSchwefels" sourceFile="BenchSchwefels.java" interface="false" size="112" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.DoubleMorse" sourceFile="DoubleMorse.java" interface="false" size="274" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.DummyFitness" sourceFile="DummyFitness.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ExternalLocOpt" sourceFile="ExternalLocOpt.java" interface="false" size="80" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential" sourceFile="FMProfessPseudoPotential.java" interface="false" size="519" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$BulkModulusProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="74" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$CellVolumeProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="74" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$DeltaGaugeProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="75" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$DensityProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="102" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$EnergyOrderProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="118" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$ForcesProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="97" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FMProfessPseudoPotential$StressTensorProfessCalculator" sourceFile="FMProfessPseudoPotential.java" interface="false" size="97" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.FitFuncToBackend" sourceFile="FitFuncToBackend.java" interface="false" size="73" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.FixedValues" sourceFile="FixedValues.java" interface="false" size="5" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.adaptive.GenericCaller" sourceFile="GenericCaller.java" interface="false" size="98" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.GenericCaller$MatrixCalculator" sourceFile="GenericCaller.java" interface="false" size="71" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.GenericCaller$ScalarCalculator" sourceFile="GenericCaller.java" interface="false" size="66" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.GenericCaller$TensorCalculator" sourceFile="GenericCaller.java" interface="false" size="76" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.GenericCaller$VectorCalculator" sourceFile="GenericCaller.java" interface="false" size="68" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.GenericNativeCaller" sourceFile="GenericNativeCaller.java" interface="false" size="71" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.GenericNativeCaller$ScalarCalculator" sourceFile="GenericNativeCaller.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.GenericParameterDarwin" sourceFile="GenericParameterDarwin.java" interface="false" size="27" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.Input" sourceFile="Input.java" interface="false" size="53" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.MainOgoAdaptive" sourceFile="MainOgoAdaptive.java" interface="false" size="220" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.NumericalGradients" sourceFile="NumericalGradients.java" interface="false" size="101" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.adaptive.Output" sourceFile="Output.java" interface="false" size="370" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParamGlobOptFactory" sourceFile="ParamGlobOptFactory.java" interface="false" size="108" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.adaptive.ParamLocOptFactory" sourceFile="ParamLocOptFactory.java" interface="false" size="31" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterDiversityCheckers" sourceFile="ParameterDiversityCheckers.java" interface="false" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterDiversityCheckers$ParamsDiversityChecker" sourceFile="ParameterDiversityCheckers.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterGradient" sourceFile="ParameterGradient.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterInit" sourceFile="ParameterInit.java" interface="false" size="47" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterReader" sourceFile="ParameterReader.java" interface="false" size="36" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterSanityCheck" sourceFile="ParameterSanityCheck.java" interface="false" size="33" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.adaptive.ParameterWriter" sourceFile="ParameterWriter.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.RangedFitFuncToBackend" sourceFile="RangedFitFuncToBackend.java" interface="false" size="117" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.RangedFitFuncToBackend$Range" sourceFile="RangedFitFuncToBackend.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.ReferencePointLibrary" sourceFile="ReferencePointLibrary.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.SearchspaceCapturer" sourceFile="SearchspaceCapturer.java" interface="false" size="106" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.SearchspaceCapturer$SearchspacePoint" sourceFile="SearchspaceCapturer.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.StaticGridNiches" sourceFile="StaticGridNiches.java" interface="false" size="58" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.UnaryGaussianMutation" sourceFile="UnaryGaussianMutation.java" interface="false" size="65" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.UnaryGaussianMutation$1" sourceFile="UnaryGaussianMutation.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.UnaryGaussianMutation$Mode" sourceFile="UnaryGaussianMutation.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.UnaryGaussianMutation$SubMode" sourceFile="UnaryGaussianMutation.java" interface="false" size="12" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.adaptive.genericfitness" total_bugs="7" total_types="26" total_size="1121" priority_2="7">
-      <ClassStats class="org.ogolem.adaptive.genericfitness.BatchedPropertyCalculator" sourceFile="BatchedPropertyCalculator.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.EnergyCalculator" sourceFile="EnergyCalculator.java" interface="false" size="25" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.FitnessTermConfig" sourceFile="FitnessTermConfig.java" interface="false" size="141" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.GenericFitnessFunction" sourceFile="GenericFitnessFunction.java" interface="false" size="122" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.GenericFitnessTerm" sourceFile="GenericFitnessTerm.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.GenericReferencePoint" sourceFile="GenericReferencePoint.java" interface="true" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.PropertyCalculator" sourceFile="PropertyCalculator.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.PseudoPropertyCalculator" sourceFile="PseudoPropertyCalculator.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.RefBulkModulusData" sourceFile="RefBulkModulusData.java" interface="false" size="37" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.RefCellVolumeData" sourceFile="RefCellVolumeData.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceDeltaGaugeData" sourceFile="ReferenceDeltaGaugeData.java" interface="false" size="41" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceDensityData" sourceFile="ReferenceDensityData.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceDummyData" sourceFile="ReferenceDummyData.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceEnergyOrderData" sourceFile="ReferenceEnergyOrderData.java" interface="false" size="34" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceForcesData" sourceFile="ReferenceForcesData.java" interface="false" size="23" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceGenericMatrixData" sourceFile="ReferenceGenericMatrixData.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceGenericScalarData" sourceFile="ReferenceGenericScalarData.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceGenericTensorData" sourceFile="ReferenceGenericTensorData.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceGenericVectorData" sourceFile="ReferenceGenericVectorData.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceGeomData" sourceFile="ReferenceGeomData.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceInputData" sourceFile="ReferenceInputData.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferencePoint" sourceFile="ReferencePoint.java" interface="false" size="44" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.ReferenceStressTensorData" sourceFile="ReferenceStressTensorData.java" interface="false" size="23" bugs="0"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.SerialBatchedPropertyCalculator" sourceFile="SerialBatchedPropertyCalculator.java" interface="false" size="60" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.SerialBatchedPropertyCalculator$PropertyBatch" sourceFile="SerialBatchedPropertyCalculator.java" interface="false" size="30" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.adaptive.genericfitness.SerialGenericFitnessTerm" sourceFile="SerialGenericFitnessTerm.java" interface="false" size="259" bugs="1" priority_2="1"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.atom2ogo" total_bugs="0" total_types="2" total_size="94">
-      <ClassStats class="org.ogolem.atom2ogo.MainAtom2Ogo" sourceFile="MainAtom2Ogo.java" interface="false" size="48" bugs="0"/>
-      <ClassStats class="org.ogolem.atom2ogo.MainOgo2Atom" sourceFile="MainOgo2Atom.java" interface="false" size="46" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.beswitched" total_bugs="0" total_types="1" total_size="67">
-      <ClassStats class="org.ogolem.beswitched.MainBeswitched" sourceFile="MainBeswitched.java" interface="false" size="67" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.clusters" total_bugs="4" total_types="4" total_size="635" priority_2="3" priority_1="1">
-      <ClassStats class="org.ogolem.clusters.ClusterAnalyzation" sourceFile="ClusterAnalyzation.java" interface="false" size="153" bugs="2" priority_2="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.clusters.ClusterAnalyzation$Shape" sourceFile="ClusterAnalyzation.java" interface="false" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.clusters.MainClusters" sourceFile="MainClusters.java" interface="false" size="388" bugs="0"/>
-      <ClassStats class="org.ogolem.clusters.MainThreadingClusterGlobOpt" sourceFile="MainThreadingClusterGlobOpt.java" interface="false" size="81" bugs="2" priority_2="2"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.core" total_bugs="160" total_types="250" total_size="27389" priority_2="154" priority_1="6">
-      <ClassStats class="org.ogolem.core.ADFCaller" sourceFile="ADFCaller.java" interface="false" size="127" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.AbstractBondInfo" sourceFile="AbstractBondInfo.java" interface="false" size="23" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AbstractCollisionInfo" sourceFile="AbstractCollisionInfo.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AbstractGradient" sourceFile="AbstractGradient.java" interface="false" size="35" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.core.AbstractLocOpt" sourceFile="AbstractLocOpt.java" interface="false" size="142" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AdditivePenaltyFunction" sourceFile="AdditivePenaltyFunction.java" interface="true" size="7" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AdvancedGraphBasedDirMut" sourceFile="AdvancedGraphBasedDirMut.java" interface="false" size="293" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.AdvancedGraphBasedDirMut$GDMConfiguration" sourceFile="AdvancedGraphBasedDirMut.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AdvancedGraphBasedDirMut$MolConnComparator" sourceFile="AdvancedGraphBasedDirMut.java" interface="false" size="15" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AdvancedPairWise" sourceFile="AdvancedPairWise.java" interface="false" size="182" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AlandGeometryXOver" sourceFile="AlandGeometryXOver.java" interface="false" size="156" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.AllowedSpace" sourceFile="AllowedSpace.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AmberCaller" sourceFile="AmberCaller.java" interface="false" size="195" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Atom" sourceFile="Atom.java" interface="false" size="80" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AtomConfig" sourceFile="AtomConfig.java" interface="false" size="37" bugs="0"/>
-      <ClassStats class="org.ogolem.core.AtomicProperties" sourceFile="AtomicProperties.java" interface="false" size="826" bugs="0"/>
-      <ClassStats class="org.ogolem.core.BackendFactory" sourceFile="BackendFactory.java" interface="false" size="376" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.BondInfo" sourceFile="BondInfo.java" interface="true" size="21" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CP2KCaller" sourceFile="CP2KCaller.java" interface="false" size="203" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CP2KCaller$FUNCTIONAL" sourceFile="CP2KCaller.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CPMDCaller" sourceFile="CPMDCaller.java" interface="false" size="287" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CPMDCaller$FUNCTIONAL" sourceFile="CPMDCaller.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CartesianCoordinates" sourceFile="CartesianCoordinates.java" interface="false" size="640" bugs="15" priority_2="15"/>
-      <ClassStats class="org.ogolem.core.CartesianCoordinates$ENVTYPE" sourceFile="CartesianCoordinates.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CartesianFullBackend" sourceFile="CartesianFullBackend.java" interface="true" size="7" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CartesianToRigidCoordinates" sourceFile="CartesianToRigidCoordinates.java" interface="false" size="278" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.CastException" sourceFile="CastException.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ChainedCartesianFullBackend" sourceFile="ChainedCartesianFullBackend.java" interface="false" size="73" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ChainedNicheComp" sourceFile="ChainedNicheComp.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionDetection" sourceFile="CollisionDetection.java" interface="false" size="134" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionDetection$1" sourceFile="CollisionDetection.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionDetection$CDTYPE" sourceFile="CollisionDetection.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionDetectionEngine" sourceFile="CollisionDetectionEngine.java" interface="true" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionInfo" sourceFile="CollisionInfo.java" interface="true" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionInfo$Collision" sourceFile="CollisionInfo.java" interface="false" size="17" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CollisionStrengthComputer" sourceFile="CollisionStrengthComputer.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CompressionMutation" sourceFile="CompressionMutation.java" interface="false" size="67" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Constants" sourceFile="Constants.java" interface="false" size="27" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ConvergenceException" sourceFile="ConvergenceException.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CoordRepresentationsNotCompatibleException" sourceFile="CoordRepresentationsNotCompatibleException.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CoordTranslation" sourceFile="CoordTranslation.java" interface="false" size="1146" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CoordinateRepresentation" sourceFile="CoordinateRepresentation.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.core.CoulombMatrixNicheComp" sourceFile="CoulombMatrixNicheComp.java" interface="false" size="53" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DFTBplusCaller" sourceFile="DFTBplusCaller.java" interface="false" size="251" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DFTBplusCaller$WHICHDRIVER" sourceFile="DFTBplusCaller.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Darwin" sourceFile="Darwin.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies" sourceFile="DirMutOptStrategies.java" interface="false" size="29" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$EnergyOnlyEvaluator" sourceFile="DirMutOptStrategies.java" interface="false" size="61" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$EulerOnlyOptimization" sourceFile="DirMutOptStrategies.java" interface="false" size="49" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$FullOptimization" sourceFile="DirMutOptStrategies.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$GDMAdaptor" sourceFile="DirMutOptStrategies.java" interface="false" size="53" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$PointOptStrategy" sourceFile="DirMutOptStrategies.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$RigidBodyOptimization" sourceFile="DirMutOptStrategies.java" interface="false" size="63" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.DirMutOptStrategies$RigidBodyOptimization$GDMBOBYQAConfig" sourceFile="DirMutOptStrategies.java" interface="false" size="12" bugs="4" priority_2="4"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders" sourceFile="DirMutPointProviders.java" interface="false" size="85" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$AverageCOMDistProvider" sourceFile="DirMutPointProviders.java" interface="false" size="162" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$COMOnlyCoordGrid" sourceFile="DirMutPointProviders.java" interface="false" size="53" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$EulerChanger" sourceFile="DirMutPointProviders.java" interface="false" size="45" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$FullExternalCoordGrid" sourceFile="DirMutPointProviders.java" interface="false" size="68" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$LotteryPointProvider" sourceFile="DirMutPointProviders.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$PointProvider" sourceFile="DirMutPointProviders.java" interface="true" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirMutPointProviders$WaterSpecificProvider" sourceFile="DirMutPointProviders.java" interface="false" size="249" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.core.DirectedMutation" sourceFile="DirectedMutation.java" interface="false" size="178" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DirectedMutation$CoordRanges" sourceFile="DirectedMutation.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DissociationDetection" sourceFile="DissociationDetection.java" interface="false" size="66" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DissociationDetection$DDTYPE" sourceFile="DissociationDetection.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DistanceCalc" sourceFile="DistanceCalc.java" interface="false" size="71" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DummyCollisionStrengthComputer" sourceFile="DummyCollisionStrengthComputer.java" interface="false" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.core.DummyLocOpt" sourceFile="DummyLocOpt.java" interface="false" size="21" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ElectrostaticTerm" sourceFile="ElectrostaticTerm.java" interface="false" size="107" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Environment" sourceFile="Environment.java" interface="true" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Environment$ENVIRONMENTTYPE" sourceFile="Environment.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.EnvironmentCartesCoordinates" sourceFile="EnvironmentCartesCoordinates.java" interface="false" size="141" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.EnvironmentFactory" sourceFile="EnvironmentFactory.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.core.EnvironmentFactory$1" sourceFile="EnvironmentFactory.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.EnvironmentFactory$KIND" sourceFile="EnvironmentFactory.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ExternalLocOpt" sourceFile="ExternalLocOpt.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FFEngineWrapper" sourceFile="FFEngineWrapper.java" interface="false" size="134" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FinlandGeometryMutation" sourceFile="FinlandGeometryMutation.java" interface="false" size="170" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FirstInCenterPenalty" sourceFile="FirstInCenterPenalty.java" interface="false" size="54" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FitnessFunctionFactory" sourceFile="FitnessFunctionFactory.java" interface="false" size="56" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FixedValues" sourceFile="FixedValues.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FoehrGeometryMutation" sourceFile="FoehrGeometryMutation.java" interface="false" size="51" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FoehrGeometryMutation$1" sourceFile="FoehrGeometryMutation.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FoehrGeometryMutation$HOWMANY" sourceFile="FoehrGeometryMutation.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FoehrGeometryMutation$MODUS" sourceFile="FoehrGeometryMutation.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FoehrGeometryXOver" sourceFile="FoehrGeometryXOver.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.core.FullyCartesianCoordinates" sourceFile="FullyCartesianCoordinates.java" interface="false" size="109" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.GenericGeometryDarwin" sourceFile="GenericGeometryDarwin.java" interface="false" size="66" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Geometry" sourceFile="Geometry.java" interface="false" size="634" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.GeometryConfig" sourceFile="GeometryConfig.java" interface="false" size="55" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometryInit" sourceFile="GeometryInit.java" interface="false" size="50" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometryInit$1" sourceFile="GeometryInit.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometryInit$INITSTYLE" sourceFile="GeometryInit.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometryInitialization" sourceFile="GeometryInitialization.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometryInitializationToGenericAdaptor" sourceFile="GeometryInitializationToGenericAdaptor.java" interface="false" size="50" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.GeometryReader" sourceFile="GeometryReader.java" interface="false" size="48" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometrySanityCheck" sourceFile="GeometrySanityCheck.java" interface="false" size="101" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GeometryWriter" sourceFile="GeometryWriter.java" interface="false" size="55" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GermanyGeometryMutation" sourceFile="GermanyGeometryMutation.java" interface="false" size="63" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GermanyGeometryXOver" sourceFile="GermanyGeometryXOver.java" interface="false" size="59" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GermanyMoleculeMutation" sourceFile="GermanyMoleculeMutation.java" interface="false" size="130" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GermanyMoleculeXOver" sourceFile="GermanyMoleculeXOver.java" interface="false" size="151" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GlobOptAlgoFactory" sourceFile="GlobOptAlgoFactory.java" interface="false" size="1007" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.GlobOptAlgoFactory$MolGlobOptAlgoFactory" sourceFile="GlobOptAlgoFactory.java" interface="false" size="69" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GlobOptAtomics" sourceFile="GlobOptAtomics.java" interface="false" size="142" bugs="2" priority_1="2"/>
-      <ClassStats class="org.ogolem.core.GlobOptAtomics$CUTTINGMODE" sourceFile="GlobOptAtomics.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GlobOptStatistics" sourceFile="GlobOptStatistics.java" interface="false" size="20" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GlobalConfig" sourceFile="GlobalConfig.java" interface="false" size="512" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.core.GlobalConfig$MOLMUTCHOICE" sourceFile="GlobalConfig.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GlobalOptimization" sourceFile="GlobalOptimization.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Gradient" sourceFile="Gradient.java" interface="false" size="111" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.core.GraphBasedDirMut" sourceFile="GraphBasedDirMut.java" interface="false" size="629" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GraphBasedDirMut$GDMAdaptor" sourceFile="GraphBasedDirMut.java" interface="false" size="58" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GraphBasedDirMut$GDMBOBYQAConfig" sourceFile="GraphBasedDirMut.java" interface="false" size="12" bugs="4" priority_2="4"/>
-      <ClassStats class="org.ogolem.core.GraphDiversityCheck" sourceFile="GraphDiversityCheck.java" interface="false" size="52" bugs="4" priority_2="4"/>
-      <ClassStats class="org.ogolem.core.GridCollisionDetection" sourceFile="GridCollisionDetection.java" interface="false" size="339" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.GromacsCaller" sourceFile="GromacsCaller.java" interface="false" size="205" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GromacsCaller$1" sourceFile="GromacsCaller.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GromacsCaller$QMENGINE" sourceFile="GromacsCaller.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.core.GulpCaller" sourceFile="GulpCaller.java" interface="false" size="88" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.HackySurfaceAdsorptionBiaser" sourceFile="HackySurfaceAdsorptionBiaser.java" interface="false" size="71" bugs="0"/>
-      <ClassStats class="org.ogolem.core.HalfSphereSpace" sourceFile="HalfSphereSpace.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.core.HydrogenBondNicheComp" sourceFile="HydrogenBondNicheComp.java" interface="false" size="86" bugs="0"/>
-      <ClassStats class="org.ogolem.core.IcelandGeometryXOver" sourceFile="IcelandGeometryXOver.java" interface="false" size="51" bugs="0"/>
-      <ClassStats class="org.ogolem.core.InitIOException" sourceFile="InitIOException.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Input" sourceFile="Input.java" interface="false" size="1771" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.core.InputSanityCheck" sourceFile="InputSanityCheck.java" interface="false" size="34" bugs="0"/>
-      <ClassStats class="org.ogolem.core.InteractionTerm" sourceFile="InteractionTerm.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.core.InteriorMoleculeNicheComp" sourceFile="InteriorMoleculeNicheComp.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.core.InverseNewtonAdapter" sourceFile="InverseNewtonAdapter.java" interface="false" size="72" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.LJNeighborNicheComp" sourceFile="LJNeighborNicheComp.java" interface="false" size="185" bugs="7" priority_2="6" priority_1="1"/>
-      <ClassStats class="org.ogolem.core.LJProjNicheComp" sourceFile="LJProjNicheComp.java" interface="false" size="127" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.LaplandGeometryXOver" sourceFile="LaplandGeometryXOver.java" interface="false" size="125" bugs="0"/>
-      <ClassStats class="org.ogolem.core.LennardJonesFF" sourceFile="LennardJonesFF.java" interface="false" size="252" bugs="0"/>
-      <ClassStats class="org.ogolem.core.LocOptFactory" sourceFile="LocOptFactory.java" interface="false" size="559" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.LocalHeatGeometryMutation" sourceFile="LocalHeatGeometryMutation.java" interface="false" size="44" bugs="0"/>
-      <ClassStats class="org.ogolem.core.LocalHeatLocOpt" sourceFile="LocalHeatLocOpt.java" interface="false" size="52" bugs="0"/>
-      <ClassStats class="org.ogolem.core.LotriffCaller" sourceFile="LotriffCaller.java" interface="false" size="78" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MNDOCaller" sourceFile="MNDOCaller.java" interface="false" size="214" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MNDOCaller$1" sourceFile="MNDOCaller.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MNDOCaller$METHOD" sourceFile="MNDOCaller.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MainOGOLEM" sourceFile="MainOGOLEM.java" interface="false" size="159" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MergingPhenoXOver" sourceFile="MergingPhenoXOver.java" interface="false" size="311" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MergingPhenoXOver$MergingPhenoConfig" sourceFile="MergingPhenoXOver.java" interface="false" size="39" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MergingPhenoXOver$OptimizeFunction" sourceFile="MergingPhenoXOver.java" interface="false" size="125" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MixedLJForceField" sourceFile="MixedLJForceField.java" interface="false" size="294" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Molecule" sourceFile="Molecule.java" interface="false" size="578" bugs="4" priority_2="3" priority_1="1"/>
-      <ClassStats class="org.ogolem.core.MoleculeConfig" sourceFile="MoleculeConfig.java" interface="false" size="133" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MoleculeUntangler" sourceFile="MoleculeUntangler.java" interface="false" size="117" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MolproCaller" sourceFile="MolproCaller.java" interface="false" size="355" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MolproCaller$1" sourceFile="MolproCaller.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MolproCaller$METHOD" sourceFile="MolproCaller.java" interface="false" size="20" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarlo2DExtOnlyGeometryMutation" sourceFile="MonteCarlo2DExtOnlyGeometryMutation.java" interface="false" size="77" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarlo2DExtOnlyGeometryMutation$1" sourceFile="MonteCarlo2DExtOnlyGeometryMutation.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarlo2DExtOnlyGeometryMutation$MOVEMODE" sourceFile="MonteCarlo2DExtOnlyGeometryMutation.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloExtOnlyGeometryMutation" sourceFile="MonteCarloExtOnlyGeometryMutation.java" interface="false" size="79" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloExtOnlyGeometryMutation$1" sourceFile="MonteCarloExtOnlyGeometryMutation.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloExtOnlyGeometryMutation$MOVEMODE" sourceFile="MonteCarloExtOnlyGeometryMutation.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloGeometryMutation" sourceFile="MonteCarloGeometryMutation.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloMoleculeMutation" sourceFile="MonteCarloMoleculeMutation.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloMutation" sourceFile="MonteCarloMutation.java" interface="false" size="151" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloMutation$1" sourceFile="MonteCarloMutation.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MonteCarloMutation$MOVEMODE" sourceFile="MonteCarloMutation.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MopacCaller" sourceFile="MopacCaller.java" interface="false" size="184" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MopacCaller$METHOD" sourceFile="MopacCaller.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.core.MultiCollisionInfo" sourceFile="MultiCollisionInfo.java" interface="false" size="17" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NAMDCaller" sourceFile="NAMDCaller.java" interface="false" size="136" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Newton" sourceFile="Newton.java" interface="true" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NewtonAdaptor" sourceFile="NewtonAdaptor.java" interface="false" size="53" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorrbottenGeometryXOver" sourceFile="NorrbottenGeometryXOver.java" interface="false" size="299" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorrbottenGeometryXOver$1" sourceFile="NorrbottenGeometryXOver.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorrbottenGeometryXOver$ROTATIONPLANE" sourceFile="NorrbottenGeometryXOver.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorwayGeometryMutation" sourceFile="NorwayGeometryMutation.java" interface="false" size="223" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorwayGeometryMutation$1" sourceFile="NorwayGeometryMutation.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorwayGeometryMutation$MUTMODE" sourceFile="NorwayGeometryMutation.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NorwayGeometryMutation$PACKDIM" sourceFile="NorwayGeometryMutation.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.NumericalGradients" sourceFile="NumericalGradients.java" interface="false" size="79" bugs="0"/>
-      <ClassStats class="org.ogolem.core.OpenBabelCaller" sourceFile="OpenBabelCaller.java" interface="false" size="157" bugs="0"/>
-      <ClassStats class="org.ogolem.core.OpenBabelCaller$FORCEFIELD" sourceFile="OpenBabelCaller.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.OrbitSpace" sourceFile="OrbitSpace.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Output" sourceFile="Output.java" interface="false" size="64" bugs="0"/>
-      <ClassStats class="org.ogolem.core.PackingInit" sourceFile="PackingInit.java" interface="false" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ParallelepipedSpace" sourceFile="ParallelepipedSpace.java" interface="false" size="67" bugs="0"/>
-      <ClassStats class="org.ogolem.core.PenaltyLocOpt" sourceFile="PenaltyLocOpt.java" interface="false" size="52" bugs="0"/>
-      <ClassStats class="org.ogolem.core.PeriodicCoordTranslator" sourceFile="PeriodicCoordTranslator.java" interface="false" size="51" bugs="0"/>
-      <ClassStats class="org.ogolem.core.PeriodicCoordinates" sourceFile="PeriodicCoordinates.java" interface="false" size="147" bugs="13" priority_2="13"/>
-      <ClassStats class="org.ogolem.core.PhenotypeGeometryXOver" sourceFile="PhenotypeGeometryXOver.java" interface="false" size="240" bugs="0"/>
-      <ClassStats class="org.ogolem.core.PluggableDirMut" sourceFile="PluggableDirMut.java" interface="false" size="128" bugs="2" priority_2="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.core.PortugalGeometryXOver" sourceFile="PortugalGeometryXOver.java" interface="false" size="58" bugs="0"/>
-      <ClassStats class="org.ogolem.core.PortugalMoleculeXOver" sourceFile="PortugalMoleculeXOver.java" interface="false" size="79" bugs="0"/>
-      <ClassStats class="org.ogolem.core.QuantumEspressoCaller" sourceFile="QuantumEspressoCaller.java" interface="false" size="69" bugs="0"/>
-      <ClassStats class="org.ogolem.core.RandomizedGeomInit" sourceFile="RandomizedGeomInit.java" interface="false" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.core.RigidBodyBackend" sourceFile="RigidBodyBackend.java" interface="true" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.core.RigidBodyCoordinates" sourceFile="RigidBodyCoordinates.java" interface="false" size="245" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.ScaTTM3FBackend" sourceFile="ScaTTM3FBackend.java" interface="false" size="250" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SerialException" sourceFile="SerialException.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SigmoidCollisionStrengthComputer" sourceFile="SigmoidCollisionStrengthComputer.java" interface="false" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SimpleBondInfo" sourceFile="SimpleBondInfo.java" interface="false" size="61" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.SimpleEnvironment" sourceFile="SimpleEnvironment.java" interface="false" size="393" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.SimpleEnvironment$FITMODE" sourceFile="SimpleEnvironment.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SimpleSeedingInit" sourceFile="SimpleSeedingInit.java" interface="false" size="91" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SimpleSurface" sourceFile="SimpleSurface.java" interface="false" size="71" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SingleCollisionInfo" sourceFile="SingleCollisionInfo.java" interface="false" size="34" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SingleGeomSpectralFitnessFunction" sourceFile="SingleGeomSpectralFitnessFunction.java" interface="false" size="184" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.SingleGeomSpectralFitnessFunction$Coefficient" sourceFile="SingleGeomSpectralFitnessFunction.java" interface="false" size="29" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SingleGeomSpectralFitnessFunction$FitnessFunction" sourceFile="SingleGeomSpectralFitnessFunction.java" interface="false" size="72" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SkalevalaCaller" sourceFile="SkalevalaCaller.java" interface="false" size="59" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SnaefellsjoekullGeometryXOver" sourceFile="SnaefellsjoekullGeometryXOver.java" interface="false" size="392" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.core.SnaefellsjoekullGeometryXOver$1" sourceFile="SnaefellsjoekullGeometryXOver.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SnaefellsjoekullGeometryXOver$CUTTYPE" sourceFile="SnaefellsjoekullGeometryXOver.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SnaefellsjoekullGeometryXOver$OptConfig" sourceFile="SnaefellsjoekullGeometryXOver.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SnaefellsjoekullGeometryXOver$OptimizeFunction" sourceFile="SnaefellsjoekullGeometryXOver.java" interface="false" size="103" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SphereSpace" sourceFile="SphereSpace.java" interface="false" size="36" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SphericalCoordinates" sourceFile="SphericalCoordinates.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.core.StreamGobbler" sourceFile="StreamGobbler.java" interface="false" size="27" bugs="0"/>
-      <ClassStats class="org.ogolem.core.StructuralData" sourceFile="StructuralData.java" interface="true" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Surface" sourceFile="Surface.java" interface="false" size="34" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SurfaceDetection" sourceFile="SurfaceDetection.java" interface="false" size="23" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.core.SurfaceDetection$SURFDETECTTYPE" sourceFile="SurfaceDetection.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SurfaceDetectionEngine" sourceFile="SurfaceDetectionEngine.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.core.SurfaceDirectedMutation" sourceFile="SurfaceDirectedMutation.java" interface="false" size="215" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.SwedenGeometryXOver" sourceFile="SwedenGeometryXOver.java" interface="false" size="50" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIP3PForceField" sourceFile="TIP3PForceField.java" interface="false" size="404" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIP4PForceField" sourceFile="TIP4PForceField.java" interface="false" size="470" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPHelpers" sourceFile="TIPnPHelpers.java" interface="false" size="31" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPHelpers$AntiColdFusionFunction" sourceFile="TIPnPHelpers.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPParameters" sourceFile="TIPnPParameters.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPParameters$StandardTIP3PParameters" sourceFile="TIPnPParameters.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPParameters$StandardTIP4PParameters" sourceFile="TIPnPParameters.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPParameters$TIP3PParameters" sourceFile="TIPnPParameters.java" interface="true" size="7" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPParameters$TIP4PParameters" sourceFile="TIPnPParameters.java" interface="true" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TIPnPParameters$TIP4P_2005" sourceFile="TIPnPParameters.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TinkerCaller" sourceFile="TinkerCaller.java" interface="false" size="301" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TinkerCaller$1" sourceFile="TinkerCaller.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TinkerCaller$METHOD" sourceFile="TinkerCaller.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TinkerMDCaller" sourceFile="TinkerMDCaller.java" interface="false" size="231" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.TinkerMDCaller$1" sourceFile="TinkerMDCaller.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.core.TinkerMDCaller$METHOD" sourceFile="TinkerMDCaller.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.core.Topology" sourceFile="Topology.java" interface="false" size="448" bugs="33" priority_2="33"/>
-      <ClassStats class="org.ogolem.core.TwoStepLocOpt" sourceFile="TwoStepLocOpt.java" interface="false" size="67" bugs="0"/>
-      <ClassStats class="org.ogolem.core.UNGlobOpt" sourceFile="UNGlobOpt.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.core.UniversalFF" sourceFile="UniversalFF.java" interface="false" size="125" bugs="0"/>
-      <ClassStats class="org.ogolem.core.VASPCaller" sourceFile="VASPCaller.java" interface="false" size="226" bugs="0"/>
-      <ClassStats class="org.ogolem.core.VinlandGeometryXOver" sourceFile="VinlandGeometryXOver.java" interface="false" size="135" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.core.VinlandGeometryXOver$MOVEMODE" sourceFile="VinlandGeometryXOver.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.core.WaterAngleNicheComp" sourceFile="WaterAngleNicheComp.java" interface="false" size="100" bugs="0"/>
-      <ClassStats class="org.ogolem.core.WeightedGraph" sourceFile="WeightedGraph.java" interface="false" size="73" bugs="0"/>
-      <ClassStats class="org.ogolem.core.XChangeGeometryMutation" sourceFile="XChangeGeometryMutation.java" interface="false" size="61" bugs="0"/>
-      <ClassStats class="org.ogolem.core.ZMatrix" sourceFile="ZMatrix.java" interface="false" size="160" bugs="14" priority_2="14"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.dimeranalyzer" total_bugs="1" total_types="1" total_size="89" priority_2="1">
-      <ClassStats class="org.ogolem.dimeranalyzer.MainDimerAnalyzer" sourceFile="MainDimerAnalyzer.java" interface="false" size="89" bugs="1" priority_2="1"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.dimerizer" total_bugs="0" total_types="3" total_size="182">
-      <ClassStats class="org.ogolem.dimerizer.DimerizerConfig" sourceFile="DimerizerConfig.java" interface="false" size="74" bugs="0"/>
-      <ClassStats class="org.ogolem.dimerizer.DimerizerCore" sourceFile="DimerizerCore.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.dimerizer.MainDimerizer" sourceFile="MainDimerizer.java" interface="false" size="62" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.familytree" total_bugs="0" total_types="4" total_size="333">
-      <ClassStats class="org.ogolem.familytree.GeneticRecord" sourceFile="GeneticRecord.java" interface="false" size="39" bugs="0"/>
-      <ClassStats class="org.ogolem.familytree.GeneticRecordComparator" sourceFile="GeneticRecordComparator.java" interface="false" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.familytree.MainFamilyTree" sourceFile="MainFamilyTree.java" interface="false" size="180" bugs="0"/>
-      <ClassStats class="org.ogolem.familytree.VisualizationConfig" sourceFile="VisualizationConfig.java" interface="false" size="104" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.fft" total_bugs="0" total_types="2" total_size="95">
-      <ClassStats class="org.ogolem.fft.MainFFTInterface" sourceFile="MainFFTInterface.java" interface="false" size="63" bugs="0"/>
-      <ClassStats class="org.ogolem.fft.Padder" sourceFile="Padder.java" interface="false" size="32" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.freqs" total_bugs="5" total_types="8" total_size="351" priority_2="5">
-      <ClassStats class="org.ogolem.freqs.Frequencies" sourceFile="Frequencies.java" interface="false" size="70" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.freqs.Frequencies$Frequency" sourceFile="Frequencies.java" interface="false" size="27" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.freqs.FrequencyMethod" sourceFile="FrequencyMethod.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.freqs.HarmonicFrequencyCalculator" sourceFile="HarmonicFrequencyCalculator.java" interface="false" size="33" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.freqs.MainFreqs" sourceFile="MainFreqs.java" interface="false" size="55" bugs="0"/>
-      <ClassStats class="org.ogolem.freqs.MainPowerSpec" sourceFile="MainPowerSpec.java" interface="false" size="57" bugs="0"/>
-      <ClassStats class="org.ogolem.freqs.MinimumDecider" sourceFile="MinimumDecider.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.freqs.NumericalHessianCalculator" sourceFile="NumericalHessianCalculator.java" interface="false" size="85" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.general" total_bugs="0" total_types="1" total_size="180">
-      <ClassStats class="org.ogolem.general.MainOgolem" sourceFile="MainOgolem.java" interface="false" size="180" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.generic" total_bugs="20" total_types="48" total_size="1489" priority_2="20">
-      <ClassStats class="org.ogolem.generic.AbstractDefaultConfig" sourceFile="AbstractDefaultConfig.java" interface="false" size="76" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.AbstractProblem" sourceFile="AbstractProblem.java" interface="false" size="44" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.BoundedGenericMutation" sourceFile="BoundedGenericMutation.java" interface="false" size="52" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.generic.BoundedInitializer" sourceFile="BoundedInitializer.java" interface="false" size="49" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.generic.Configuration" sourceFile="Configuration.java" interface="true" size="17" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.ContinuousProblem" sourceFile="ContinuousProblem.java" interface="false" size="15" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.Copyable" sourceFile="Copyable.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.DiscreteProblem" sourceFile="DiscreteProblem.java" interface="false" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.DummyIndividualReader" sourceFile="DummyIndividualReader.java" interface="false" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.EmptySanityCheck" sourceFile="EmptySanityCheck.java" interface="false" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericAbsolutePrescreeningLocOpt" sourceFile="GenericAbsolutePrescreeningLocOpt.java" interface="false" size="34" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericAbstractDarwin" sourceFile="GenericAbstractDarwin.java" interface="false" size="139" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.GenericAbstractGradFreeLocOpt" sourceFile="GenericAbstractGradFreeLocOpt.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericAbstractLocOpt" sourceFile="GenericAbstractLocOpt.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericBackend" sourceFile="GenericBackend.java" interface="true" size="15" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericChainedFitnessFunc" sourceFile="GenericChainedFitnessFunc.java" interface="false" size="44" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.GenericChainedMutation" sourceFile="GenericChainedMutation.java" interface="false" size="46" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.generic.GenericChainedXOver" sourceFile="GenericChainedXOver.java" interface="false" size="48" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.generic.GenericCrossover" sourceFile="GenericCrossover.java" interface="true" size="7" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericDarwin" sourceFile="GenericDarwin.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericFitnessBackend" sourceFile="GenericFitnessBackend.java" interface="true" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericFitnessBackend$BOUNDSTYPE" sourceFile="GenericFitnessBackend.java" interface="false" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericFitnessFunction" sourceFile="GenericFitnessFunction.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericFitnessFunctionBackendWrapper" sourceFile="GenericFitnessFunctionBackendWrapper.java" interface="false" size="59" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.generic.GenericGermanyCrossover" sourceFile="GenericGermanyCrossover.java" interface="false" size="34" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericGlobalOptimization" sourceFile="GenericGlobalOptimization.java" interface="true" size="7" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericGlobalOptimizationFactory" sourceFile="GenericGlobalOptimizationFactory.java" interface="false" size="147" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericHollandCrossover" sourceFile="GenericHollandCrossover.java" interface="false" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericInitializer" sourceFile="GenericInitializer.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericLocOpt" sourceFile="GenericLocOpt.java" interface="true" size="7" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericMultipleGlobOpt" sourceFile="GenericMultipleGlobOpt.java" interface="false" size="56" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.GenericMutation" sourceFile="GenericMutation.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericMutationAsXOver" sourceFile="GenericMutationAsXOver.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericNoLocOpt" sourceFile="GenericNoLocOpt.java" interface="false" size="26" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericOperator" sourceFile="GenericOperator.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericPortugalCrossover" sourceFile="GenericPortugalCrossover.java" interface="false" size="41" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericRelativePrescreeningLocOpt" sourceFile="GenericRelativePrescreeningLocOpt.java" interface="false" size="42" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.GenericSanityCheck" sourceFile="GenericSanityCheck.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.GenericStepChangingMut" sourceFile="GenericStepChangingMut.java" interface="false" size="49" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.GenericStepChangingXOver" sourceFile="GenericStepChangingXOver.java" interface="false" size="54" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.IndividualReader" sourceFile="IndividualReader.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.IndividualWriter" sourceFile="IndividualWriter.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.MultipleMutationWrapper" sourceFile="MultipleMutationWrapper.java" interface="false" size="53" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.MultipleXOverWrapper" sourceFile="MultipleXOverWrapper.java" interface="false" size="57" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.NoCrossover" sourceFile="NoCrossover.java" interface="false" size="17" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.NoMutation" sourceFile="NoMutation.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.Optimizable" sourceFile="Optimizable.java" interface="true" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.SimpleGenericDarwin" sourceFile="SimpleGenericDarwin.java" interface="false" size="25" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.generic.generichistory" total_bugs="1" total_types="3" total_size="199" priority_2="1">
-      <ClassStats class="org.ogolem.generic.generichistory.GenericHistory" sourceFile="GenericHistory.java" interface="false" size="159" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.generichistory.GenericHistoryConfig" sourceFile="GenericHistoryConfig.java" interface="false" size="21" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.generichistory.GeneticRecord" sourceFile="GeneticRecord.java" interface="false" size="19" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.generic.genericpool" total_bugs="17" total_types="19" total_size="1135" priority_2="17">
-      <ClassStats class="org.ogolem.generic.genericpool.AbstractNicher" sourceFile="AbstractNicher.java" interface="false" size="59" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.genericpool.DiversityChecker" sourceFile="DiversityChecker.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericDiversityCheckers" sourceFile="GenericDiversityCheckers.java" interface="false" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericDiversityCheckers$FitnessDiversityChecker" sourceFile="GenericDiversityCheckers.java" interface="false" size="17" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericDiversityCheckers$PercentageFitnessDiversityChecker" sourceFile="GenericDiversityCheckers.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericDiversityCheckers$ScaledFitnessDiversityChecker" sourceFile="GenericDiversityCheckers.java" interface="false" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericParentSelectors" sourceFile="GenericParentSelectors.java" interface="false" size="58" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericParentSelectors$FitnessWeightedParentSelector" sourceFile="GenericParentSelectors.java" interface="false" size="74" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericParentSelectors$RandomParentSelector" sourceFile="GenericParentSelectors.java" interface="false" size="23" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericParentSelectors$RealFitnessWeightedParentSelector" sourceFile="GenericParentSelectors.java" interface="false" size="52" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericPool" sourceFile="GenericPool.java" interface="false" size="465" bugs="7" priority_2="7"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericPoolConfig" sourceFile="GenericPoolConfig.java" interface="false" size="149" bugs="6" priority_2="6"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericPoolEntry" sourceFile="GenericPoolEntry.java" interface="false" size="19" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.generic.genericpool.GenericStatistics" sourceFile="GenericStatistics.java" interface="false" size="97" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.Niche" sourceFile="Niche.java" interface="false" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.NicheComputer" sourceFile="NicheComputer.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.Nicher" sourceFile="Nicher.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.ParentSelector" sourceFile="ParentSelector.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.genericpool.SimpleNicher" sourceFile="SimpleNicher.java" interface="false" size="54" bugs="1" priority_2="1"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.generic.mpi" total_bugs="7" total_types="3" total_size="367" priority_2="6" priority_1="1">
-      <ClassStats class="org.ogolem.generic.mpi.GenericMPIOptimization" sourceFile="GenericMPIOptimization.java" interface="false" size="126" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.generic.mpi.MPIInterface" sourceFile="MPIInterface.java" interface="false" size="228" bugs="6" priority_2="6"/>
-      <ClassStats class="org.ogolem.generic.mpi.MPIInterface$MPIStatus" sourceFile="MPIInterface.java" interface="false" size="13" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.generic.stats" total_bugs="1" total_types="4" total_size="169" priority_2="1">
-      <ClassStats class="org.ogolem.generic.stats.BasicDetailedBackend" sourceFile="BasicDetailedBackend.java" interface="false" size="45" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.stats.DetailedStatistics" sourceFile="DetailedStatistics.java" interface="true" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.stats.DummyDetailedStats" sourceFile="DummyDetailedStats.java" interface="false" size="27" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.stats.GenericDetailStatistics" sourceFile="GenericDetailStatistics.java" interface="false" size="84" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.generic.threading" total_bugs="11" total_types="10" total_size="547" priority_2="11">
-      <ClassStats class="org.ogolem.generic.threading.GenericGlobOptTask" sourceFile="GenericGlobOptTask.java" interface="false" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericGlobOptTask$1" sourceFile="GenericGlobOptTask.java" interface="false" size="71" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericInitTask" sourceFile="GenericInitTask.java" interface="false" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericInitTask$1" sourceFile="GenericInitTask.java" interface="false" size="47" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericOGOLEMOptimization" sourceFile="GenericOGOLEMOptimization.java" interface="false" size="196" bugs="5" priority_2="5"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericSeedTask" sourceFile="GenericSeedTask.java" interface="false" size="26" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericSeedTask$1" sourceFile="GenericSeedTask.java" interface="false" size="69" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.generic.threading.GenericThreadDispatcher" sourceFile="GenericThreadDispatcher.java" interface="false" size="84" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.generic.threading.ObjectCache" sourceFile="ObjectCache.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.generic.threading.TaskFactory" sourceFile="TaskFactory.java" interface="true" size="2" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.heat" total_bugs="0" total_types="6" total_size="321">
-      <ClassStats class="org.ogolem.heat.LocalHeatPulses" sourceFile="LocalHeatPulses.java" interface="false" size="173" bugs="0"/>
-      <ClassStats class="org.ogolem.heat.LocalHeatPulses$1" sourceFile="LocalHeatPulses.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.heat.LocalHeatPulses$Configuration" sourceFile="LocalHeatPulses.java" interface="false" size="77" bugs="0"/>
-      <ClassStats class="org.ogolem.heat.LocalHeatPulses$Configuration$CHOOSEMODE" sourceFile="LocalHeatPulses.java" interface="false" size="15" bugs="0"/>
-      <ClassStats class="org.ogolem.heat.LocalHeatPulses$Configuration$MOVEMODE" sourceFile="LocalHeatPulses.java" interface="false" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.heat.MainLocalHeat" sourceFile="MainLocalHeat.java" interface="false" size="42" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.helpers" total_bugs="1" total_types="8" total_size="211" priority_1="1">
-      <ClassStats class="org.ogolem.helpers.CopyableTuple" sourceFile="CopyableTuple.java" interface="false" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.helpers.Fortune" sourceFile="Fortune.java" interface="false" size="10" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.helpers.IndexSort" sourceFile="IndexSort.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.helpers.Machine" sourceFile="Machine.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.helpers.StatisticUtils" sourceFile="StatisticUtils.java" interface="false" size="79" bugs="0"/>
-      <ClassStats class="org.ogolem.helpers.Tuple" sourceFile="Tuple.java" interface="false" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.helpers.Tuple3D" sourceFile="Tuple3D.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.helpers.Tuple4D" sourceFile="Tuple4D.java" interface="false" size="12" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.interfaces" total_bugs="0" total_types="7" total_size="709">
-      <ClassStats class="org.ogolem.interfaces.GenericInterface" sourceFile="GenericInterface.java" interface="false" size="77" bugs="0"/>
-      <ClassStats class="org.ogolem.interfaces.OrcaCaller" sourceFile="OrcaCaller.java" interface="false" size="321" bugs="0"/>
-      <ClassStats class="org.ogolem.interfaces.XTBCaller" sourceFile="XTBCaller.java" interface="false" size="255" bugs="0"/>
-      <ClassStats class="org.ogolem.interfaces.XTBCaller$1" sourceFile="XTBCaller.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.interfaces.XTBCaller$METHOD" sourceFile="XTBCaller.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.interfaces.XTBCaller$OPTLEVEL" sourceFile="XTBCaller.java" interface="false" size="20" bugs="0"/>
-      <ClassStats class="org.ogolem.interfaces.XTBCaller$SUBDIRS" sourceFile="XTBCaller.java" interface="false" size="14" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.io" total_bugs="2" total_types="6" total_size="260" priority_2="2">
-      <ClassStats class="org.ogolem.io.FileFilter" sourceFile="FileFilter.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.io.FixedValues" sourceFile="FixedValues.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.io.InputPrimitives" sourceFile="InputPrimitives.java" interface="false" size="45" bugs="0"/>
-      <ClassStats class="org.ogolem.io.InquiryPrimitives" sourceFile="InquiryPrimitives.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.io.ManipulationPrimitives" sourceFile="ManipulationPrimitives.java" interface="false" size="71" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.io.OutputPrimitives" sourceFile="OutputPrimitives.java" interface="false" size="88" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.ljreferences" total_bugs="0" total_types="5" total_size="230">
-      <ClassStats class="org.ogolem.ljreferences.LittleHelpers" sourceFile="LittleHelpers.java" interface="false" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.ljreferences.MainLJRefs" sourceFile="MainLJRefs.java" interface="false" size="69" bugs="0"/>
-      <ClassStats class="org.ogolem.ljreferences.Molpro" sourceFile="Molpro.java" interface="false" size="75" bugs="0"/>
-      <ClassStats class="org.ogolem.ljreferences.Orca" sourceFile="Orca.java" interface="false" size="39" bugs="0"/>
-      <ClassStats class="org.ogolem.ljreferences.TwoBodyTerm" sourceFile="TwoBodyTerm.java" interface="false" size="39" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.locopt" total_bugs="1" total_types="15" total_size="1079" priority_2="1">
-      <ClassStats class="org.ogolem.locopt.AbstractLocOptFactory" sourceFile="AbstractLocOptFactory.java" interface="false" size="312" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.BOBYQALocOpt" sourceFile="BOBYQALocOpt.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.BOBYQALocOpt$Adapter" sourceFile="BOBYQALocOpt.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.CGLocOpt" sourceFile="CGLocOpt.java" interface="false" size="63" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.FIRELocOpt" sourceFile="FIRELocOpt.java" interface="false" size="205" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.FIRELocOpt$BestPoint" sourceFile="FIRELocOpt.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.FIRELocOpt$FireConfig" sourceFile="FIRELocOpt.java" interface="false" size="64" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.FIRELocOpt$Scr" sourceFile="FIRELocOpt.java" interface="false" size="17" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.FleminLocOpt" sourceFile="FleminLocOpt.java" interface="false" size="51" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.GenericChainedLocalOpt" sourceFile="GenericChainedLocalOpt.java" interface="false" size="50" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.locopt.LBFGSLocOpt" sourceFile="LBFGSLocOpt.java" interface="false" size="81" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.NEWUOALocOpt" sourceFile="NEWUOALocOpt.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.NEWUOALocOpt$Adapter" sourceFile="NEWUOALocOpt.java" interface="false" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.PraxisLocOpt" sourceFile="PraxisLocOpt.java" interface="false" size="59" bugs="0"/>
-      <ClassStats class="org.ogolem.locopt.RNK1MinLocOpt" sourceFile="RNK1MinLocOpt.java" interface="false" size="54" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.locopt.apachehelpers" total_bugs="4" total_types="2" total_size="52" priority_2="4">
-      <ClassStats class="org.ogolem.locopt.apachehelpers.MultivariateToEnergyProvider" sourceFile="MultivariateToEnergyProvider.java" interface="false" size="30" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.locopt.apachehelpers.MultivariateToGradientProvider" sourceFile="MultivariateToGradientProvider.java" interface="false" size="22" bugs="2" priority_2="2"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.locopt.numalhelpers" total_bugs="2" total_types="2" total_size="33" priority_2="2">
-      <ClassStats class="org.ogolem.locopt.numalhelpers.NumalFitnessWrapper" sourceFile="NumalFitnessWrapper.java" interface="false" size="15" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.locopt.numalhelpers.NumalGradientWrapper" sourceFile="NumalGradientWrapper.java" interface="false" size="18" bugs="1" priority_2="1"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.macrobenchmarks" total_bugs="6" total_types="6" total_size="232" priority_2="6">
-      <ClassStats class="org.ogolem.macrobenchmarks.AdaptiveBenchmarkRunner" sourceFile="AdaptiveBenchmarkRunner.java" interface="false" size="62" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.macrobenchmarks.BenchmarkRunner" sourceFile="BenchmarkRunner.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.macrobenchmarks.ClusterBenchmarkRunner" sourceFile="ClusterBenchmarkRunner.java" interface="false" size="83" bugs="5" priority_2="5"/>
-      <ClassStats class="org.ogolem.macrobenchmarks.Helpers" sourceFile="Helpers.java" interface="false" size="29" bugs="0"/>
-      <ClassStats class="org.ogolem.macrobenchmarks.Helpers$Rank0Filter" sourceFile="Helpers.java" interface="false" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.macrobenchmarks.MainMacroBenchmarks" sourceFile="MainMacroBenchmarks.java" interface="false" size="51" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.math" total_bugs="3" total_types="16" total_size="657" priority_2="2" priority_1="1">
-      <ClassStats class="org.ogolem.math.AbstractLookup" sourceFile="AbstractLookup.java" interface="false" size="86" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.math.AcosLookup" sourceFile="AcosLookup.java" interface="false" size="42" bugs="0"/>
-      <ClassStats class="org.ogolem.math.BLASInterface" sourceFile="BLASInterface.java" interface="false" size="48" bugs="0"/>
-      <ClassStats class="org.ogolem.math.BLASInterface$TRANSPOSE" sourceFile="BLASInterface.java" interface="false" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.math.CosLookup" sourceFile="CosLookup.java" interface="false" size="37" bugs="0"/>
-      <ClassStats class="org.ogolem.math.ExpLookup" sourceFile="ExpLookup.java" interface="false" size="19" bugs="0"/>
-      <ClassStats class="org.ogolem.math.FastFunctions" sourceFile="FastFunctions.java" interface="false" size="70" bugs="0"/>
-      <ClassStats class="org.ogolem.math.GenericLookup" sourceFile="GenericLookup.java" interface="false" size="26" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.math.LAPACKInterface" sourceFile="LAPACKInterface.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.math.LookupedFunction" sourceFile="LookupedFunction.java" interface="true" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.math.MathUtils" sourceFile="MathUtils.java" interface="false" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.math.Matrix" sourceFile="Matrix.java" interface="true" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.math.Matrix3x3" sourceFile="Matrix3x3.java" interface="false" size="22" bugs="0"/>
-      <ClassStats class="org.ogolem.math.SinLookup" sourceFile="SinLookup.java" interface="false" size="37" bugs="0"/>
-      <ClassStats class="org.ogolem.math.SymmetricMatrixNoDiag" sourceFile="SymmetricMatrixNoDiag.java" interface="false" size="30" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.math.TrivialLinearAlgebra" sourceFile="TrivialLinearAlgebra.java" interface="false" size="197" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.microbenchmarks" total_bugs="20" total_types="41" total_size="1376" priority_2="8" priority_1="12">
-      <ClassStats class="org.ogolem.microbenchmarks.AckleyBench" sourceFile="AckleyBench.java" interface="false" size="22" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AckleyGradBench" sourceFile="AckleyGradBench.java" interface="false" size="24" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AdaptiveLJFFEnergyBench" sourceFile="AdaptiveLJFFEnergyBench.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AdaptiveLJFFGradientBench" sourceFile="AdaptiveLJFFGradientBench.java" interface="false" size="40" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AdvPairwiseCDBenchmark" sourceFile="AdvPairwiseCDBenchmark.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AdvPairwiseCDCheckOnlyBenchmark" sourceFile="AdvPairwiseCDCheckOnlyBenchmark.java" interface="false" size="16" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AligningBench" sourceFile="AligningBench.java" interface="false" size="13" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AngleBench" sourceFile="AngleBench.java" interface="false" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.AngleBench2" sourceFile="AngleBench2.java" interface="false" size="25" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.CartesianCoordinatesLibrary" sourceFile="CartesianCoordinatesLibrary.java" interface="false" size="104" bugs="8" priority_2="8"/>
-      <ClassStats class="org.ogolem.microbenchmarks.DihedralBench" sourceFile="DihedralBench.java" interface="false" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.LJFFEnergyBench" sourceFile="LJFFEnergyBench.java" interface="false" size="21" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.LJFFGradientBench" sourceFile="LJFFGradientBench.java" interface="false" size="23" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.LunacekBench" sourceFile="LunacekBench.java" interface="false" size="22" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.LunacekGradBench" sourceFile="LunacekGradBench.java" interface="false" size="24" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.MainMicroBenchmarks" sourceFile="MainMicroBenchmarks.java" interface="false" size="175" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.Mat3x3MultBenchmark" sourceFile="Mat3x3MultBenchmark.java" interface="false" size="27" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.MatMultBenchmark" sourceFile="MatMultBenchmark.java" interface="false" size="34" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.MixedLJFFEnergyBench" sourceFile="MixedLJFFEnergyBench.java" interface="false" size="26" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.MixedLJFFGradientBench" sourceFile="MixedLJFFGradientBench.java" interface="false" size="27" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.MixedLJLocOptBench" sourceFile="MixedLJLocOptBench.java" interface="false" size="56" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.NorwayPackingLJBench" sourceFile="NorwayPackingLJBench.java" interface="false" size="44" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.RastriginBench" sourceFile="RastriginBench.java" interface="false" size="22" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.RastriginGradBench" sourceFile="RastriginGradBench.java" interface="false" size="24" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.SchafferF7Bench" sourceFile="SchafferF7Bench.java" interface="false" size="22" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.SchafferF7GradBench" sourceFile="SchafferF7GradBench.java" interface="false" size="24" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.SchwefelBench" sourceFile="SchwefelBench.java" interface="false" size="22" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.SchwefelGradBench" sourceFile="SchwefelGradBench.java" interface="false" size="24" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.microbenchmarks.SingleMicroBenchmark" sourceFile="SingleMicroBenchmark.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.TIP3PEnergyBench" sourceFile="TIP3PEnergyBench.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.TIP3PGradientBench" sourceFile="TIP3PGradientBench.java" interface="false" size="40" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.TIP4PEnergyBench" sourceFile="TIP4PEnergyBench.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.TIP4PGradientBench" sourceFile="TIP4PGradientBench.java" interface="false" size="40" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.UFFFrozenSurfaceEnergyBenchmark" sourceFile="UFFFrozenSurfaceEnergyBenchmark.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.UFFFrozenSurfaceGradientBenchmark" sourceFile="UFFFrozenSurfaceGradientBenchmark.java" interface="false" size="39" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.UFFLargeMoleculeEnergyBenchmark" sourceFile="UFFLargeMoleculeEnergyBenchmark.java" interface="false" size="31" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.UFFLargeMoleculeGradientBenchmark" sourceFile="UFFLargeMoleculeGradientBenchmark.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.UFFSurfaceEnergyBenchmark" sourceFile="UFFSurfaceEnergyBenchmark.java" interface="false" size="38" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.UFFSurfaceGradientBenchmark" sourceFile="UFFSurfaceGradientBenchmark.java" interface="false" size="39" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.WaterTTM3FLargeBenchmark" sourceFile="WaterTTM3FLargeBenchmark.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.microbenchmarks.WaterTTM3FSmallBenchmark" sourceFile="WaterTTM3FSmallBenchmark.java" interface="false" size="29" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.molecules" total_bugs="1" total_types="1" total_size="7" priority_1="1">
-      <ClassStats class="org.ogolem.molecules.FixedValues" sourceFile="FixedValues.java" interface="false" size="7" bugs="1" priority_1="1"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.parameters" total_bugs="0" total_types="1" total_size="102">
-      <ClassStats class="org.ogolem.parameters.MainParameters" sourceFile="MainParameters.java" interface="false" size="102" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.properties" total_bugs="3" total_types="25" total_size="996" priority_2="3">
-      <ClassStats class="org.ogolem.properties.BulkModulus" sourceFile="BulkModulus.java" interface="false" size="28" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.CellVolume" sourceFile="CellVolume.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.DegreeOfFreedom" sourceFile="DegreeOfFreedom.java" interface="false" size="43" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.properties.DeltaGauge" sourceFile="DeltaGauge.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.Density" sourceFile="Density.java" interface="false" size="79" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.Dipole" sourceFile="Dipole.java" interface="false" size="25" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.DipoleMoment" sourceFile="DipoleMoment.java" interface="false" size="34" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.properties.Energy" sourceFile="Energy.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.EnergyOrder" sourceFile="EnergyOrder.java" interface="false" size="104" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.properties.EnergyOrder$EnergyComparator" sourceFile="EnergyOrder.java" interface="false" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.ExcitationDifference" sourceFile="ExcitationDifference.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.ExcitationEnergy" sourceFile="ExcitationEnergy.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.Forces" sourceFile="Forces.java" interface="false" size="49" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.GenericMatrixProperty" sourceFile="GenericMatrixProperty.java" interface="false" size="43" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.GenericScalarProperty" sourceFile="GenericScalarProperty.java" interface="false" size="31" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.GenericTensorProperty" sourceFile="GenericTensorProperty.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.GenericVectorProperty" sourceFile="GenericVectorProperty.java" interface="false" size="40" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.MatrixProperty" sourceFile="MatrixProperty.java" interface="false" size="69" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.Property" sourceFile="Property.java" interface="true" size="10" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.ScalarProperty" sourceFile="ScalarProperty.java" interface="false" size="25" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.Spectrum" sourceFile="Spectrum.java" interface="false" size="24" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.Stability" sourceFile="Stability.java" interface="false" size="31" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.StressTensor" sourceFile="StressTensor.java" interface="false" size="43" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.TensorProperty" sourceFile="TensorProperty.java" interface="false" size="80" bugs="0"/>
-      <ClassStats class="org.ogolem.properties.VectorProperty" sourceFile="VectorProperty.java" interface="false" size="57" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.random" total_bugs="1" total_types="4" total_size="235" priority_1="1">
-      <ClassStats class="org.ogolem.random.Lottery" sourceFile="Lottery.java" interface="false" size="43" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.random.RNGenerator" sourceFile="RNGenerator.java" interface="true" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.random.RandomUtils" sourceFile="RandomUtils.java" interface="false" size="158" bugs="0"/>
-      <ClassStats class="org.ogolem.random.StandardRNG" sourceFile="StandardRNG.java" interface="false" size="25" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.rmi" total_bugs="27" total_types="33" total_size="2428" priority_2="19" priority_1="8">
-      <ClassStats class="org.ogolem.rmi.AliveCheck" sourceFile="AliveCheck.java" interface="false" size="21" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.rmi.AliveCheck$AliveChecker" sourceFile="AliveCheck.java" interface="false" size="15" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.rmi.ClientList" sourceFile="ClientList.java" interface="false" size="69" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.ClientList$ClientCleaner" sourceFile="ClientList.java" interface="false" size="30" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.DummyTask" sourceFile="DummyTask.java" interface="false" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.EmptyJob" sourceFile="EmptyJob.java" interface="false" size="18" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.GenericGlobOptJob" sourceFile="GenericGlobOptJob.java" interface="false" size="374" bugs="5" priority_2="5"/>
-      <ClassStats class="org.ogolem.rmi.GenericGlobOptTask" sourceFile="GenericGlobOptTask.java" interface="false" size="26" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.GenericInitTask" sourceFile="GenericInitTask.java" interface="false" size="23" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.rmi.GenericProxyJob" sourceFile="GenericProxyJob.java" interface="false" size="386" bugs="6" priority_2="6"/>
-      <ClassStats class="org.ogolem.rmi.GenericProxyJob$1" sourceFile="GenericProxyJob.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.GenericSeedTask" sourceFile="GenericSeedTask.java" interface="false" size="30" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.rmi.GenericThreadingClientBackend" sourceFile="GenericThreadingClientBackend.java" interface="false" size="255" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.rmi.GenericThreadingClientBackend$1" sourceFile="GenericThreadingClientBackend.java" interface="false" size="4" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.GenericThreadingClientBackend$GlobTaskFactory" sourceFile="GenericThreadingClientBackend.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.GenericThreadingClientBackend$GlobTaskFactory$1" sourceFile="GenericThreadingClientBackend.java" interface="false" size="72" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.rmi.Job" sourceFile="Job.java" interface="true" size="8" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.JobFactory" sourceFile="JobFactory.java" interface="false" size="129" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.MainOgolemRMI" sourceFile="MainOgolemRMI.java" interface="false" size="91" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.MainRMIClient" sourceFile="MainRMIClient.java" interface="false" size="142" bugs="2" priority_1="2"/>
-      <ClassStats class="org.ogolem.rmi.MainRMIProxy" sourceFile="MainRMIProxy.java" interface="false" size="153" bugs="2" priority_1="2"/>
-      <ClassStats class="org.ogolem.rmi.MainRMIThreader" sourceFile="MainRMIThreader.java" interface="false" size="137" bugs="2" priority_1="2"/>
-      <ClassStats class="org.ogolem.rmi.RMICodes" sourceFile="RMICodes.java" interface="false" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.RMICodes$JOBSTATE" sourceFile="RMICodes.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.RMICommImpl" sourceFile="RMICommImpl.java" interface="false" size="90" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.RMICommunication" sourceFile="RMICommunication.java" interface="true" size="11" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.Result" sourceFile="Result.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.SwitchGlobOptJob" sourceFile="SwitchGlobOptJob.java" interface="false" size="170" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.rmi.SwitchGlobOptTask" sourceFile="SwitchGlobOptTask.java" interface="false" size="25" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.rmi.SwitchInitTask" sourceFile="SwitchInitTask.java" interface="false" size="27" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.Task" sourceFile="Task.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.TaskQueue" sourceFile="TaskQueue.java" interface="false" size="21" bugs="0"/>
-      <ClassStats class="org.ogolem.rmi.ThreadingClientFactory" sourceFile="ThreadingClientFactory.java" interface="false" size="31" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.scanalyzer" total_bugs="0" total_types="2" total_size="84">
-      <ClassStats class="org.ogolem.scanalyzer.Analyzer" sourceFile="Analyzer.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.scanalyzer.MainScAnalyzer" sourceFile="MainScAnalyzer.java" interface="false" size="52" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.scanner" total_bugs="0" total_types="6" total_size="220">
-      <ClassStats class="org.ogolem.scanner.MainScanner" sourceFile="MainScanner.java" interface="false" size="53" bugs="0"/>
-      <ClassStats class="org.ogolem.scanner.ScannerConfig" sourceFile="ScannerConfig.java" interface="false" size="41" bugs="0"/>
-      <ClassStats class="org.ogolem.scanner.ScannerCore" sourceFile="ScannerCore.java" interface="false" size="70" bugs="0"/>
-      <ClassStats class="org.ogolem.scanner.ScannerCore$State" sourceFile="ScannerCore.java" interface="false" size="5" bugs="0"/>
-      <ClassStats class="org.ogolem.scanner.ScannerDoF" sourceFile="ScannerDoF.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.scanner.ScannerDoF$ScannerDoFIterator" sourceFile="ScannerDoF.java" interface="false" size="18" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.spectral" total_bugs="5" total_types="4" total_size="243" priority_2="5">
-      <ClassStats class="org.ogolem.spectral.FullSpectrum" sourceFile="FullSpectrum.java" interface="false" size="192" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.spectral.Peak" sourceFile="Peak.java" interface="false" size="36" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.spectral.Spectrum" sourceFile="Spectrum.java" interface="true" size="9" bugs="0"/>
-      <ClassStats class="org.ogolem.spectral.SpectrumConfig" sourceFile="SpectrumConfig.java" interface="false" size="6" bugs="1" priority_2="1"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.switches" total_bugs="13" total_types="34" total_size="2793" priority_2="11" priority_1="2">
-      <ClassStats class="org.ogolem.switches.Backbone" sourceFile="Backbone.java" interface="false" size="41" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.Color" sourceFile="Color.java" interface="false" size="37" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.ColorPalette" sourceFile="ColorPalette.java" interface="false" size="37" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.switches.Excitor" sourceFile="Excitor.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.ExcitorGateway" sourceFile="ExcitorGateway.java" interface="false" size="56" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.FitnessFunction" sourceFile="FitnessFunction.java" interface="false" size="128" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.FixedValues" sourceFile="FixedValues.java" interface="false" size="6" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.GermanyGlobOpt" sourceFile="GermanyGlobOpt.java" interface="false" size="62" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.GlobOptAtomics" sourceFile="GlobOptAtomics.java" interface="false" size="38" bugs="1" priority_1="1"/>
-      <ClassStats class="org.ogolem.switches.GlobalOptimization" sourceFile="GlobalOptimization.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.GugaCI" sourceFile="GugaCI.java" interface="false" size="104" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.LittleHelpers" sourceFile="LittleHelpers.java" interface="false" size="14" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.LocalOpt" sourceFile="LocalOpt.java" interface="false" size="34" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.LocalOptimization" sourceFile="LocalOptimization.java" interface="true" size="2" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.MagicGlue" sourceFile="MagicGlue.java" interface="false" size="306" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.MainSwitches" sourceFile="MainSwitches.java" interface="false" size="81" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.MopacExcitor" sourceFile="MopacExcitor.java" interface="false" size="70" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.MopacLocOpt" sourceFile="MopacLocOpt.java" interface="false" size="76" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.OpenBabelLocOpt" sourceFile="OpenBabelLocOpt.java" interface="false" size="132" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.OrcaExcitor" sourceFile="OrcaExcitor.java" interface="false" size="82" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.switches.Output" sourceFile="Output.java" interface="false" size="270" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.Sidechain" sourceFile="Sidechain.java" interface="false" size="32" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.SidechainInter" sourceFile="SidechainInter.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.Switch" sourceFile="Switch.java" interface="false" size="162" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.switches.SwitchWriter" sourceFile="SwitchWriter.java" interface="false" size="29" bugs="2" priority_2="2"/>
-      <ClassStats class="org.ogolem.switches.SwitchesConfig" sourceFile="SwitchesConfig.java" interface="false" size="200" bugs="3" priority_2="3"/>
-      <ClassStats class="org.ogolem.switches.SwitchesDarwin" sourceFile="SwitchesDarwin.java" interface="true" size="3" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.SwitchesGlobOpt" sourceFile="SwitchesGlobOpt.java" interface="false" size="12" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.SwitchesInput" sourceFile="SwitchesInput.java" interface="false" size="552" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.switches.Taboos" sourceFile="Taboos.java" interface="false" size="19" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.switches.ThreadingGlobOpt" sourceFile="ThreadingGlobOpt.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.ThreadingInits" sourceFile="ThreadingInits.java" interface="false" size="35" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.TinkerLocOpt" sourceFile="TinkerLocOpt.java" interface="false" size="115" bugs="1" priority_2="1"/>
-      <ClassStats class="org.ogolem.switches.Tupel" sourceFile="Tupel.java" interface="false" size="16" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.switches.backbones" total_bugs="0" total_types="1" total_size="41">
-      <ClassStats class="org.ogolem.switches.backbones.BrABBackbone" sourceFile="BrABBackbone.java" interface="false" size="41" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.switches.sidechains" total_bugs="0" total_types="9" total_size="366">
-      <ClassStats class="org.ogolem.switches.sidechains.AldehydeSide" sourceFile="AldehydeSide.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.AminoSide" sourceFile="AminoSide.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.CarboxylSide" sourceFile="CarboxylSide.java" interface="false" size="55" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.ChlorideSide" sourceFile="ChlorideSide.java" interface="false" size="26" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.HydrogenSide" sourceFile="HydrogenSide.java" interface="false" size="26" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.HydroxylSide" sourceFile="HydroxylSide.java" interface="false" size="33" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.MethylSide" sourceFile="MethylSide.java" interface="false" size="55" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.NitroSide" sourceFile="NitroSide.java" interface="false" size="46" bugs="0"/>
-      <ClassStats class="org.ogolem.switches.sidechains.ThiolSide" sourceFile="ThiolSide.java" interface="false" size="33" bugs="0"/>
-    </PackageStats>
-    <PackageStats package="org.ogolem.tests" total_bugs="0" total_types="1" total_size="107">
-      <ClassStats class="org.ogolem.tests.MainTests" sourceFile="MainTests.java" interface="false" size="107" bugs="0"/>
-    </PackageStats>
-    <FindBugsProfile>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.ValueNumberDataflowFactory" totalMilliseconds="1662" invocations="5811" avgMicrosecondsPerInvocation="286" maxMicrosecondsPerInvocation="45483" standardDeviationMicrosecondsPerInvocation="1446"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.UnconditionalValueDerefDataflowFactory" totalMilliseconds="1385" invocations="4595" avgMicrosecondsPerInvocation="301" maxMicrosecondsPerInvocation="53756" standardDeviationMicrosecondsPerInvocation="1567"/>
-      <ClassProfile name="edu.umd.cs.findbugs.ba.npe.NullDerefAndRedundantComparisonFinder" totalMilliseconds="1348" invocations="4449" avgMicrosecondsPerInvocation="303" maxMicrosecondsPerInvocation="55153" standardDeviationMicrosecondsPerInvocation="1630"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.StreamResourceTracker" totalMilliseconds="1105" invocations="1882" avgMicrosecondsPerInvocation="587" maxMicrosecondsPerInvocation="13384" standardDeviationMicrosecondsPerInvocation="1017"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.IsNullValueDataflowFactory" totalMilliseconds="1002" invocations="5321" avgMicrosecondsPerInvocation="188" maxMicrosecondsPerInvocation="25164" standardDeviationMicrosecondsPerInvocation="886"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.TypeDataflowFactory" totalMilliseconds="873" invocations="5785" avgMicrosecondsPerInvocation="151" maxMicrosecondsPerInvocation="17568" standardDeviationMicrosecondsPerInvocation="595"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindRefComparison$SpecialTypeAnalysis" totalMilliseconds="592" invocations="4450" avgMicrosecondsPerInvocation="133" maxMicrosecondsPerInvocation="14762" standardDeviationMicrosecondsPerInvocation="519"/>
-      <ClassProfile name="edu.umd.cs.findbugs.OpcodeStack$JumpInfoFactory" totalMilliseconds="558" invocations="7003" avgMicrosecondsPerInvocation="79" maxMicrosecondsPerInvocation="11299" standardDeviationMicrosecondsPerInvocation="335"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine" totalMilliseconds="436" invocations="2487" avgMicrosecondsPerInvocation="175" maxMicrosecondsPerInvocation="18367" standardDeviationMicrosecondsPerInvocation="653"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.ConstantDataflowFactory" totalMilliseconds="395" invocations="5321" avgMicrosecondsPerInvocation="74" maxMicrosecondsPerInvocation="10865" standardDeviationMicrosecondsPerInvocation="398"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.CFGFactory" totalMilliseconds="310" invocations="5325" avgMicrosecondsPerInvocation="58" maxMicrosecondsPerInvocation="7347" standardDeviationMicrosecondsPerInvocation="164"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindOpenStream" totalMilliseconds="283" invocations="738" avgMicrosecondsPerInvocation="383" maxMicrosecondsPerInvocation="25798" standardDeviationMicrosecondsPerInvocation="1690"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FieldItemSummary" totalMilliseconds="203" invocations="1008" avgMicrosecondsPerInvocation="202" maxMicrosecondsPerInvocation="4311" standardDeviationMicrosecondsPerInvocation="406"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindNoSideEffectMethods" totalMilliseconds="193" invocations="1008" avgMicrosecondsPerInvocation="192" maxMicrosecondsPerInvocation="3595" standardDeviationMicrosecondsPerInvocation="354"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindUselessObjects" totalMilliseconds="184" invocations="738" avgMicrosecondsPerInvocation="249" maxMicrosecondsPerInvocation="89396" standardDeviationMicrosecondsPerInvocation="3312"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.LiveLocalStoreDataflowFactory" totalMilliseconds="179" invocations="4348" avgMicrosecondsPerInvocation="41" maxMicrosecondsPerInvocation="4085" standardDeviationMicrosecondsPerInvocation="166"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.UnreadFields" totalMilliseconds="156" invocations="738" avgMicrosecondsPerInvocation="212" maxMicrosecondsPerInvocation="8849" standardDeviationMicrosecondsPerInvocation="466"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.LoadOfKnownNullValue" totalMilliseconds="151" invocations="738" avgMicrosecondsPerInvocation="204" maxMicrosecondsPerInvocation="11953" standardDeviationMicrosecondsPerInvocation="573"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.DumbMethods" totalMilliseconds="148" invocations="738" avgMicrosecondsPerInvocation="200" maxMicrosecondsPerInvocation="4472" standardDeviationMicrosecondsPerInvocation="377"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.MethodReturnCheck" totalMilliseconds="131" invocations="738" avgMicrosecondsPerInvocation="178" maxMicrosecondsPerInvocation="6813" standardDeviationMicrosecondsPerInvocation="439"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.RuntimeExceptionCapture" totalMilliseconds="128" invocations="738" avgMicrosecondsPerInvocation="174" maxMicrosecondsPerInvocation="10078" standardDeviationMicrosecondsPerInvocation="494"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindNullDeref$CheckCallSitesAndReturnInstructions" totalMilliseconds="127" invocations="4449" avgMicrosecondsPerInvocation="28" maxMicrosecondsPerInvocation="5719" standardDeviationMicrosecondsPerInvocation="114"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.bcel.MethodGenFactory" totalMilliseconds="127" invocations="5680" avgMicrosecondsPerInvocation="22" maxMicrosecondsPerInvocation="4306" standardDeviationMicrosecondsPerInvocation="122"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.DefaultEncodingDetector" totalMilliseconds="117" invocations="738" avgMicrosecondsPerInvocation="159" maxMicrosecondsPerInvocation="4979" standardDeviationMicrosecondsPerInvocation="415"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindSelfComparison" totalMilliseconds="114" invocations="738" avgMicrosecondsPerInvocation="155" maxMicrosecondsPerInvocation="6372" standardDeviationMicrosecondsPerInvocation="393"/>
-      <ClassProfile name="edu.umd.cs.findbugs.ba.npe.TypeQualifierNullnessAnnotationDatabase" totalMilliseconds="112" invocations="160035" avgMicrosecondsPerInvocation="0" maxMicrosecondsPerInvocation="241" standardDeviationMicrosecondsPerInvocation="1"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.RepeatedConditionals" totalMilliseconds="111" invocations="738" avgMicrosecondsPerInvocation="150" maxMicrosecondsPerInvocation="3807" standardDeviationMicrosecondsPerInvocation="335"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.InfiniteLoop" totalMilliseconds="110" invocations="738" avgMicrosecondsPerInvocation="149" maxMicrosecondsPerInvocation="4301" standardDeviationMicrosecondsPerInvocation="332"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindPuzzlers" totalMilliseconds="109" invocations="738" avgMicrosecondsPerInvocation="147" maxMicrosecondsPerInvocation="4329" standardDeviationMicrosecondsPerInvocation="332"/>
-      <ClassProfile name="edu.umd.cs.findbugs.classfile.engine.ClassDataAnalysisEngine" totalMilliseconds="108" invocations="2494" avgMicrosecondsPerInvocation="43" maxMicrosecondsPerInvocation="3844" standardDeviationMicrosecondsPerInvocation="82"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.SwitchFallthrough" totalMilliseconds="108" invocations="738" avgMicrosecondsPerInvocation="146" maxMicrosecondsPerInvocation="5278" standardDeviationMicrosecondsPerInvocation="345"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.IncompatMask" totalMilliseconds="102" invocations="738" avgMicrosecondsPerInvocation="139" maxMicrosecondsPerInvocation="3689" standardDeviationMicrosecondsPerInvocation="288"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.InfiniteRecursiveLoop" totalMilliseconds="100" invocations="738" avgMicrosecondsPerInvocation="136" maxMicrosecondsPerInvocation="5321" standardDeviationMicrosecondsPerInvocation="353"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindDoubleCheck" totalMilliseconds="97" invocations="738" avgMicrosecondsPerInvocation="132" maxMicrosecondsPerInvocation="3560" standardDeviationMicrosecondsPerInvocation="271"/>
-      <ClassProfile name="edu.umd.cs.findbugs.detect.FindHEmismatch" totalMilliseconds="97" invocations="738" avgMicrosecondsPerInvocation="132" maxMicrosecondsPerInvocation="3920" standardDeviationMicrosecondsPerInvocation="270"/>
-    </FindBugsProfile>
+  <FindBugsSummary timestamp="Fri, 7 Jan 2022 20:34:25 -0600" total_classes="0" referenced_classes="0" total_bugs="400" total_size="0" num_packages="32" java_version="17.0.1" vm_version="17.0.1+12" cpu_seconds="160.44" clock_seconds="26.46" peak_mbytes="969.03" alloc_mbytes="4096.00" gc_seconds="0.52" priority_2="352" priority_1="48">
+    <FileStats path="contrib/bobyqa/BOBYQAOptimizer.java" bugCount="5" size="0" bugHash="02df92db8a0d632e485370f73e6e1b33"/>
+    <FileStats path="contrib/edu/princeton/eac/Grid.java" bugCount="5" size="0" bugHash="251eb162a72e2566121eefb876ee6d55"/>
+    <FileStats path="contrib/jama/CholeskyDecomposition.java" bugCount="1" size="0" bugHash="41d37c4a6cddaa062ff3ee500d7f0d16"/>
+    <FileStats path="contrib/jama/EigenvalueDecomposition.java" bugCount="3" size="0" bugHash="e85f17394ac825a376badd80f4bc9cb0"/>
+    <FileStats path="contrib/jama/LUDecomposition.java" bugCount="1" size="0" bugHash="2eddbcf35d071bdd723a580865367dba"/>
+    <FileStats path="contrib/jama/Matrix.java" bugCount="7" size="0" bugHash="89bc77b9b83dbfb0defe6129ac729905"/>
+    <FileStats path="contrib/jama/SingularValueDecomposition.java" bugCount="3" size="0" bugHash="fe455f3e47c78f262cef159696391903"/>
+    <FileStats path="contrib/jama/test/TestMatrix.java" bugCount="8" size="0" bugHash="ce2f1d8eb13041f55fbfea7b1dec9606"/>
+    <FileStats path="contrib/lbfgs/LBFGS.java" bugCount="2" size="0" bugHash="ab3e7aed1d2a3a25823e7b9409414e04"/>
+    <FileStats path="contrib/newuoa/NEWUOAOptimizer.java" bugCount="1" size="0" bugHash="296db4da1b5fc70a1451aa33993ecea1"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveAmberFF.java" bugCount="1" size="0" bugHash="4b227dd68bdd180d5fd9a9ab533f0bc3"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveAmberLJTerm.java" bugCount="3" size="0" bugHash="6799109d7c76449a4fa2ffdc256b40c8"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveConf.java" bugCount="1" size="0" bugHash="f32b3ff8d1baed2e2bc7040749d95bd0"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveCustomSpillage.java" bugCount="1" size="0" bugHash="3e092946378c0fa266a76092a65a44dd"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveCustomSpillage2.java" bugCount="1" size="0" bugHash="476f9d90c3d2b94b7f6fa23af2080f22"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveGUPTA.java" bugCount="3" size="0" bugHash="82b1c2c209ff0632d3bcb8cd0585adbd"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveLJFF.java" bugCount="1" size="0" bugHash="ad7b33751f95937e233d4eb8b818380b"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveMorse.java" bugCount="1" size="0" bugHash="bc8bfbae6b6c8399b2cc64ca809c38f4"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveParameters.java" bugCount="5" size="0" bugHash="1bf6412bc0df85ea1d7b1bdb962b4d47"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveSWGFF.java" bugCount="1" size="0" bugHash="e8418a28106055fac84dea9b28c0fe6f"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveSkalevalaCaller.java" bugCount="4" size="0" bugHash="ef101583b7fe14d885b1d14863c9c0af"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveUFF.java" bugCount="1" size="0" bugHash="8e89c0fd0db8e1e73a345bca50a01be1"/>
+    <FileStats path="org/ogolem/adaptive/BenchBerndGauss10D.java" bugCount="1" size="0" bugHash="35669d04df369d38e30ef81a293ccd0a"/>
+    <FileStats path="org/ogolem/adaptive/FMProfessPseudoPotential.java" bugCount="3" size="0" bugHash="3842a8c4a33109fe9ccc5e32768ac7a3"/>
+    <FileStats path="org/ogolem/adaptive/FixedValues.java" bugCount="1" size="0" bugHash="bf5633c8a55ec8f0f769c8e7fd632c6a"/>
+    <FileStats path="org/ogolem/adaptive/GenericCaller.java" bugCount="4" size="0" bugHash="7250c920f0700943c2932aad41c6208d"/>
+    <FileStats path="org/ogolem/adaptive/GenericNativeCaller.java" bugCount="1" size="0" bugHash="bab6bc17b6d78b2568588106939b3f5a"/>
+    <FileStats path="org/ogolem/adaptive/NumericalGradients.java" bugCount="1" size="0" bugHash="9e1c6c2e9ec5016913db1e9e6c4d7ca6"/>
+    <FileStats path="org/ogolem/adaptive/ParamGlobOptFactory.java" bugCount="3" size="0" bugHash="df04433f81800c2befba9325d9b062c9"/>
+    <FileStats path="org/ogolem/adaptive/ParameterSanityCheck.java" bugCount="2" size="0" bugHash="c5295bc7a34bd588707b20af611bce09"/>
+    <FileStats path="org/ogolem/adaptive/genericfitness/GenericFitnessFunction.java" bugCount="2" size="0" bugHash="41790b15ab0b7fa2a7a45357860276d2"/>
+    <FileStats path="org/ogolem/adaptive/genericfitness/ReferenceEnergyOrderData.java" bugCount="2" size="0" bugHash="de59de99384372514221a54bf47044f9"/>
+    <FileStats path="org/ogolem/adaptive/genericfitness/SerialBatchedPropertyCalculator.java" bugCount="2" size="0" bugHash="d077c70271bfd1dc2713934569eee5e6"/>
+    <FileStats path="org/ogolem/adaptive/genericfitness/SerialGenericFitnessTerm.java" bugCount="1" size="0" bugHash="e876cbb8beeca69d2c237d1596cc8a6c"/>
+    <FileStats path="org/ogolem/clusters/ClusterAnalyzation.java" bugCount="2" size="0" bugHash="6668d1917380dda7977eea533e64cf58"/>
+    <FileStats path="org/ogolem/clusters/MainThreadingClusterGlobOpt.java" bugCount="2" size="0" bugHash="2e3dbc32a658d59504b5210e8bc9ce37"/>
+    <FileStats path="org/ogolem/core/ADFCaller.java" bugCount="1" size="0" bugHash="7cf9a36c86b5178bc223c098b97befc3"/>
+    <FileStats path="org/ogolem/core/AbstractGradient.java" bugCount="3" size="0" bugHash="1b8a134fc1ffdc70baa39f0dcbc60c8b"/>
+    <FileStats path="org/ogolem/core/AdvancedGraphBasedDirMut.java" bugCount="2" size="0" bugHash="14799ea338ac6b1cb392b4e23dbb9328"/>
+    <FileStats path="org/ogolem/core/AlandGeometryXOver.java" bugCount="2" size="0" bugHash="f4b789e3083bbba04200ea2ba263bb4d"/>
+    <FileStats path="org/ogolem/core/BackendFactory.java" bugCount="2" size="0" bugHash="dc759bb64f6398f23b9fe277ee9f1760"/>
+    <FileStats path="org/ogolem/core/CartesianCoordinates.java" bugCount="15" size="0" bugHash="5e96798307218e592f67dc512f13ac7d"/>
+    <FileStats path="org/ogolem/core/CartesianToRigidCoordinates.java" bugCount="2" size="0" bugHash="4d9f18bac2872a7fc70670bd1e4f3325"/>
+    <FileStats path="org/ogolem/core/DirMutOptStrategies.java" bugCount="6" size="0" bugHash="d930ae57125307958f97eb20a964b6a3"/>
+    <FileStats path="org/ogolem/core/DirMutPointProviders.java" bugCount="10" size="0" bugHash="bc794c3a534d23d5db86541c8f3ade10"/>
+    <FileStats path="org/ogolem/core/EnvironmentCartesCoordinates.java" bugCount="1" size="0" bugHash="5d11936f9b8d67814025e36b6fc2f9a7"/>
+    <FileStats path="org/ogolem/core/FullyCartesianCoordinates.java" bugCount="1" size="0" bugHash="ad29db0f49034b25b89a0307c1208579"/>
+    <FileStats path="org/ogolem/core/Geometry.java" bugCount="2" size="0" bugHash="99cbd9981b68b7373f20579947a15712"/>
+    <FileStats path="org/ogolem/core/GeometryInitializationToGenericAdaptor.java" bugCount="1" size="0" bugHash="7d5dc30350db7877a7f3fd37b025665e"/>
+    <FileStats path="org/ogolem/core/GlobOptAlgoFactory.java" bugCount="2" size="0" bugHash="a5412ca381753f4e879f499fdf17d3a5"/>
+    <FileStats path="org/ogolem/core/GlobOptAtomics.java" bugCount="2" size="0" bugHash="0b4fe53f3bc6cf9fcdd8f704901a39a0"/>
+    <FileStats path="org/ogolem/core/GlobalConfig.java" bugCount="3" size="0" bugHash="f7e048eae720cce80cd6dcd9d8a13a32"/>
+    <FileStats path="org/ogolem/core/Gradient.java" bugCount="3" size="0" bugHash="b381ba47e2c3bf581e24d323edae32c2"/>
+    <FileStats path="org/ogolem/core/GraphBasedDirMut.java" bugCount="4" size="0" bugHash="f26cca80b8083f6a0afdabe54f2d22f0"/>
+    <FileStats path="org/ogolem/core/GraphDiversityCheck.java" bugCount="4" size="0" bugHash="7859ebb25e25b9e2d62eee64783b69e8"/>
+    <FileStats path="org/ogolem/core/GridCollisionDetection.java" bugCount="1" size="0" bugHash="021915ab1d78d8f9d778ebf46e1cb33f"/>
+    <FileStats path="org/ogolem/core/GulpCaller.java" bugCount="1" size="0" bugHash="f1b5eb5b2926fa5be6f26977d11b629a"/>
+    <FileStats path="org/ogolem/core/Input.java" bugCount="1" size="0" bugHash="05707eb1ba0dc146bedcadc2499df227"/>
+    <FileStats path="org/ogolem/core/InverseNewtonAdapter.java" bugCount="1" size="0" bugHash="df75f2ea9acd9a583e606f1170e1a25f"/>
+    <FileStats path="org/ogolem/core/LJNeighborNicheComp.java" bugCount="7" size="0" bugHash="c3973b2ff01fa512ad9e4f4bf1b63cab"/>
+    <FileStats path="org/ogolem/core/LJProjNicheComp.java" bugCount="1" size="0" bugHash="bb6312127105e6b18e5fe8344ebab35d"/>
+    <FileStats path="org/ogolem/core/LocOptFactory.java" bugCount="2" size="0" bugHash="09d2d38c5998592ae2000d75684a5a8a"/>
+    <FileStats path="org/ogolem/core/Molecule.java" bugCount="4" size="0" bugHash="b23876898cc3044f2423079f1ad41246"/>
+    <FileStats path="org/ogolem/core/PeriodicCoordinates.java" bugCount="13" size="0" bugHash="1d6e15e013fbd02e19be29e4eeba007b"/>
+    <FileStats path="org/ogolem/core/PluggableDirMut.java" bugCount="2" size="0" bugHash="871c442a69b068905e380571450c49eb"/>
+    <FileStats path="org/ogolem/core/RigidBodyCoordinates.java" bugCount="1" size="0" bugHash="c70aaa7b339ccdd9dde017d65b750a63"/>
+    <FileStats path="org/ogolem/core/SimpleBondInfo.java" bugCount="2" size="0" bugHash="d5d37b23238f286eab8ec85d2fb3a19c"/>
+    <FileStats path="org/ogolem/core/SimpleEnvironment.java" bugCount="1" size="0" bugHash="6c6a93aafd17dac9291c73ee5f4ea5cd"/>
+    <FileStats path="org/ogolem/core/SingleGeomSpectralFitnessFunction.java" bugCount="2" size="0" bugHash="1f8977969eab840dbff6d58d37418bc7"/>
+    <FileStats path="org/ogolem/core/SnaefellsjoekullGeometryXOver.java" bugCount="2" size="0" bugHash="c1ddbd7c2d8f534e54c11a8331ee4530"/>
+    <FileStats path="org/ogolem/core/SurfaceDetection.java" bugCount="3" size="0" bugHash="039ece6a27c90dfd780c9b3dfc0c9382"/>
+    <FileStats path="org/ogolem/core/SurfaceDirectedMutation.java" bugCount="1" size="0" bugHash="0bf3f642475be1a96bac77d0a0a60d77"/>
+    <FileStats path="org/ogolem/core/TinkerMDCaller.java" bugCount="1" size="0" bugHash="e055063baf9481bd201a3978bf919133"/>
+    <FileStats path="org/ogolem/core/Topology.java" bugCount="33" size="0" bugHash="786ce2458ac0ba7bc8f1e5bea014e44e"/>
+    <FileStats path="org/ogolem/core/VinlandGeometryXOver.java" bugCount="1" size="0" bugHash="46c5d57668b498497b143ff4cf830821"/>
+    <FileStats path="org/ogolem/core/ZMatrix.java" bugCount="14" size="0" bugHash="fab4db437974bce461fe46fd6d3b41b5"/>
+    <FileStats path="org/ogolem/dimeranalyzer/MainDimerAnalyzer.java" bugCount="1" size="0" bugHash="9b22e33007125793bfe4a40110d515b3"/>
+    <FileStats path="org/ogolem/freqs/Frequencies.java" bugCount="3" size="0" bugHash="62fef1dc4772171057b2b71008924b98"/>
+    <FileStats path="org/ogolem/freqs/HarmonicFrequencyCalculator.java" bugCount="2" size="0" bugHash="82faffff93546344c2d159af60477a31"/>
+    <FileStats path="org/ogolem/generic/AbstractDefaultConfig.java" bugCount="1" size="0" bugHash="ac3227fca1970d2aabe909370ff044ab"/>
+    <FileStats path="org/ogolem/generic/BoundedGenericMutation.java" bugCount="2" size="0" bugHash="8c55bfcc973f17bf01d56034a7e20809"/>
+    <FileStats path="org/ogolem/generic/BoundedInitializer.java" bugCount="2" size="0" bugHash="c1bd19ca508fecfc1d01f7bd6149081a"/>
+    <FileStats path="org/ogolem/generic/GenericAbstractDarwin.java" bugCount="1" size="0" bugHash="4f1a97a1ac8346e5adb510b0b7fff311"/>
+    <FileStats path="org/ogolem/generic/GenericChainedFitnessFunc.java" bugCount="1" size="0" bugHash="ee15b8d534e0e5bcf268144c243aab4b"/>
+    <FileStats path="org/ogolem/generic/GenericChainedMutation.java" bugCount="2" size="0" bugHash="0da9c82db96761d66789db8248c8fdb3"/>
+    <FileStats path="org/ogolem/generic/GenericChainedXOver.java" bugCount="2" size="0" bugHash="33d1f75873bb4650351b99de00ab7964"/>
+    <FileStats path="org/ogolem/generic/GenericFitnessFunctionBackendWrapper.java" bugCount="3" size="0" bugHash="33b9501ff635601ba3b7aaeca642cd2a"/>
+    <FileStats path="org/ogolem/generic/GenericMultipleGlobOpt.java" bugCount="1" size="0" bugHash="d338a4dd0063c09a91956b62c49a33a2"/>
+    <FileStats path="org/ogolem/generic/GenericRelativePrescreeningLocOpt.java" bugCount="1" size="0" bugHash="964beea0b1d0bfb3dccce0b5338d140c"/>
+    <FileStats path="org/ogolem/generic/GenericStepChangingMut.java" bugCount="1" size="0" bugHash="7738b209a1cd52b7669628c8db4918fc"/>
+    <FileStats path="org/ogolem/generic/GenericStepChangingXOver.java" bugCount="1" size="0" bugHash="5fc0c557a49da3187a951fd4ae90e300"/>
+    <FileStats path="org/ogolem/generic/MultipleMutationWrapper.java" bugCount="1" size="0" bugHash="695242c17d2171df43d659ddf119ddcf"/>
+    <FileStats path="org/ogolem/generic/MultipleXOverWrapper.java" bugCount="1" size="0" bugHash="b5ae805ae8f6256e29896bbdbb2b9ee0"/>
+    <FileStats path="org/ogolem/generic/generichistory/GenericHistory.java" bugCount="1" size="0" bugHash="84bcd7d0f9aa3c99806b0948966d1aa9"/>
+    <FileStats path="org/ogolem/generic/genericpool/AbstractNicher.java" bugCount="1" size="0" bugHash="f0d4a33882257bb70222033cdaf748e4"/>
+    <FileStats path="org/ogolem/generic/genericpool/GenericPool.java" bugCount="7" size="0" bugHash="ffdfd0638436308a531b49b8fe17a508"/>
+    <FileStats path="org/ogolem/generic/genericpool/GenericPoolConfig.java" bugCount="6" size="0" bugHash="68d9e650fec16a8682d048ab66132763"/>
+    <FileStats path="org/ogolem/generic/genericpool/GenericPoolEntry.java" bugCount="2" size="0" bugHash="fdf2cd7a04a44fd938abf7f86a45d7c5"/>
+    <FileStats path="org/ogolem/generic/genericpool/SimpleNicher.java" bugCount="1" size="0" bugHash="be5e897cf3e412ea7fbc78a3052a4f6b"/>
+    <FileStats path="org/ogolem/generic/mpi/GenericMPIOptimization.java" bugCount="1" size="0" bugHash="47d96b15cb152ffa93d3437a8d95e28e"/>
+    <FileStats path="org/ogolem/generic/mpi/MPIInterface.java" bugCount="6" size="0" bugHash="e81f187009dea43b12badc24e37a2d17"/>
+    <FileStats path="org/ogolem/generic/stats/BasicDetailedBackend.java" bugCount="1" size="0" bugHash="48f6bf8cc61698154d74bec10ae51dfa"/>
+    <FileStats path="org/ogolem/generic/threading/GenericOGOLEMOptimization.java" bugCount="5" size="0" bugHash="9830887e0538a9d94140f73911bb4543"/>
+    <FileStats path="org/ogolem/generic/threading/GenericSeedTask.java" bugCount="4" size="0" bugHash="23b4d58a48ec1942cf1fa5fec86cee12"/>
+    <FileStats path="org/ogolem/generic/threading/GenericThreadDispatcher.java" bugCount="2" size="0" bugHash="8a39c2590fa60f5f5f4d208b9ded5518"/>
+    <FileStats path="org/ogolem/helpers/Fortune.java" bugCount="1" size="0" bugHash="7968b303821278d04652dbf660b86a4a"/>
+    <FileStats path="org/ogolem/io/ManipulationPrimitives.java" bugCount="2" size="0" bugHash="4143145ed83dc45b7b4f21eae7d78568"/>
+    <FileStats path="org/ogolem/locopt/GenericChainedLocalOpt.java" bugCount="1" size="0" bugHash="2190027f79220169ccd6f9ab4beef854"/>
+    <FileStats path="org/ogolem/locopt/apachehelpers/MultivariateToEnergyProvider.java" bugCount="2" size="0" bugHash="8cf6ccafa67fce5d8f19856994480c24"/>
+    <FileStats path="org/ogolem/locopt/apachehelpers/MultivariateToGradientProvider.java" bugCount="2" size="0" bugHash="3e46436ff8e6aa5b30058df6eed03abd"/>
+    <FileStats path="org/ogolem/locopt/numalhelpers/NumalFitnessWrapper.java" bugCount="1" size="0" bugHash="72be53b63c4b4e38fc08f50a381e322c"/>
+    <FileStats path="org/ogolem/locopt/numalhelpers/NumalGradientWrapper.java" bugCount="1" size="0" bugHash="d3375d17d2a24ba2334f874c4f2c5e7c"/>
+    <FileStats path="org/ogolem/macrobenchmarks/AdaptiveBenchmarkRunner.java" bugCount="1" size="0" bugHash="943a797a2bca2fe0a2a911a1af0d13db"/>
+    <FileStats path="org/ogolem/macrobenchmarks/ClusterBenchmarkRunner.java" bugCount="5" size="0" bugHash="7202e10000700411da5e5ec699e78e5a"/>
+    <FileStats path="org/ogolem/math/AbstractLookup.java" bugCount="1" size="0" bugHash="4cfc27bcee2452f96cac49cab417d3d8"/>
+    <FileStats path="org/ogolem/math/BoolSymmetricMatrixNoDiag.java" bugCount="1" size="0" bugHash="0e804d323472e227907f372fe42a1e00"/>
+    <FileStats path="org/ogolem/math/GenericLookup.java" bugCount="1" size="0" bugHash="8512e5f1b55988782746200a3f6f9cff"/>
+    <FileStats path="org/ogolem/math/ShortSymmetricMatrixNoDiag.java" bugCount="1" size="0" bugHash="60a0959bfe0e939174b9c7471d73198b"/>
+    <FileStats path="org/ogolem/math/SymmetricMatrixNoDiag.java" bugCount="1" size="0" bugHash="44f21be94da0a4a654e888799c708a66"/>
+    <FileStats path="org/ogolem/microbenchmarks/AckleyBench.java" bugCount="1" size="0" bugHash="ead17f79fea5c85a05993597e00419fa"/>
+    <FileStats path="org/ogolem/microbenchmarks/AckleyGradBench.java" bugCount="1" size="0" bugHash="44846ce50ba367db8be9b7a79c3747e6"/>
+    <FileStats path="org/ogolem/microbenchmarks/CartesianCoordinatesLibrary.java" bugCount="8" size="0" bugHash="72ae1230fb8d24a79addaa3ca3c14110"/>
+    <FileStats path="org/ogolem/microbenchmarks/LunacekBench.java" bugCount="1" size="0" bugHash="f42d5ddae0aa74876a7daed6112c0afb"/>
+    <FileStats path="org/ogolem/microbenchmarks/LunacekGradBench.java" bugCount="1" size="0" bugHash="0d8fa043f6abb5ba7a94f6555d0d1b0f"/>
+    <FileStats path="org/ogolem/microbenchmarks/Mat3x3MultBenchmark.java" bugCount="1" size="0" bugHash="549c3c3edb14196b96401502ee42a1b5"/>
+    <FileStats path="org/ogolem/microbenchmarks/MatMultBenchmark.java" bugCount="1" size="0" bugHash="d9e35f93640ef7c8cd0427d6aef4487f"/>
+    <FileStats path="org/ogolem/microbenchmarks/RastriginBench.java" bugCount="1" size="0" bugHash="43246fe94d88de2b287fac992db72965"/>
+    <FileStats path="org/ogolem/microbenchmarks/RastriginGradBench.java" bugCount="1" size="0" bugHash="d26298b31dc7944ed9aea563206bea30"/>
+    <FileStats path="org/ogolem/microbenchmarks/SchafferF7Bench.java" bugCount="1" size="0" bugHash="6e838732c26fe7289982f44b9bdfed17"/>
+    <FileStats path="org/ogolem/microbenchmarks/SchafferF7GradBench.java" bugCount="1" size="0" bugHash="b932145db59c0d57019ad731df00d16b"/>
+    <FileStats path="org/ogolem/microbenchmarks/SchwefelBench.java" bugCount="1" size="0" bugHash="779ac927581f86bc2f7935887cdf60dc"/>
+    <FileStats path="org/ogolem/microbenchmarks/SchwefelGradBench.java" bugCount="1" size="0" bugHash="21d8dc1c21f089a66263d0dc73be766a"/>
+    <FileStats path="org/ogolem/molecules/FixedValues.java" bugCount="1" size="0" bugHash="ec601e685efc4f4ce4ed0568ca770bf8"/>
+    <FileStats path="org/ogolem/properties/DegreeOfFreedom.java" bugCount="1" size="0" bugHash="fec6292573c41e8c244e6f1260c0df18"/>
+    <FileStats path="org/ogolem/properties/DipoleMoment.java" bugCount="1" size="0" bugHash="59eb1c113424230705da3f928a61882b"/>
+    <FileStats path="org/ogolem/properties/EnergyOrder.java" bugCount="1" size="0" bugHash="81598fc4916d91608650be053416e84d"/>
+    <FileStats path="org/ogolem/random/Lottery.java" bugCount="1" size="0" bugHash="032c7eb9748ba256b70f4fb5ba2306de"/>
+    <FileStats path="org/ogolem/rmi/AliveCheck.java" bugCount="2" size="0" bugHash="1ebb2b68d0f9ea6cfa99d0ab5af8e6b3"/>
+    <FileStats path="org/ogolem/rmi/GenericGlobOptJob.java" bugCount="5" size="0" bugHash="884a3aeeba47381c1310bc416ed55be6"/>
+    <FileStats path="org/ogolem/rmi/GenericInitTask.java" bugCount="1" size="0" bugHash="3bb4930d30a38b0989aa08dec9870305"/>
+    <FileStats path="org/ogolem/rmi/GenericProxyJob.java" bugCount="6" size="0" bugHash="2abf9ec0c14a61934a0e17e9388614fd"/>
+    <FileStats path="org/ogolem/rmi/GenericSeedTask.java" bugCount="2" size="0" bugHash="1ddfeb56a25805cb80b6258a457eaad6"/>
+    <FileStats path="org/ogolem/rmi/GenericThreadingClientBackend.java" bugCount="2" size="0" bugHash="d67d87c666f5f9dd74e15216890a7d46"/>
+    <FileStats path="org/ogolem/rmi/MainRMIClient.java" bugCount="2" size="0" bugHash="a184606b1c3d904776b3b0b0a0b14c2e"/>
+    <FileStats path="org/ogolem/rmi/MainRMIProxy.java" bugCount="2" size="0" bugHash="141fcffe9f3562132063772784bfeee0"/>
+    <FileStats path="org/ogolem/rmi/MainRMIThreader.java" bugCount="2" size="0" bugHash="2c23a4806088a39c9a396e935e7e27f1"/>
+    <FileStats path="org/ogolem/rmi/SwitchGlobOptJob.java" bugCount="2" size="0" bugHash="b24b45967470f11302076ba51fd28e4f"/>
+    <FileStats path="org/ogolem/rmi/SwitchGlobOptTask.java" bugCount="1" size="0" bugHash="887e92aa6a05d2fac5f91d4945c1937a"/>
+    <FileStats path="org/ogolem/spectral/FullSpectrum.java" bugCount="3" size="0" bugHash="c601d40b1011e75a3686d06d040f1ca8"/>
+    <FileStats path="org/ogolem/spectral/Peak.java" bugCount="1" size="0" bugHash="dd496e9a7e0ddacbd516ba2628134cfc"/>
+    <FileStats path="org/ogolem/spectral/SpectrumConfig.java" bugCount="1" size="0" bugHash="f3e56561bf1cc8474567d4593788124b"/>
+    <FileStats path="org/ogolem/switches/ColorPalette.java" bugCount="1" size="0" bugHash="739417c87f9651c85c5d9aff78256eb8"/>
+    <FileStats path="org/ogolem/switches/GlobOptAtomics.java" bugCount="1" size="0" bugHash="0eb750f6e878f3aa6f15089736017253"/>
+    <FileStats path="org/ogolem/switches/OrcaExcitor.java" bugCount="1" size="0" bugHash="8e18d2be89356f726a907b76a81367be"/>
+    <FileStats path="org/ogolem/switches/Switch.java" bugCount="2" size="0" bugHash="0c53eadc6b92c5ecf4423df108877a08"/>
+    <FileStats path="org/ogolem/switches/SwitchWriter.java" bugCount="2" size="0" bugHash="23f4fd3f95a2d898c5ebea7f0c08985c"/>
+    <FileStats path="org/ogolem/switches/SwitchesConfig.java" bugCount="3" size="0" bugHash="8ffd6fbb2f37d260b2fbeb58265e7c49"/>
+    <FileStats path="org/ogolem/switches/SwitchesInput.java" bugCount="1" size="0" bugHash="f4316f59cd0fc03e3133071ad5032ffc"/>
+    <FileStats path="org/ogolem/switches/Taboos.java" bugCount="1" size="0" bugHash="7c432d69c7bd5cc76f10c7e2955ebd05"/>
+    <FileStats path="org/ogolem/switches/TinkerLocOpt.java" bugCount="1" size="0" bugHash="37e9bbc4b679850db7514524bd91af1e"/>
+    <FindBugsProfile></FindBugsProfile>
   </FindBugsSummary>
   <ClassFeatures></ClassFeatures>
   <History></History>

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'com.github.johnrengelman.shadow' version '7.1.2'
-  id 'com.diffplug.spotless' version '6.1.0'
-  id 'com.github.spotbugs' version '5.0.3'
+  id 'com.diffplug.spotless' version '6.2.1'
+  id 'com.github.spotbugs' version '5.0.5'
   id 'java'
   id 'application'
 }
@@ -33,8 +33,8 @@ dependencies {
   implementation 'org.jgrapht:jgrapht-ext:1.3.1'
   implementation 'org.jgrapht:jgrapht-io:1.3.1'
   implementation 'org.scala-lang:scala-library:2.13.6'
-  implementation 'org.slf4j:slf4j-api:1.7.32'
-  implementation 'org.slf4j:slf4j-simple:1.7.32'
+  implementation 'org.slf4j:slf4j-api:1.7.35'
+  implementation 'org.slf4j:slf4j-simple:1.7.35'
   testImplementation(
     'org.junit.jupiter:junit-jupiter-api:5.8.2'
   )

--- a/src/org/ogolem/adaptive/AdaptiveSkalevalaCaller.java
+++ b/src/org/ogolem/adaptive/AdaptiveSkalevalaCaller.java
@@ -59,7 +59,7 @@ import org.ogolem.skalevala.Vainamoinen;
  */
 public class AdaptiveSkalevalaCaller extends AbstractAdaptiveBackend {
 
-  private static final long serialVersionUID = (long) 20150727;
+  private static final long serialVersionUID = (long) 20201228;
 
   private final int runotID;
   private final Runot runot;
@@ -132,14 +132,22 @@ public class AdaptiveSkalevalaCaller extends AbstractAdaptiveBackend {
     }
     final int charge = (int) fCharge;
 
+    final var symBonds = bonds.getFullBondMatrix();
+    final var symBuffer = symBonds.underlyingStorageBuffer();
+    int symBondsIdx = 0;
+    final var fullBondMatrix = new boolean[noOfAtoms][noOfAtoms];
+    for (int i = 0; i < noOfAtoms; i++) {
+      fullBondMatrix[i][i] = true; // mark self-bonds
+      for (int j = i + i; j < noOfAtoms; j++) {
+        fullBondMatrix[i][j] = symBuffer[symBondsIdx];
+        fullBondMatrix[j][i] = symBuffer[symBondsIdx];
+        symBondsIdx++;
+      }
+    }
+
     final org.ogolem.skalevala.CartesianCoordinates ca =
         new org.ogolem.skalevala.CartesianCoordinates(
-            cartes2Cartes(xyz1d, noOfAtoms),
-            atomTypes,
-            atomNos,
-            spin,
-            charge,
-            bonds.getFullBondMatrix());
+            cartes2Cartes(xyz1d, noOfAtoms), atomTypes, atomNos, spin, charge, fullBondMatrix);
 
     final double e = runot.energy(ca, p);
 
@@ -170,14 +178,22 @@ public class AdaptiveSkalevalaCaller extends AbstractAdaptiveBackend {
     }
     final int charge = (int) fCharge;
 
+    final var symBonds = bonds.getFullBondMatrix();
+    final var symBuffer = symBonds.underlyingStorageBuffer();
+    int symBondsIdx = 0;
+    final var fullBondMatrix = new boolean[noOfAtoms][noOfAtoms];
+    for (int i = 0; i < noOfAtoms; i++) {
+      fullBondMatrix[i][i] = true; // mark self-bonds
+      for (int j = i + i; j < noOfAtoms; j++) {
+        fullBondMatrix[i][j] = symBuffer[symBondsIdx];
+        fullBondMatrix[j][i] = symBuffer[symBondsIdx];
+        symBondsIdx++;
+      }
+    }
+
     final org.ogolem.skalevala.CartesianCoordinates ca =
         new org.ogolem.skalevala.CartesianCoordinates(
-            cartes2Cartes(xyz1d, noOfAtoms),
-            atomTypes,
-            atomNos,
-            spin,
-            charge,
-            bonds.getFullBondMatrix());
+            cartes2Cartes(xyz1d, noOfAtoms), atomTypes, atomNos, spin, charge, fullBondMatrix);
 
     final org.ogolem.skalevala.Gradient g = runot.gradient(ca, p);
 
@@ -192,8 +208,23 @@ public class AdaptiveSkalevalaCaller extends AbstractAdaptiveBackend {
       final BondInfo bonds) {
 
     if (!useCaching || c == null) {
+
+      final var noOfAtoms = cartes.getNoOfAtoms();
+      final var symBonds = bonds.getFullBondMatrix();
+      final var symBuffer = symBonds.underlyingStorageBuffer();
+      int symBondsIdx = 0;
+      final var fullBondMatrix = new boolean[noOfAtoms][noOfAtoms];
+      for (int i = 0; i < noOfAtoms; i++) {
+        fullBondMatrix[i][i] = true; // mark self-bonds
+        for (int j = i + i; j < noOfAtoms; j++) {
+          fullBondMatrix[i][j] = symBuffer[symBondsIdx];
+          fullBondMatrix[j][i] = symBuffer[symBondsIdx];
+          symBondsIdx++;
+        }
+      }
+
       // initialize c fresh
-      c = createCartesStub(cartes, bonds.getFullBondMatrix());
+      c = createCartesStub(cartes, fullBondMatrix);
     }
 
     if (p == null) {
@@ -223,8 +254,23 @@ public class AdaptiveSkalevalaCaller extends AbstractAdaptiveBackend {
       final double[] grad) {
 
     if (!useCaching || c == null) {
+
+      final var noOfAtoms = cartes.getNoOfAtoms();
+      final var symBonds = bonds.getFullBondMatrix();
+      final var symBuffer = symBonds.underlyingStorageBuffer();
+      int symBondsIdx = 0;
+      final var fullBondMatrix = new boolean[noOfAtoms][noOfAtoms];
+      for (int i = 0; i < noOfAtoms; i++) {
+        fullBondMatrix[i][i] = true; // mark self-bonds
+        for (int j = i + i; j < noOfAtoms; j++) {
+          fullBondMatrix[i][j] = symBuffer[symBondsIdx];
+          fullBondMatrix[j][i] = symBuffer[symBondsIdx];
+          symBondsIdx++;
+        }
+      }
+
       // initialize c fresh
-      c = createCartesStub(cartes, bonds.getFullBondMatrix());
+      c = createCartesStub(cartes, fullBondMatrix);
     }
 
     if (p == null) {

--- a/src/org/ogolem/core/AdvancedGraphBasedDirMut.java
+++ b/src/org/ogolem/core/AdvancedGraphBasedDirMut.java
@@ -51,6 +51,7 @@ import org.ogolem.generic.GenericFitnessBackend;
 import org.ogolem.generic.GenericLocOpt;
 import org.ogolem.generic.GenericMutation;
 import org.ogolem.helpers.Tuple;
+import org.ogolem.math.BoolSymmetricMatrixNoDiag;
 
 /**
  * A directed mutation using a graph-based analysis of the cluster in question.
@@ -239,13 +240,13 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule, Geome
           (work.containsEnvironment() && envAware)
               ? CoordTranslation.checkForBondsIncludingEnvironment(work, blowBonds)
               : CoordTranslation.checkForBonds(work, blowBonds);
-      final boolean[][] full = fullBonds.getFullBondMatrix();
+
+      final BoolSymmetricMatrixNoDiag bondMat = fullBonds.getFullBondMatrix();
 
       if (DEBUG) {
-        System.out.println("DEBUG: Bonds with blow fator " + blowBonds);
-        for (final boolean[] fullRow : full) {
-          System.out.println(Arrays.toString(fullRow));
-        }
+        System.out.println("Bonds with blow factor " + blowBonds);
+        final boolean[] bondsBuffer = bondMat.underlyingStorageBuffer();
+        System.out.println(Arrays.toString(bondsBuffer));
       }
 
       // figure out the number of connections from each molecule to another one (do not count
@@ -264,7 +265,8 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule, Geome
           // not only is this easier, but it makes more sense for the application at hand
           // which is to find the least connected molecule
           for (int x = 0; x < noAtoms; x++) {
-            if (full[at][x]) {
+            if (at == x) continue;
+            if (bondMat.getElement(at, x)) {
               if (x < atCounter || x >= atCounter + ats) {
                 if (DEBUG) {
 
@@ -292,7 +294,8 @@ public class AdvancedGraphBasedDirMut implements GenericMutation<Molecule, Geome
           if (work.containsEnvironment() && envAware) {
             // count connections with the environment
             for (int x = 0; x < noEnvAtoms; x++) {
-              if (full[at][x + noAtoms]) {
+              if (at == x + noAtoms) continue;
+              if (bondMat.getElement(at, x + noAtoms)) {
                 connections[i]++;
               }
             }

--- a/src/org/ogolem/core/BondInfo.java
+++ b/src/org/ogolem/core/BondInfo.java
@@ -40,6 +40,8 @@ package org.ogolem.core;
 import java.io.Serializable;
 import java.util.List;
 import org.ogolem.generic.Copyable;
+import org.ogolem.math.BoolSymmetricMatrixNoDiag;
+import org.ogolem.math.ShortSymmetricMatrixNoDiag;
 
 /**
  * Interface describing what bond information implementations need to be capable of.
@@ -120,7 +122,7 @@ public interface BondInfo extends Serializable, Copyable {
    *
    * @return the bond matrix (boolean: bond yes/no)
    */
-  public boolean[][] getFullBondMatrix();
+  public BoolSymmetricMatrixNoDiag getFullBondMatrix();
 
   /**
    * Whether or not the return of the full bond information is fast or not.
@@ -134,7 +136,7 @@ public interface BondInfo extends Serializable, Copyable {
    *
    * @return the bond information as the above described shorts.
    */
-  public short[][] getBondInformation();
+  public ShortSymmetricMatrixNoDiag getBondInformation();
 
   /**
    * Translates this bond information to the input formatted one.

--- a/src/org/ogolem/core/CoordTranslation.java
+++ b/src/org/ogolem/core/CoordTranslation.java
@@ -1449,11 +1449,6 @@ public final class CoordTranslation {
     final int noOfAtoms = cartes.getNoOfAtoms();
     final SimpleBondInfo bonds = new SimpleBondInfo(noOfAtoms);
 
-    for (int i = 0; i < noOfAtoms; i++) {
-      // of course between two identical atoms there is a bond. kind of...
-      bonds.setBond(i, i, BondInfo.UNCERTAIN);
-    }
-
     final double[][] xyz = cartes.getAllXYZCoord();
     final short[] atomNos = cartes.getAllAtomNumbers();
 

--- a/src/org/ogolem/core/GlobalConfig.java
+++ b/src/org/ogolem/core/GlobalConfig.java
@@ -1,7 +1,7 @@
 /*
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2020, J. M. Dieterich and B. Hartke
+              2015-2022, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,7 @@ import org.ogolem.random.Lottery;
  * "constructor madness". Default values are provided.
  *
  * @author Johannes Dieterich
- * @version 2020-12-30
+ * @version 2022-02-05
  */
 public class GlobalConfig implements Configuration<Molecule, Geometry> {
 
@@ -412,8 +412,11 @@ public class GlobalConfig implements Configuration<Molecule, Geometry> {
         final StringBuffer sBuff = new StringBuffer();
         for (int l = iOffSet; l < iEndSet; l++) {
           sBuff.append("\t");
-          sBuff.append(geoConf.bonds.bondType(k, l));
-          assert (geoConf.bonds.bondType(k, l) == geoConf.bonds.bondType(l, k));
+          if (k == l) sBuff.append("S");
+          else {
+            sBuff.append(geoConf.bonds.bondType(k, l));
+            assert (geoConf.bonds.bondType(k, l) == geoConf.bonds.bondType(l, k));
+          }
         }
 
         configData.add(sBuff.toString());

--- a/src/org/ogolem/core/GraphBasedDirMut.java
+++ b/src/org/ogolem/core/GraphBasedDirMut.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.ogolem.generic.GenericMutation;
 import org.ogolem.helpers.Tuple;
+import org.ogolem.math.BoolSymmetricMatrixNoDiag;
 import org.ogolem.math.TrivialLinearAlgebra;
 import org.ogolem.random.Lottery;
 import org.ogolem.random.RandomUtils;
@@ -250,13 +251,12 @@ public class GraphBasedDirMut implements GenericMutation<Molecule, Geometry> {
     // create the connectivity matrix for the geometry (so in between molecules)
     // 1) get the full one
     final SimpleBondInfo fullBonds = CoordTranslation.checkForBonds(c, blowBonds);
-    final boolean[][] full = fullBonds.getFullBondMatrix();
+    final BoolSymmetricMatrixNoDiag bondMat = fullBonds.getFullBondMatrix();
 
     if (DEBUG) {
-      System.out.println("Bonds with blow fator " + blowBonds);
-      for (final boolean[] fullRow : full) {
-        System.out.println(Arrays.toString(fullRow));
-      }
+      System.out.println("Bonds with blow factor " + blowBonds);
+      final boolean[] bondsBuffer = bondMat.underlyingStorageBuffer();
+      System.out.println(Arrays.toString(bondsBuffer));
     }
 
     // figure out the number of connections from each molecule to another one (do not count internal
@@ -276,7 +276,8 @@ public class GraphBasedDirMut implements GenericMutation<Molecule, Geometry> {
         // not only is this easier, but it makes more sense for the application at hand
         // which is to find the least connected molecule
         for (int x = 0; x < c.getNoOfAtoms(); x++) {
-          if (full[at][x]) {
+          if (at == x) continue;
+          if (bondMat.getElement(at, x)) {
             if (x < atCounter || x >= atCounter + ats) {
               if (DEBUG) {
 

--- a/src/org/ogolem/core/Input.java
+++ b/src/org/ogolem/core/Input.java
@@ -1475,10 +1475,9 @@ public final class Input {
     // get the bond information
     final BondInfo bonds = new SimpleBondInfo(noAtomsTotal);
 
-    double dBlowBond = globConf.blowFacInitialBondDetect;
+    final double dBlowBond = globConf.blowFacInitialBondDetect;
 
-    int iEndSet = 0;
-
+    int atomOffset = 0;
     for (int i = 0; i < gc.noOfParticles; i++) {
 
       final MoleculeConfig mc = gc.geomMCs.get(i);
@@ -1487,14 +1486,12 @@ public final class Input {
         molBonds = CoordTranslation.checkForBonds(mc.toCartesians(), dBlowBond);
       }
 
-      final int iOffSet = iEndSet;
-      iEndSet += mc.noOfAtoms;
-
-      for (int j = iOffSet; j < iEndSet; j++) {
-        for (int k = iOffSet; k < iEndSet; k++) {
-          bonds.setBond(j, k, molBonds.bondType(j - iOffSet, k - iOffSet));
+      for (int j = 0; j < mc.noOfAtoms - 1; j++) {
+        for (int k = j + 1; k < mc.noOfAtoms; k++) {
+          bonds.setBond(j + atomOffset, k + atomOffset, molBonds.bondType(j, k));
         }
       }
+      atomOffset += mc.noOfAtoms;
     }
 
     gc.bonds = bonds;
@@ -1908,9 +1905,6 @@ public final class Input {
 
     // initialize with defaults
     final BondInfo bonds = new SimpleBondInfo(noOfAtoms);
-    for (int i = 0; i < noOfAtoms; i++) {
-      bonds.setBond(i, i, BondInfo.UNCERTAIN);
-    }
 
     // parse data and manipulate bonds
     for (final String data1 : data) {

--- a/src/org/ogolem/core/MixedLJForceField.java
+++ b/src/org/ogolem/core/MixedLJForceField.java
@@ -1,7 +1,7 @@
 /*
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2014, J. M. Dieterich
-              2015-2021, J. M. Dieterich and B. Hartke
+              2015-2022, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -48,7 +48,7 @@ import jdk.incubator.vector.VectorSpecies;
  * combination rules.
  *
  * @author Johannes Dieterich
- * @version 2021-04-22
+ * @version 2022-02-05
  */
 public class MixedLJForceField implements CartesianFullBackend {
 
@@ -297,6 +297,9 @@ public class MixedLJForceField implements CartesianFullBackend {
 
     final var vConst2 = DoubleVector.broadcast(SPECIES, 10000.0);
     final var one = DoubleVector.broadcast(SPECIES, 1);
+    final var negTwo = DoubleVector.broadcast(SPECIES, -2);
+    final var four = DoubleVector.broadcast(SPECIES, 4);
+    final var twentyFour = DoubleVector.broadcast(SPECIES, 24);
 
     // calculate all pair distances
     double dPotEnergyAdded = 0.0;
@@ -363,7 +366,7 @@ public class MixedLJForceField implements CartesianFullBackend {
             System.err.println(
                 "WARNING: LJ gradient: Atoms too close together, we take the cutoff potential.");
 
-          final var vCst1 = vEps.mul(4).mul(vT112_Hex).sub(10000);
+          final var vCst1 = vEps.mul(four).mul(vT112_Hex).sub(10000);
           final var vConst1 = vCst1.div(vSeam);
           final var vTmp = vConst1.mul(vDist).add(vConst2);
 
@@ -385,8 +388,8 @@ public class MixedLJForceField implements CartesianFullBackend {
           vPotEnergy = vPotEnergy.add(vVecTmp);
           // dTemp = -48.0 * dEpsilon * dInvRPow12 * dDistInv + 24.0 * dEpsilon * dInvRPow6 *
           // dDistInv;
-          final var vDistGrad = vEps.mul(vDistInv).mul(24);
-          final var vGrad2 = vInvRPow12.mul(vDistGrad).mul(-2);
+          final var vDistGrad = vEps.mul(vDistInv).mul(twentyFour);
+          final var vGrad2 = vInvRPow12.mul(vDistGrad).mul(negTwo);
           final var vGradTmp = vInvRPow6.fma(vDistGrad, vGrad2);
           final var vNegGradTmp = vGradTmp.neg();
 
@@ -412,15 +415,15 @@ public class MixedLJForceField implements CartesianFullBackend {
               vInvRPow12
                   .sub(vInvRPow6)
                   .mul(vEps)
-                  .mul(4); // XXX I bet one could do this with bitshifts
+                  .mul(four); // XXX I bet one could do this with bitshifts
           final var vEP = DoubleVector.fromArray(SPECIES, energyparts, j);
           final var vEPAdd = vEP.add(vVecTmp);
           vEPAdd.intoArray(energyparts, j);
           vPotEnergy = vPotEnergy.add(vVecTmp);
           // dTemp = -48.0 * dEpsilon * dInvRPow12 * dDistInv + 24.0 * dEpsilon * dInvRPow6 *
           // dDistInv;
-          final var vDistGrad = vEps.mul(vDistInv).mul(24);
-          final var vGrad2 = vInvRPow12.mul(vDistGrad).mul(-2);
+          final var vDistGrad = vEps.mul(vDistInv).mul(twentyFour);
+          final var vGrad2 = vInvRPow12.mul(vDistGrad).mul(negTwo);
           final var vGradTmp = vInvRPow6.fma(vDistGrad, vGrad2);
           final var vNegGradTmp = vGradTmp.neg();
 

--- a/src/org/ogolem/core/NorwayGeometryMutation.java
+++ b/src/org/ogolem/core/NorwayGeometryMutation.java
@@ -379,7 +379,10 @@ public class NorwayGeometryMutation implements GenericMutation<Molecule, Geometr
           countTotalFailed++;
           if (DEBUG) {
             System.out.println("DEBUG: At least one collision detected.");
+            collInfo.resizeDistsAndClearState(noAtoms);
+            colldetect.checkForCollision(cartesCache, blowColl, mutated.getBondInfo(), collInfo);
             final List<CollisionInfo.Collision> colls = collInfo.getCollisions();
+            System.out.println("Colls length " + colls.size());
             colls.forEach(
                 (coll) -> {
                   System.out.println(

--- a/src/org/ogolem/core/Output.java
+++ b/src/org/ogolem/core/Output.java
@@ -45,7 +45,7 @@ import org.ogolem.io.OutputPrimitives;
  * All kind of output related features using the primitive I/O classes.
  *
  * @author Johannes Dieterich
- * @version 2020-08-11
+ * @version 2022-02-05
  */
 public final class Output {
 
@@ -72,7 +72,7 @@ public final class Output {
           "",
           "",
           "",
-          "Copyright (c) 2009-2020, J. M. Dieterich and B. Hartke",
+          "Copyright (c) 2009-2022, J. M. Dieterich and B. Hartke",
           "All rights reserved.",
           "",
           "Redistribution and use in source and binary forms, with or without",

--- a/src/org/ogolem/core/ScaTTM3FBackend.java
+++ b/src/org/ogolem/core/ScaTTM3FBackend.java
@@ -42,6 +42,7 @@ import static org.ogolem.core.Constants.*;
 import java.io.File;
 import java.util.Locale;
 import org.ogolem.io.OutputPrimitives;
+import org.ogolem.math.BoolSymmetricMatrixNoDiag;
 import org.ogolem.properties.DipoleMoment;
 import org.ogolem.scaTTM3F.TTM3F;
 
@@ -199,12 +200,16 @@ public class ScaTTM3FBackend implements CartesianFullBackend {
 
     if (simpleExtraTerm) {
 
-      final boolean[][] bondMat = bonds.getFullBondMatrix();
+      final BoolSymmetricMatrixNoDiag bondMat = bonds.getFullBondMatrix();
+      final boolean[] bondBuff = bondMat.underlyingStorageBuffer();
+      int bondsIdx = -1; // to offset
+
       boolean anythingFound = false;
       for (int i = 0; i < noAts - 1; i++) {
         for (int j = i + 1; j < noAts; j++) {
 
-          if (bondMat[i][j]) {
+          bondsIdx++;
+          if (bondBuff[bondsIdx]) {
             continue;
           } // this would not help if there would be a water collapsing in itself w/ an aritifically
           // low energy: never seen that though.
@@ -380,11 +385,16 @@ public class ScaTTM3FBackend implements CartesianFullBackend {
 
     if (simpleExtraTerm) {
 
-      final boolean[][] bondMat = bonds.getFullBondMatrix();
+      final BoolSymmetricMatrixNoDiag bondMat = bonds.getFullBondMatrix();
+      final boolean[] bondBuff = bondMat.underlyingStorageBuffer();
+      int bondsIdx = -1; // to offset
+
       for (int i = 0; i < noAts - 1; i++) {
         for (int j = i + 1; j < noAts; j++) {
 
-          if (bondMat[i][j]) {
+          bondsIdx++;
+
+          if (bondBuff[bondsIdx]) {
             continue;
           } // this would not help if there would be a water collapsing in itself w/ an aritifically
           // low energy: never seen that though.

--- a/src/org/ogolem/core/SkalevalaCaller.java
+++ b/src/org/ogolem/core/SkalevalaCaller.java
@@ -52,7 +52,7 @@ import org.ogolem.skalevala.Runot;
 class SkalevalaCaller implements CartesianFullBackend {
   // TODO debug, extend
   // the ID
-  private static final long serialVersionUID = (long) 20120103;
+  private static final long serialVersionUID = (long) 20201228;
 
   @Override
   public SkalevalaCaller copy() {
@@ -94,12 +94,25 @@ class SkalevalaCaller implements CartesianFullBackend {
       spin += iaSpins[i];
     }
 
+    final var symBonds = bonds.getFullBondMatrix();
+    final var symBuffer = symBonds.underlyingStorageBuffer();
+    int symBondsIdx = 0;
+    final var fullBondMatrix = new boolean[iNoOfAtoms][iNoOfAtoms];
+    for (int i = 0; i < iNoOfAtoms; i++) {
+      fullBondMatrix[i][i] = true; // mark self-bonds
+      for (int j = i + i; j < iNoOfAtoms; j++) {
+        fullBondMatrix[i][j] = symBuffer[symBondsIdx];
+        fullBondMatrix[j][i] = symBuffer[symBondsIdx];
+        symBondsIdx++;
+      }
+    }
+
     Configuration.printTimings_$eq(false);
     // System.out.println("DEBUG: EHNDO entering energy...");
     final Runot runot = new EHNDO();
     final org.ogolem.skalevala.CartesianCoordinates cartes =
         new org.ogolem.skalevala.CartesianCoordinates(
-            daXYZ, saAtomTypes, atomNos, spin, (int) fcharge, bonds.getFullBondMatrix());
+            daXYZ, saAtomTypes, atomNos, spin, (int) fcharge, fullBondMatrix);
     final EHNDOParameters params = new EHNDOParameters();
     params.initializeDefaults();
 
@@ -144,11 +157,24 @@ class SkalevalaCaller implements CartesianFullBackend {
       spin += iaSpins[i];
     }
 
+    final var symBonds = bonds.getFullBondMatrix();
+    final var symBuffer = symBonds.underlyingStorageBuffer();
+    int symBondsIdx = 0;
+    final var fullBondMatrix = new boolean[iNoOfAtoms][iNoOfAtoms];
+    for (int i = 0; i < iNoOfAtoms; i++) {
+      fullBondMatrix[i][i] = true; // mark self-bonds
+      for (int j = i + i; j < iNoOfAtoms; j++) {
+        fullBondMatrix[i][j] = symBuffer[symBondsIdx];
+        fullBondMatrix[j][i] = symBuffer[symBondsIdx];
+        symBondsIdx++;
+      }
+    }
+
     Configuration.printTimings_$eq(false);
     final Runot runot = new EHNDO();
     final org.ogolem.skalevala.CartesianCoordinates cartes =
         new org.ogolem.skalevala.CartesianCoordinates(
-            xyz, saAtomTypes, atomNos, spin, (int) fcharge, bonds.getFullBondMatrix());
+            xyz, saAtomTypes, atomNos, spin, (int) fcharge, fullBondMatrix);
     final EHNDOParameters params = new EHNDOParameters();
     params.initializeDefaults();
 

--- a/src/org/ogolem/core/TinkerCaller.java
+++ b/src/org/ogolem/core/TinkerCaller.java
@@ -136,6 +136,7 @@ class TinkerCaller extends AbstractLocOpt implements CartesianFullBackend {
     this.envIsRigid =
         (gTmp.containsEnvironment()) ? gTmp.getEnvironment().isEnvironmentRigid() : false;
 
+    final var bonds = globconf.geoConf.bonds.getFullBondMatrix();
     saTinkerSecondHalf = new String[noAtomsTotal + 1];
     saTinkerSecondHalf[0] = " ";
 
@@ -176,28 +177,24 @@ class TinkerCaller extends AbstractLocOpt implements CartesianFullBackend {
 
       // once more ugly java code! ;-)
       CartesianCoordinates cartes;
-      BondInfo bonds;
       if (gTmp.containsEnvironment()) {
         final Tuple<CartesianCoordinates, BondInfo> tup =
             gTmp.getCartesiansAndBondsWithEnvironment();
         cartes = tup.getObject1();
-        bonds = tup.getObject2();
       } else {
         cartes = gTmp.getCartesians();
-        bonds = gTmp.getBondInfo();
       }
-      final boolean[][] bondMat = bonds.getFullBondMatrix();
       final String[] atoms = cartes.getAllAtomTypes();
 
-      // now we act on the boolean[][] bond information
-      for (int i = 0; i < bondMat.length; i++) {
+      // now we act on the bond information
+      for (int i = 0; i < bonds.noCols(); i++) {
 
         if (atoms[i].equalsIgnoreCase("DM")) {
           // real dummy for TIP5P
           continue;
         }
 
-        for (int j = 0; j < bondMat.length; j++) {
+        for (int j = 0; j < bonds.noCols(); j++) {
 
           if (atoms[j].equalsIgnoreCase("DM")) {
             // real dummy for TIP5P
@@ -216,7 +213,7 @@ class TinkerCaller extends AbstractLocOpt implements CartesianFullBackend {
           if (i == j) {
             continue;
           }
-          if (bondMat[i][j]) {
+          if (bonds.getElement(i, j)) {
             // bond, add that to the connectivity info
             int k = j + 1;
             saTinkerSecondHalf[i + 1] += k + "\t";

--- a/src/org/ogolem/core/TinkerMDCaller.java
+++ b/src/org/ogolem/core/TinkerMDCaller.java
@@ -95,8 +95,8 @@ final class TinkerMDCaller extends AbstractLocOpt {
 
     this.useSolvation = useSolv;
 
-    final boolean[][] bonds = conf.geoConf.bonds.getFullBondMatrix();
-    saTinkerSecondHalf = new String[bonds.length + 1];
+    final var bonds = conf.geoConf.bonds.getFullBondMatrix();
+    saTinkerSecondHalf = new String[bonds.noCols() + 1];
     saTinkerSecondHalf[0] = " ";
 
     String[] saAuxInput;
@@ -116,7 +116,7 @@ final class TinkerMDCaller extends AbstractLocOpt {
     // read in, which parameters are to be taken
     sWhichParameters = saAuxInput[1].trim();
 
-    for (int i = 2; i < bonds.length + 2; i++) {
+    for (int i = 2; i < bonds.noCols() + 2; i++) {
       // get the force field parameter code in every single line
       saAuxInput[i] = saAuxInput[i].trim();
       saAuxInput[i] = saAuxInput[i].substring(saAuxInput[i].indexOf(" "));
@@ -132,18 +132,14 @@ final class TinkerMDCaller extends AbstractLocOpt {
     this.envIsRigid =
         (gTmp.containsEnvironment()) ? gTmp.getEnvironment().isEnvironmentRigid() : false;
 
-    // now we act on the boolean[][] bond information
-    for (int i = 0; i < bonds.length; i++) {
-      for (int j = 0; j < bonds.length; j++) {
-        if (i == j) {
-          // not specified in tinker
-        } else {
-          if (bonds[i][j]) {
+    // now we act on the bond information
+    for (int i = 0; i < bonds.noCols(); i++) {
+      for (int j = 0; j < bonds.noRows(); j++) {
+        if (i != j) {
+          if (bonds.getElement(i, j)) {
             // bond, add that to the connectivity info
             int k = j + 1;
             saTinkerSecondHalf[i + 1] = saTinkerSecondHalf[i + 1] + k + "\t";
-          } else {
-            // no bond, go on
           }
         }
       }

--- a/src/org/ogolem/core/UniversalFF.java
+++ b/src/org/ogolem/core/UniversalFF.java
@@ -185,15 +185,21 @@ public class UniversalFF implements CartesianFullBackend {
         if (atomNos[j] == 0) {
           continue;
         }
-        final short bond = bonds.bondType(i, j);
-        if (bond == BondInfo.UNCERTAIN) {
+        if (i == j) {
+          // capture self-self
           bonding[c1][c2] = 1;
           numBonds++;
-        } else if (bond == BondInfo.VDW) {
-          // vdW is no bond for us here
         } else {
-          bonding[c1][c2] = bond;
-          numBonds++;
+          final short bond = bonds.bondType(i, j);
+          if (bond == BondInfo.UNCERTAIN) {
+            bonding[c1][c2] = 1;
+            numBonds++;
+          } else if (bond == BondInfo.VDW) {
+            // vdW is no bond for us here
+          } else {
+            bonding[c1][c2] = bond;
+            numBonds++;
+          }
         }
         c2++;
       }

--- a/src/org/ogolem/math/BoolMatrix.java
+++ b/src/org/ogolem/math/BoolMatrix.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,62 +34,35 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-package org.ogolem.core;
+package org.ogolem.math;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.Serializable;
+import org.ogolem.generic.Copyable;
 
 /**
- * A collision info only able to store a single collision.
+ * An interface for matrices.
  *
  * @author Johannes Dieterich
- * @version 2015-07-23
+ * @version 2020-12-28
  */
-public class SingleCollisionInfo extends AbstractCollisionInfo {
-
-  private static final long serialVersionUID = (long) 20150720;
-
-  private int atom1;
-  private int atom2;
-  private double strength;
+public interface BoolMatrix extends Serializable, Copyable {
 
   @Override
-  public boolean reportCollision(final int atom1, final int atom2, final double strength) {
+  public BoolMatrix copy();
 
-    if (noCollisions > 0) {
-      System.err.println("Previous collision already stored in SingleCollisionInfo.");
-      return false;
-    }
+  public int noRows();
 
-    this.atom1 = atom1;
-    this.atom2 = atom2;
-    this.strength = strength;
-    noCollisions++;
-    System.out.println("Collision reported between " + atom1 + " and " + atom2);
+  public int noCols();
 
-    return true;
-  }
+  public void setElement(final int i, final int j, final boolean val);
 
-  @Override
-  public List<Collision> getCollisions() {
+  public boolean getElement(final int i, final int j);
 
-    System.out.println("NO COLLISIONS: " + noCollisions);
-
-    if (noCollisions == 0) {
-      return new ArrayList<>();
-    }
-
-    final Collision coll = new Collision(atom1, atom2, strength);
-    final List<Collision> colls = new ArrayList<>();
-    colls.add(coll);
-
-    return colls;
-  }
-
-  @Override
-  protected void cleanState() {
-    atom1 = -1;
-    atom2 = -1;
-    strength = -1.0;
-  }
+  /**
+   * Returns a direct reference to the underlying storage buffer.
+   *
+   * @return the underlying storage buffer. Size and indexing implementation dependent. Handle with
+   *     utmost care!
+   */
+  public boolean[] underlyingStorageBuffer();
 }

--- a/src/org/ogolem/math/BoolSymmetricMatrixNoDiag.java
+++ b/src/org/ogolem/math/BoolSymmetricMatrixNoDiag.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2020-2022, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,62 +34,85 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-package org.ogolem.core;
-
-import java.util.ArrayList;
-import java.util.List;
+package org.ogolem.math;
 
 /**
- * A collision info only able to store a single collision.
+ * A matrix implementation for a symmetric matrix without diagonal.
  *
  * @author Johannes Dieterich
- * @version 2015-07-23
+ * @version 2022-02-05
  */
-public class SingleCollisionInfo extends AbstractCollisionInfo {
+public final class BoolSymmetricMatrixNoDiag implements BoolMatrix {
 
-  private static final long serialVersionUID = (long) 20150720;
+  private static final long serialVersionUID = (long) 20220205;
 
-  private int atom1;
-  private int atom2;
-  private double strength;
+  private final int noRowsCols;
+  private final boolean[] buffer;
 
-  @Override
-  public boolean reportCollision(final int atom1, final int atom2, final double strength) {
+  public BoolSymmetricMatrixNoDiag(final int noRowsCols) {
+    assert (noRowsCols >= 0);
+    this.noRowsCols = noRowsCols;
+    this.buffer = new boolean[noRowsCols * (noRowsCols - 1) / 2];
+  }
 
-    if (noCollisions > 0) {
-      System.err.println("Previous collision already stored in SingleCollisionInfo.");
-      return false;
-    }
-
-    this.atom1 = atom1;
-    this.atom2 = atom2;
-    this.strength = strength;
-    noCollisions++;
-    System.out.println("Collision reported between " + atom1 + " and " + atom2);
-
-    return true;
+  private BoolSymmetricMatrixNoDiag(final BoolSymmetricMatrixNoDiag orig) {
+    assert (orig != null);
+    this.noRowsCols = orig.noRowsCols;
+    this.buffer = orig.buffer.clone();
   }
 
   @Override
-  public List<Collision> getCollisions() {
-
-    System.out.println("NO COLLISIONS: " + noCollisions);
-
-    if (noCollisions == 0) {
-      return new ArrayList<>();
-    }
-
-    final Collision coll = new Collision(atom1, atom2, strength);
-    final List<Collision> colls = new ArrayList<>();
-    colls.add(coll);
-
-    return colls;
+  public BoolSymmetricMatrixNoDiag copy() {
+    return new BoolSymmetricMatrixNoDiag(this);
   }
 
   @Override
-  protected void cleanState() {
-    atom1 = -1;
-    atom2 = -1;
-    strength = -1.0;
+  public int noRows() {
+    return noRowsCols;
+  }
+
+  @Override
+  public int noCols() {
+    return noRowsCols;
+  }
+
+  @Override
+  public void setElement(final int i, final int j, final boolean val) {
+
+    final int idx = idx(i, j);
+    buffer[idx] = val;
+  }
+
+  @Override
+  public boolean getElement(final int i, final int j) {
+
+    final int idx = idx(i, j);
+    return buffer[idx];
+  }
+
+  /** Returns the n*(n-1)/2 storage buffer where j > i always. */
+  @Override
+  public boolean[] underlyingStorageBuffer() {
+    return buffer;
+  }
+
+  public int idx(final int i, final int j) {
+
+    assert (i != j);
+    assert (i < noRowsCols);
+    assert (j < noRowsCols);
+
+    // we always assume j > i
+    final int row = Math.min(j, i);
+    final int col = Math.max(j, i);
+
+    final int idx =
+        (noRowsCols * (noRowsCols - 1) / 2)
+            - (noRowsCols - row) * ((noRowsCols - row) - 1) / 2
+            + col
+            - row
+            - 1;
+
+    return idx;
   }
 }

--- a/src/org/ogolem/math/Matrix.java
+++ b/src/org/ogolem/math/Matrix.java
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.ogolem.math;
 
 import java.io.Serializable;
+import org.ogolem.generic.Copyable;
 
 /**
  * An interface for matrices.
@@ -44,7 +45,10 @@ import java.io.Serializable;
  * @author Johannes Dieterich
  * @version 2020-12-21
  */
-public interface Matrix extends Serializable {
+public interface Matrix extends Serializable, Copyable {
+
+  @Override
+  public Matrix copy();
 
   public int noRows();
 

--- a/src/org/ogolem/math/ShortMatrix.java
+++ b/src/org/ogolem/math/ShortMatrix.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015, J. M. Dieterich and B. Hartke
+Copyright (c) 2020, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -34,62 +34,35 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-package org.ogolem.core;
+package org.ogolem.math;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.io.Serializable;
+import org.ogolem.generic.Copyable;
 
 /**
- * A collision info only able to store a single collision.
+ * An interface for matrices.
  *
  * @author Johannes Dieterich
- * @version 2015-07-23
+ * @version 2020-12-28
  */
-public class SingleCollisionInfo extends AbstractCollisionInfo {
-
-  private static final long serialVersionUID = (long) 20150720;
-
-  private int atom1;
-  private int atom2;
-  private double strength;
+public interface ShortMatrix extends Serializable, Copyable {
 
   @Override
-  public boolean reportCollision(final int atom1, final int atom2, final double strength) {
+  public ShortMatrix copy();
 
-    if (noCollisions > 0) {
-      System.err.println("Previous collision already stored in SingleCollisionInfo.");
-      return false;
-    }
+  public int noRows();
 
-    this.atom1 = atom1;
-    this.atom2 = atom2;
-    this.strength = strength;
-    noCollisions++;
-    System.out.println("Collision reported between " + atom1 + " and " + atom2);
+  public int noCols();
 
-    return true;
-  }
+  public void setElement(final int i, final int j, final short val);
 
-  @Override
-  public List<Collision> getCollisions() {
+  public short getElement(final int i, final int j);
 
-    System.out.println("NO COLLISIONS: " + noCollisions);
-
-    if (noCollisions == 0) {
-      return new ArrayList<>();
-    }
-
-    final Collision coll = new Collision(atom1, atom2, strength);
-    final List<Collision> colls = new ArrayList<>();
-    colls.add(coll);
-
-    return colls;
-  }
-
-  @Override
-  protected void cleanState() {
-    atom1 = -1;
-    atom2 = -1;
-    strength = -1.0;
-  }
+  /**
+   * Returns a direct reference to the underlying storage buffer.
+   *
+   * @return the underlying storage buffer. Size and indexing implementation dependent. Handle with
+   *     utmost care!
+   */
+  public short[] underlyingStorageBuffer();
 }

--- a/src/org/ogolem/math/SymmetricMatrixNoDiag.java
+++ b/src/org/ogolem/math/SymmetricMatrixNoDiag.java
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2020, J. M. Dieterich and B. Hartke
+Copyright (c) 2020-2022, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -40,11 +40,11 @@ package org.ogolem.math;
  * A matrix implementation for a symmetric matrix without diagonal.
  *
  * @author Johannes Dieterich
- * @version 2020-12-21
+ * @version 2022-02-05
  */
-public class SymmetricMatrixNoDiag implements Matrix {
+public final class SymmetricMatrixNoDiag implements Matrix {
 
-  private static final long serialVersionUID = (long) 20201221;
+  private static final long serialVersionUID = (long) 20220205;
 
   private final int noRowsCols;
   private final double[] buffer;
@@ -53,6 +53,17 @@ public class SymmetricMatrixNoDiag implements Matrix {
     assert (noRowsCols >= 0);
     this.noRowsCols = noRowsCols;
     this.buffer = new double[noRowsCols * (noRowsCols - 1) / 2];
+  }
+
+  private SymmetricMatrixNoDiag(final SymmetricMatrixNoDiag orig) {
+    assert (orig != null);
+    this.noRowsCols = orig.noRowsCols;
+    this.buffer = orig.buffer.clone();
+  }
+
+  @Override
+  public SymmetricMatrixNoDiag copy() {
+    return new SymmetricMatrixNoDiag(this);
   }
 
   @Override
@@ -68,34 +79,14 @@ public class SymmetricMatrixNoDiag implements Matrix {
   @Override
   public void setElement(final int i, final int j, final double val) {
 
-    // we always assume j > i
-    final int row = Math.min(j, i);
-    final int col = Math.max(j, i);
-
-    final int idx =
-        (noRowsCols * (noRowsCols - 1) / 2)
-            - (noRowsCols - row) * ((noRowsCols - row) - 1) / 2
-            + col
-            - row
-            - 1;
-
+    final int idx = idx(i, j);
     buffer[idx] = val;
   }
 
   @Override
   public double getElement(final int i, final int j) {
 
-    // we always assume j > i
-    final int row = Math.min(j, i);
-    final int col = Math.max(j, i);
-
-    final int idx =
-        (noRowsCols * (noRowsCols - 1) / 2)
-            - (noRowsCols - row) * ((noRowsCols - row) - 1) / 2
-            + col
-            - row
-            - 1;
-
+    final int idx = idx(i, j);
     return buffer[idx];
   }
 
@@ -103,5 +94,25 @@ public class SymmetricMatrixNoDiag implements Matrix {
   @Override
   public double[] underlyingStorageBuffer() {
     return buffer;
+  }
+
+  public int idx(final int i, final int j) {
+
+    assert (i != j);
+    assert (i < noRowsCols);
+    assert (j < noRowsCols);
+
+    // we always assume j > i
+    final int row = Math.min(j, i);
+    final int col = Math.max(j, i);
+
+    final int idx =
+        (noRowsCols * (noRowsCols - 1) / 2)
+            - (noRowsCols - row) * ((noRowsCols - row) - 1) / 2
+            + col
+            - row
+            - 1;
+
+    return idx;
   }
 }

--- a/src/org/ogolem/switches/TinkerLocOpt.java
+++ b/src/org/ogolem/switches/TinkerLocOpt.java
@@ -43,13 +43,13 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import org.ogolem.core.CartesianCoordinates;
 import org.ogolem.core.StreamGobbler;
-// physical constants
+import org.ogolem.math.BoolSymmetricMatrixNoDiag;
 
 /**
  * Uses tinker for the local optimization of a set of cartesian coordinates.
  *
  * @author Johannes Dieterich
- * @version 2012-06-24
+ * @version 2012-12-28
  */
 final class TinkerLocOpt implements LocalOptimization {
 
@@ -97,17 +97,17 @@ final class TinkerLocOpt implements LocalOptimization {
      * first we need to figure out what atomic types we have, for that we
      * need to create the bonding information
      */
-    final boolean[][] baBonds =
-        LittleHelpers.bondingInfo(startCartes, dBlowBondFac).getFullBondMatrix();
+    final var baBonds = LittleHelpers.bondingInfo(startCartes, dBlowBondFac).getFullBondMatrix();
 
     if (bDebug) {
       System.out.println("DEBUG: Operating with bonding blow factor: " + dBlowBondFac);
       // we print the bonding info out
       System.out.println("DEBUG: Bonding info coming from TinkerLocOpt:");
-      for (int i = 0; i < baBonds.length; i++) {
+      for (int i = 0; i < baBonds.noCols(); i++) {
         String sBonds = " ";
-        for (int j = 0; j < baBonds[0].length; j++) {
-          sBonds += baBonds[i][j] + "  ";
+        for (int j = 0; j < baBonds.noCols(); j++) {
+          if (i == j) continue;
+          sBonds += baBonds.getElement(i, j) + "  ";
         }
         System.out.println("DEBUG: " + sBonds);
       }
@@ -310,7 +310,8 @@ final class TinkerLocOpt implements LocalOptimization {
     return endCartes;
   }
 
-  private static int[][] assignConnects(final String[] saAtoms, final boolean[][] baBonds) {
+  private static int[][] assignConnects(
+      final String[] saAtoms, final BoolSymmetricMatrixNoDiag baBonds) {
 
     final int[][] iaConnects = new int[saAtoms.length][];
 
@@ -319,10 +320,9 @@ final class TinkerLocOpt implements LocalOptimization {
       // collect connectivity
       final LinkedList<Integer> llTempConn = new LinkedList<>();
 
-      final boolean[] baPartBonds = baBonds[i];
-
-      for (int j = 0; j < baPartBonds.length; j++) {
-        final boolean bCurrBond = baPartBonds[j];
+      for (int j = 0; j < baBonds.noCols(); j++) {
+        if (i == j) continue;
+        final boolean bCurrBond = baBonds.getElement(i, j);
         if (bCurrBond && j != i) {
           llTempConn.add(j);
         }


### PR DESCRIPTION
Employ symmetric matrixces w/o a diagonal for both bond boolean and short bond type. This decreases memory demand for these quantities by half and decreases object allocation (and hence GC pressure) by (noAtoms - 1) times.

Improve bond marrying in simple environment through use of fill/arraycopy.

Improve MixedLJ by storing some constants in DoubleVectors to eschew implicit allocation in loop.

While there, update some dependencies.