### PR TITLE
Punch a lottery ticket for RMI client.

### DIFF
--- a/baseline.xml
+++ b/baseline.xml
@@ -1,783 +1,783 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<BugCollection version="4.7.3" sequence="0" timestamp="1668632269702" analysisTimestamp="1668632269702" release="">
+<BugCollection version="4.7.3" sequence="0" timestamp="1693861193515" analysisTimestamp="1693861193515" release="">
   <Project projectName="ogolem (spotbugsMain)">
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanner/ScannerCore.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanner/ScannerDoF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanner/ScannerConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanner/MainScanner.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanner/ScannerCore$State.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanner/ScannerDoF$ScannerDoFIterator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanalyzer/MainScAnalyzer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/scanalyzer/Analyzer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/familytree/MainFamilyTree.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/familytree/VisualizationConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/familytree/GeneticRecord.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/familytree/GeneticRecordComparator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericGlobalOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericSanityCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/DummyIndividualReader.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/ContinuousProblem.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/generichistory/GenericHistoryConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/generichistory/GeneticRecord.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/generichistory/GenericHistory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/stats/DetailedStatistics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/stats/BasicDetailedBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/stats/GenericDetailStatistics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/stats/DummyDetailedStats.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/NoCrossover.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericMultipleGlobOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/Configuration.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/AbstractDefaultConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/NoMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/Copyable.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericStepChangingMut.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericAbstractDarwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/MultipleXOverWrapper.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericStepChangingXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/MultipleMutationWrapper.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/DiscreteProblem.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericChainedFitnessFunc.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/AbstractProblem.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericAbsolutePrescreeningLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericPortugalCrossover.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericFitnessBackend$BOUNDSTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers$FitnessDiversityChecker.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers$PercentageFitnessDiversityChecker.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/DiversityChecker.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericPool.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors$FitnessWeightedParentSelector.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericPoolEntry.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericStatistics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericPoolConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/Niche.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors$RealFitnessWeightedParentSelector.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors$RandomParentSelector.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/AbstractNicher.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/ParentSelector.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/Nicher.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers$ScaledFitnessDiversityChecker.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/SimpleNicher.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/genericpool/NicheComputer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/mpi/GenericMPIOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/mpi/MPIInterface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/mpi/MPIInterface$MPIStatus.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericInitializer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/EmptySanityCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericNoLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericGlobalOptimizationFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/IndividualWriter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/Optimizable.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericChainedXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/BoundedInitializer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericFitnessFunctionBackendWrapper.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/SimpleGenericDarwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericOperator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericAbstractGradFreeLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericInitTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/TaskFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericInitTask$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericGlobOptTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericSeedTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericThreadDispatcher.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericOGOLEMOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericGlobOptTask$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/ObjectCache.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/threading/GenericSeedTask$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericRelativePrescreeningLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericHollandCrossover.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericFitnessBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericCrossover.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/BoundedGenericMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericAbstractLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/IndividualReader.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericDarwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericGermanyCrossover.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericFitnessFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericChainedMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/generic/GenericMutationAsXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/spectral/FullSpectrum.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/spectral/Peak.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/spectral/Spectrum.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/spectral/SpectrumConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/molecules/FixedValues.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/dimerizer/DimerizerConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/dimerizer/MainDimerizer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/dimerizer/DimerizerCore.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/TrivialLinearAlgebra.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/CosLookup.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/SymmetricMatrixNoDiag.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BoolSymmetricMatrixNoDiag.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/ExpLookup.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/LookupedFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/Matrix3x3.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/MathUtils.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BLASInterface$TRANSPOSE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/LAPACKInterface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BoolMatrix.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/AbstractLookup.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/GenericLookup.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/ShortSymmetricMatrixNoDiag.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/AcosLookup.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/SinLookup.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/FastFunctions.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/BLASInterface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/ShortMatrix.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/math/Matrix.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Backbone.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/ExcitorGateway.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/SidechainInter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/FixedValues.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Excitor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/LittleHelpers.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/SwitchesGlobOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/SwitchesConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/FitnessFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/OrcaExcitor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Color.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/ColorPalette.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Sidechain.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/TinkerLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/LocalOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Taboos.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/backbones/BrABBackbone.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/SwitchesDarwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/GermanyGlobOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/MainSwitches.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Output.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/SwitchesInput.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/ThreadingGlobOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/MopacLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/MopacExcitor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Switch.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/GlobalOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/GugaCI.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/MagicGlue.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/OpenBabelLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/SwitchWriter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/LocalOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/Tupel.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/HydroxylSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/AminoSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/MethylSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/AldehydeSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/NitroSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/ChlorideSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/HydrogenSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/ThiolSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/sidechains/CarboxylSide.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/ThreadingInits.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/switches/GlobOptAtomics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/clusters/ClusterAnalyzation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/clusters/MainThreadingClusterGlobOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/clusters/ClusterAnalyzation$Shape.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/clusters/MainClusters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/beswitched/MainBeswitched.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/general/MainOgolem.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/random/RNGenerator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/random/Lottery.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/random/StandardRNG.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/random/RandomUtils.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/CartesianCoordinatesLibrary.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/SchwefelBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/MixedLJFFGradientBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/WaterTTM3FLargeBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AligningBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/SchafferF7GradBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AdaptiveLJFFEnergyBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/UFFLargeMoleculeGradientBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/UFFLargeMoleculeEnergyBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/TIP3PGradientBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/UFFSurfaceGradientBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/LunacekBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AngleBench2.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/SchwefelGradBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/TIP4PGradientBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/RastriginBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/Mat3x3MultBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/LJFFEnergyBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/UFFFrozenSurfaceGradientBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/DihedralBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AdvPairwiseCDCheckOnlyBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/UFFFrozenSurfaceEnergyBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/MatMultBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/SingleMicroBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/TIP3PEnergyBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AdaptiveLJFFGradientBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AckleyGradBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AckleyBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/LunacekGradBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/WaterTTM3FSmallBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/TIP4PEnergyBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/SchafferF7Bench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/UFFSurfaceEnergyBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/MainMicroBenchmarks.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/NorwayPackingLJBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/RastriginGradBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/MixedLJLocOptBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/LJFFGradientBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AdvPairwiseCDBenchmark.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/MixedLJFFEnergyBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/microbenchmarks/AngleBench.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/MainPowerSpec.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/NumericalHessianCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/Frequencies.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/MainFreqs.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/Frequencies$Frequency.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/HarmonicFrequencyCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/FrequencyMethod.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/freqs/MinimumDecider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/atom2ogo/MainAtom2Ogo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/atom2ogo/MainOgo2Atom.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Newton.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryInitializationToGenericAdaptor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirectedMutation$CoordRanges.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GromacsCaller$QMENGINE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$COMOnlyCoordGrid.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SigmoidCollisionStrengthComputer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$GDMAdaptor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ParallelepipedSpace.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$CUTTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SurfaceDetection$SURFDETECTTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$WaterSpecificProvider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/InitIOException.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AdvancedGraphBasedDirMut.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Darwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FullyCartesianCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LaplandGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GraphBasedDirMut$GDMAdaptor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FixedValues.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LennardJonesFF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/StreamGobbler.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SimpleSurface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$RigidBodyOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/UNGlobOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PhenotypeGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Molecule.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/WaterAngleNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NewtonAdaptor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$EulerOnlyOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TinkerCaller$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LocalHeatLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CartesianFullBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/OpenBabelCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MainOGOLEM.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AdvancedPairWise.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/IcelandGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/RigidBodyBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LocalHeatGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionDetectionEngine.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloMutation$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AtomConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/HydrogenBondNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryInit$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$OptimizeFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GermanyGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FitnessFunctionFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GulpCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/OrbitSpace.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DistanceCalc.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryWriter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobOptAlgoFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SerialException.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIP3PForceField.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIP4PForceField.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MergingPhenoXOver$MergingPhenoConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/BondInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PenaltyLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirectedMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SimpleBondInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ExternalLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/QuantumEspressoCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Environment$ENVIRONMENTTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/UniversalFF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/RandomizedGeomInit.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/EnvironmentFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TinkerMDCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPParameters$TIP3PParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AdvancedGraphBasedDirMut$MolConnComparator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/EnvironmentFactory$KIND.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPParameters$TIP4P_2005.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ChainedNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Surface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/InverseNewtonAdapter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SingleCollisionInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FoehrGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/HackySurfaceAdsorptionBiaser.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$EnergyOnlyEvaluator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SimpleSeedingInit.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobalConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FinlandGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CP2KCaller$FUNCTIONAL.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ADFCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DummyLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryInit$INITSTYLE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionInfo$Collision.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ConvergenceException.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/OpenBabelCaller$FORCEFIELD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ZMatrix.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PortugalMoleculeXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/InteractionTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPHelpers.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionDetection$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/VinlandGeometryXOver$MOVEMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AdditivePenaltyFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PackingInit.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CartesianCoordinates$ENVTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorrbottenGeometryXOver$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CoulombMatrixNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Input.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NAMDCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobOptAlgoFactory$MolGlobOptAlgoFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation$MODUS.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MNDOCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SurfaceDetection.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AlandGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SingleGeomSpectralFitnessFunction$FitnessFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/RigidBodyCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GermanyGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ElectrostaticTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryReader.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/EnvironmentCartesCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NumericalGradients.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/VASPCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$LotteryPointProvider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MopacCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$PointOptStrategy.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AllowedSpace.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryInitialization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloMoleculeMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MixedLJForceField.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MultiCollisionInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AbstractLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/BackendFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DFTBplusCaller$WHICHDRIVER.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GenericGeometryDarwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SurfaceDetectionEngine.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FFEngineWrapper.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPParameters$StandardTIP4PParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MolproCaller$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MNDOCaller$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CPMDCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DFTBplusCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GromacsCaller$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/WeightedGraph.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CoordTranslation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CartesianCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SingleGeomSpectralFitnessFunction$Coefficient.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorrbottenGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$EulerChanger.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DissociationDetection$DDTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TinkerCaller$METHOD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$FullExternalCoordGrid.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Gradient.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SurfaceDirectedMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LJNeighborNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Output.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LocOptFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TinkerCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SkalevalaCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPParameters$TIP4PParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MergingPhenoXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometryInit.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MoleculeUntangler.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Geometry.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PluggableDirMut.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TinkerMDCaller$METHOD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TinkerMDCaller$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SwedenGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ChainedCartesianFullBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PeriodicCoordTranslator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AdvancedGraphBasedDirMut$GDMConfiguration.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Constants.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/VinlandGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MopacCaller$METHOD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation$MUTMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CompressionMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MNDOCaller$METHOD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TwoStepLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$RigidBodyOptimization$GDMBOBYQAConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPHelpers$AntiColdFusionFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionStrengthComputer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Environment.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloExtOnlyGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GridCollisionDetection.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/InputSanityCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AbstractBondInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobalOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SphericalCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AtomicProperties.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GermanyMoleculeMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/ScaTTM3FBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CPMDCaller$FUNCTIONAL.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation$MOVEMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/StructuralData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SimpleEnvironment$FITMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobOptStatistics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AbstractGradient.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionDetection.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation$PACKDIM.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloExtOnlyGeometryMutation$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CoordRepresentationsNotCompatibleException.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$PointProvider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CollisionDetection$CDTYPE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/XChangeGeometryMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/EnvironmentFactory$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FirstInCenterPenalty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SphereSpace.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloExtOnlyGeometryMutation$MOVEMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobOptAtomics$CUTTINGMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation$HOWMANY.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DissociationDetection.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Topology.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AmberCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GromacsCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GermanyMoleculeXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorrbottenGeometryXOver$ROTATIONPLANE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GraphDiversityCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobalConfig$MOLMUTCHOICE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutPointProviders$AverageCOMDistProvider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LJProjNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CastException.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/HalfSphereSpace.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/Atom.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SimpleEnvironment.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MoleculeConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GeometrySanityCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CoordinateRepresentation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/LotriffCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$FullOptimization.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CP2KCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/AbstractCollisionInfo.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$OptConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/SingleGeomSpectralFitnessFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/TIPnPParameters$StandardTIP3PParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MergingPhenoXOver$OptimizeFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/InteriorMoleculeNicheComp.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MolproCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PortugalGeometryXOver.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GraphBasedDirMut$GDMBOBYQAConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MonteCarloMutation$MOVEMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/CartesianToRigidCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/PeriodicCoordinates.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GlobOptAtomics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/MolproCaller$METHOD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/DummyCollisionStrengthComputer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/core/GraphBasedDirMut.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/macrobenchmarks/BenchmarkRunner.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/macrobenchmarks/Helpers.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/macrobenchmarks/AdaptiveBenchmarkRunner.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/macrobenchmarks/Helpers$Rank0Filter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/macrobenchmarks/MainMacroBenchmarks.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/macrobenchmarks/ClusterBenchmarkRunner.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/TensorProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Energy.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/DipoleMoment.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Stability.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Property.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Density.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/VectorProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/ExcitationDifference.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/BulkModulus.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/GenericScalarProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Spectrum.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/GenericMatrixProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/GenericTensorProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/ExcitationEnergy.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/StressTensor.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/EnergyOrder.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/MatrixProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Forces.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/CellVolume.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/EnergyOrder$EnergyComparator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/Dipole.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/GenericVectorProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/DeltaGauge.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/DegreeOfFreedom.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/properties/ScalarProperty.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericInitTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/RMICommImpl.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend$GlobTaskFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/EmptyJob.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/AliveCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/ThreadingClientFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/AliveCheck$AliveChecker.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/SwitchGlobOptJob.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/MainRMIProxy.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/RMICodes$JOBSTATE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/Task.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend$GlobTaskFactory$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/Result.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/MainRMIThreader.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericGlobOptJob.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/ClientList.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericProxyJob.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/TaskQueue.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericGlobOptTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericSeedTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/MainRMIClient.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/SwitchGlobOptTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericProxyJob$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/RMICodes.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/JobFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/RMICommunication.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/ClientList$ClientCleaner.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/Job.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/MainOgolemRMI.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/SwitchInitTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/rmi/DummyTask.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/CopyableTuple.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/Tuple.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/IndexSort.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/StatisticUtils.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/Machine.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/Tuple4D.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/Tuple3D.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/helpers/Fortune.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/io/FixedValues.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/io/FileFilter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/io/InquiryPrimitives.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/io/ManipulationPrimitives.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/io/InputPrimitives.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/io/OutputPrimitives.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$Configuration$MOVEMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/heat/LocalHeatPulses.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$Configuration$CHOOSEMODE.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$Configuration.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/heat/MainLocalHeat.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$ForcesProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchSchwefels.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterWriter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/StaticGridNiches.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveGateway.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceStressTensorData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceInputData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceForcesData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/FitnessTermConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceDummyData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/SerialBatchedPropertyCalculator$PropertyBatch.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/PropertyCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/GenericFitnessTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/BatchedPropertyCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericTensorData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericMatrixData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/SerialGenericFitnessTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericVectorData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericScalarData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/EnergyCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/RefBulkModulusData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceDensityData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/PseudoPropertyCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferencePoint.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceDeltaGaugeData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/SerialBatchedPropertyCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceEnergyOrderData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGeomData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/GenericReferencePoint.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/RefCellVolumeData.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/genericfitness/GenericFitnessFunction.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveCachedBondTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericNativeCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterSanityCheck.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation$SubMode.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FixedValues.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericCaller$VectorCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/Analytics.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchBerndGauss10D.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchRastrigin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AbstractAdaptiveBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/DoubleMorse.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterGradient.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$DeltaGaugeProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveMorseTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveCustomSpillage2.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveGUPTA.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericCaller$MatrixCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveCustomSpillage.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$DensityProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericCaller$ScalarCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveBondedHarmonicTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ExternalLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchLunacek.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FitFuncToBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberDihedralTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AbstractAdaptivable.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/MainOgoAdaptive.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/SearchspaceCapturer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveOrcaCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/RangedFitFuncToBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveExternalCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/DummyFitness.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterInit.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/Adaptivable.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/Input.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveInteractionTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveLJFF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/NumericalGradients.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation$Mode.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberLJTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParamLocOptFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberAngleTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParamGlobOptFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveNewton.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/Output.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericNativeCaller$ScalarCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericCaller$TensorCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchSchafferF6.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveSWG2BodyTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/GenericParameterDarwin.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveSWG3BodyTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveSkalevalaCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveMorse.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$BulkModulusProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveCustomSpillage$WfnFilter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveMopacCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$CellVolumeProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$EnergyOrderProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveUFF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterDiversityCheckers$ParamsDiversityChecker.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveBackend.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ReferencePointLibrary.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchAckley.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveTotalEnergyShifter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$StressTensorProfessCalculator.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterReader.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveConf$StructureDataType.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveSWGFF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ArcticAdaptiveCrossover.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberFF.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/SearchspaceCapturer$SearchspacePoint.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberFF$AmberMath.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/ParameterDiversityCheckers.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptivePolaris.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchSchaffer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/RangedFitFuncToBackend$Range.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/BenchGriewangkRosenbrock.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/AdaptiveConf.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/parameters/MainParameters.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/tests/MainTests.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/XTBCaller$1.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/XTBCaller$OPTLEVEL.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/OrcaCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/XTBCaller$SUBDIRS.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/XTBCaller$METHOD.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/XTBCaller.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/interfaces/GenericInterface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/RNK1MinLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/BOBYQALocOpt$Adapter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/LBFGSLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/apachehelpers/MultivariateToGradientProvider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/apachehelpers/MultivariateToEnergyProvider.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/NEWUOALocOpt$Adapter.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/PraxisLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/numalhelpers/NumalGradientWrapper.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/numalhelpers/NumalFitnessWrapper.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/FIRELocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/FIRELocOpt$BestPoint.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/FIRELocOpt$Scr.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/CGLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/GenericChainedLocalOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/AbstractLocOptFactory.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/FIRELocOpt$FireConfig.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/NEWUOALocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/BOBYQALocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/locopt/FleminLocOpt.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/dimeranalyzer/MainDimerAnalyzer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/fft/MainFFTInterface.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/fft/Padder.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/ljreferences/Molpro.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/ljreferences/LittleHelpers.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/ljreferences/TwoBodyTerm.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/ljreferences/MainLJRefs.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/org/ogolem/ljreferences/Orca.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/LUDecomposition.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/util/Maths.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/test/TestMatrix.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/QRDecomposition.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/SingularValueDecomposition.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/CholeskyDecomposition.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/EigenvalueDecomposition.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/jama/Matrix.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/lbfgs/LBFGS.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/lbfgs/LBFGS$ExceptionWithIflag.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/lbfgs/LBFGS$Mcsrch.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/newuoa/TestNewUO.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/newuoa/NEWUOAOptimizer$ScopedPtr.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/newuoa/ChebyQuad.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/newuoa/NEWUOAOptimizer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/newuoa/NEWUOAMethod.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/edu/princeton/eac/Grid.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer$IntRef.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer$DoubleRef.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer$ScopedPtr.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/bobyqa/AbstractBOBYQAMethod.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/contrib/bobyqa/BOBYQAMethod.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/numal/AP_linemin_method.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/numal/Analytic_problems.class</Jar>
-    <Jar>/home/jmd/software/ogolem-development_jmd/build/classes/java/main/numal/AP_praxis_method.class</Jar>
-    <AuxClasspathEntry>/home/jmd/software/ogolem-development_jmd/libs/atomdroiduff-3.0.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/software/ogolem-development_jmd/libs/corrmd.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/software/ogolem-development_jmd/libs/evbqmdff.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/software/ogolem-development_jmd/libs/lionbench.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/software/ogolem-development_jmd/libs/scaTTM3F.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/software/ogolem-development_jmd/libs/skalevala.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.6.1/e4ba98f1d4b3c80ec46392f25e094a6a2e58fcbf/commons-math3-3.6.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-all/0.41/f7cd6a2803432288f7d082cd06e00e7f90509c8d/ejml-all-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil.netlib/native_ref-java/1.1/408c71ffbc3646dda7bee1e22bf19101e5e9ee90/native_ref-java-1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-ext/1.3.1/29e8262c9bce3f978b608de538f2367ae9192eb8/jgrapht-ext-1.3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-io/1.3.1/46b561ae08b49aad5967dd2f9310b3809a3e9e19/jgrapht-io-1.3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-core/1.3.1/2a60359a72bea12c2336400408cebd0254b63be/jgrapht-core-1.3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.scala-lang/scala3-library_3/3.1.0/c04dbffc2e8eb159dcc31e9db3fb2618de13cf0d/scala3-library_3-3.1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/2.0.3/c1c8dea1c7f350d15e0568a7d87abe629c7da1c9/slf4j-simple-2.0.3.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/2.0.3/deef7fc81f00bd5e6205bb097be1040b4094f007/slf4j-api-2.0.3.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-simple/0.41/c3b36475a6a380c2d17c160a687a929555b886da/ejml-simple-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fsparse/0.41/69f6f700bd7a87a0d011addd8dd32c5158568751/ejml-fsparse-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fdense/0.41/bf1300827846352d3981502fcbec6b9b824c8ff3/ejml-fdense-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-dsparse/0.41/a9f9d7a36a233736cf28998b2473e98df9e9f69/ejml-dsparse-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-ddense/0.41/782c80d4c3c8a3432c4641f24c177f336a360f9c/ejml-ddense-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-cdense/0.41/64e8604e2a93ceab09ebc3acdf98748765c1afaf/ejml-cdense-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-zdense/0.41/cb70da15c6d91d5c1960c2090bc263fa4aa32d84/ejml-zdense-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-core/0.41/92ac2bee332a5697c42e576b94d563ba8c25877c/ejml-core-0.41.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil/jniloader/1.1/4840f897eeb54d67ee14e478f8a45cc9937f3ce1/jniloader-1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil.netlib/core/1.1/839e9b8107e43741810e6cf66798ef15543e9f98/core-1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/net.sourceforge.f2j/arpack_combined_all/0.1/225619a060b42605b4d9fd4af11815664abf26eb/arpack_combined_all-0.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.jheaps/jheaps/0.10/4a85245d16284f555e94dd2a05b6de377f542e9a/jheaps-0.10.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/com.github.vlsi.mxgraph/jgraphx/3.9.8.1/e10723d4811701cc7247dcf0fdac5e5b5daaba17/jgraphx-3.9.8.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.antlr/antlr4-runtime/4.7.2/e27d8ab4f984f9d186f54da984a6ab1cccac755e/antlr4-runtime-4.7.2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-text/1.6/ba72cf0c40cf701e972fe7720ae844629f4ecca2/commons-text-1.6.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.scala-lang/scala-library/2.13.6/ed7a2f528c7389ea65746c22a01031613d98ab3d/scala-library-2.13.6.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-lang3/3.8.1/6505a72a097d9270f7a9e7bf42c4238283247755/commons-lang3-3.8.1.jar</AuxClasspathEntry>
-    <SrcDir>/home/jmd/software/ogolem-development_jmd/src/main/resources</SrcDir>
-    <SrcDir>/home/jmd/software/ogolem-development_jmd/src</SrcDir>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/familytree/VisualizationConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/familytree/MainFamilyTree.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/familytree/GeneticRecord.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/familytree/GeneticRecordComparator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/dimerizer/DimerizerConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/dimerizer/DimerizerCore.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/dimerizer/MainDimerizer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/molecules/FixedValues.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/heat/LocalHeatPulses.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$Configuration$MOVEMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$Configuration$CHOOSEMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/heat/MainLocalHeat.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/heat/LocalHeatPulses$Configuration.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/FixedValues.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/SwitchWriter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Backbone.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/OrcaExcitor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/MopacExcitor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/SidechainInter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Output.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/GermanyGlobOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/ExcitorGateway.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/MethylSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/AldehydeSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/NitroSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/CarboxylSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/HydrogenSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/ThiolSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/HydroxylSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/AminoSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/sidechains/ChlorideSide.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/GlobalOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/LocalOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/MainSwitches.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Switch.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Excitor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/FitnessFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/SwitchesDarwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/GlobOptAtomics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Taboos.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/backbones/BrABBackbone.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/LittleHelpers.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Tupel.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/OpenBabelLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Sidechain.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/SwitchesGlobOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/SwitchesConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/SwitchesInput.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/ColorPalette.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/ThreadingInits.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/MopacLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/TinkerLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/MagicGlue.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/LocalOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/GugaCI.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/Color.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/switches/ThreadingGlobOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloExtOnlyGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FixedValues.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CPMDCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NewtonAdaptor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Darwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryWriter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AbstractGradient.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ChainedCartesianFullBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SurfaceDirectedMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LennardJonesFF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorrbottenGeometryXOver$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MolproCaller$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AdditivePenaltyFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Surface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ParallelepipedSpace.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SerialException.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloMutation$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Geometry.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/OpenBabelCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GromacsCaller$QMENGINE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPParameters$TIP3PParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/XChangeGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Newton.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/WaterAngleNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$FullOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TinkerMDCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Constants.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryInit$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobOptAlgoFactory$MolGlobOptAlgoFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GermanyMoleculeXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CoordRepresentationsNotCompatibleException.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryInit$INITSTYLE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SingleGeomSpectralFitnessFunction$FitnessFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AtomicProperties.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AdvancedGraphBasedDirMut$GDMConfiguration.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AbstractCollisionInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MNDOCaller$METHOD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Environment.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPParameters$StandardTIP3PParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AbstractLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GridCollisionDetection.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LocalHeatGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Environment$ENVIRONMENTTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CoulombMatrixNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionInfo$Collision.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionStrengthComputer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PackingInit.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/VASPCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SimpleSurface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SurfaceDetectionEngine.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PortugalMoleculeXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/RigidBodyBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AtomConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SphereSpace.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$WaterSpecificProvider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$COMOnlyCoordGrid.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/StreamGobbler.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MopacCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionDetection$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ExternalLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/StructuralData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPHelpers$AntiColdFusionFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$RigidBodyOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SingleGeomSpectralFitnessFunction$Coefficient.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FitnessFunctionFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/QuantumEspressoCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TinkerCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GulpCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DummyCollisionStrengthComputer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Output.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CoordinateRepresentation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DFTBplusCaller$WHICHDRIVER.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation$MODUS.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TwoStepLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LotriffCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/InputSanityCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$PointOptStrategy.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CP2KCaller$FUNCTIONAL.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MergingPhenoXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIP3PForceField.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MultiCollisionInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/BackendFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ChainedNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PortugalGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SimpleSeedingInit.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SimpleBondInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/RandomizedGeomInit.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$EnergyOnlyEvaluator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LJNeighborNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MolproCaller$METHOD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GermanyMoleculeMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CartesianFullBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NumericalGradients.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobOptStatistics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Molecule.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AbstractBondInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LocOptFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/InteractionTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryInit.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TinkerMDCaller$METHOD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MopacCaller$METHOD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobalConfig$MOLMUTCHOICE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ZMatrix.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ADFCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SwedenGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobalOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SimpleEnvironment$FITMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CPMDCaller$FUNCTIONAL.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryInitialization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionDetectionEngine.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorrbottenGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NAMDCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FirstInCenterPenalty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CartesianToRigidCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/OpenBabelCaller$FORCEFIELD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GermanyGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/WeightedGraph.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AmberCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PeriodicCoordTranslator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$PointProvider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/VinlandGeometryXOver$MOVEMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MergingPhenoXOver$OptimizeFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirectedMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloExtOnlyGeometryMutation$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MainOGOLEM.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloMutation$MOVEMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TinkerMDCaller$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$EulerChanger.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Gradient.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ElectrostaticTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PeriodicCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MNDOCaller$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Input.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/UniversalFF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GromacsCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloMoleculeMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/EnvironmentFactory$KIND.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation$HOWMANY.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$AverageCOMDistProvider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GraphBasedDirMut$GDMAdaptor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/EnvironmentCartesCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/OrbitSpace.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobalConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation$PACKDIM.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPParameters$TIP4P_2005.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$LotteryPointProvider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PenaltyLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FinlandGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GromacsCaller$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CoordTranslation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirectedMutation$CoordRanges.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AdvancedGraphBasedDirMut.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Topology.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AdvancedGraphBasedDirMut$MolConnComparator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AdvancedPairWise.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MergingPhenoXOver$MergingPhenoConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SigmoidCollisionStrengthComputer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GraphBasedDirMut$GDMBOBYQAConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobOptAtomics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DummyLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AllowedSpace.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/EnvironmentFactory$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/Atom.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/HydrogenBondNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TinkerCaller$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/RigidBodyCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIP4PForceField.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorrbottenGeometryXOver$ROTATIONPLANE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$OptConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LaplandGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SingleGeomSpectralFitnessFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$EulerOnlyOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FFEngineWrapper.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$OptimizeFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionDetection.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SingleCollisionInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/VinlandGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FullyCartesianCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/EnvironmentFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GraphBasedDirMut.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SkalevalaCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$GDMAdaptor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders$FullExternalCoordGrid.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PluggableDirMut.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CP2KCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GenericGeometryDarwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarlo2DExtOnlyGeometryMutation$MOVEMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ScaTTM3FBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloExtOnlyGeometryMutation$MOVEMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobOptAlgoFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/ConvergenceException.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MixedLJForceField.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/InitIOException.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CompressionMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MNDOCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DissociationDetection.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LJProjNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GermanyGeometryMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPParameters$StandardTIP4PParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MonteCarloMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CartesianCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DissociationDetection$DDTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutOptStrategies$RigidBodyOptimization$GDMBOBYQAConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPHelpers.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/InverseNewtonAdapter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SurfaceDetection$SURFDETECTTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/IcelandGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CollisionDetection$CDTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/PhenotypeGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/AlandGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DFTBplusCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FoehrGeometryMutation$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryInitializationToGenericAdaptor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DirMutPointProviders.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/UNGlobOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometrySanityCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/BondInfo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SurfaceDetection.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/HackySurfaceAdsorptionBiaser.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SnaefellsjoekullGeometryXOver$CUTTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GeometryReader.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SphericalCoordinates.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GraphDiversityCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CartesianCoordinates$ENVTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/HalfSphereSpace.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MoleculeConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/NorwayGeometryMutation$MUTMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/GlobOptAtomics$CUTTINGMODE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/InteriorMoleculeNicheComp.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TIPnPParameters$TIP4PParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/LocalHeatLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/CastException.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MolproCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/SimpleEnvironment.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/MoleculeUntangler.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/TinkerCaller$METHOD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/FoehrGeometryXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/core/DistanceCalc.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/general/MainOgolem.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/macrobenchmarks/ClusterBenchmarkRunner.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/macrobenchmarks/Helpers.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/macrobenchmarks/BenchmarkRunner.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/macrobenchmarks/MainMacroBenchmarks.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/macrobenchmarks/Helpers$Rank0Filter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/macrobenchmarks/AdaptiveBenchmarkRunner.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/clusters/ClusterAnalyzation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/clusters/ClusterAnalyzation$Shape.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/clusters/MainClusters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/clusters/MainThreadingClusterGlobOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/io/FixedValues.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/io/ManipulationPrimitives.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/io/InquiryPrimitives.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/io/FileFilter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/io/InputPrimitives.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/io/OutputPrimitives.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/tests/MainTests.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/dimeranalyzer/MainDimerAnalyzer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/spectral/Peak.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/spectral/Spectrum.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/spectral/FullSpectrum.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/spectral/SpectrumConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/GenericLookup.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/Matrix3x3.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/TrivialLinearAlgebra.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/BoolMatrix.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/AcosLookup.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/MathUtils.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/CosLookup.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/SinLookup.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/AbstractLookup.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/LAPACKInterface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/ShortMatrix.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/ExpLookup.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/BoolSymmetricMatrixNoDiag.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/LookupedFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/BLASInterface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/Matrix.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/SymmetricMatrixNoDiag.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/BLASInterface$TRANSPOSE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/FastFunctions.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/math/ShortSymmetricMatrixNoDiag.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/ScalarProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/TensorProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/ExcitationEnergy.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/GenericMatrixProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/GenericVectorProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Property.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/DipoleMoment.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Density.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/DeltaGauge.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/GenericScalarProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/GenericTensorProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/MatrixProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/VectorProperty.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/EnergyOrder$EnergyComparator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/BulkModulus.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Forces.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/ExcitationDifference.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Energy.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/DegreeOfFreedom.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/StressTensor.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Spectrum.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/EnergyOrder.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Dipole.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/Stability.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/properties/CellVolume.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanalyzer/MainScAnalyzer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanalyzer/Analyzer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/beswitched/MainBeswitched.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/parameters/MainParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/HarmonicFrequencyCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/NumericalHessianCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/MainPowerSpec.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/MainFreqs.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/MinimumDecider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/Frequencies$Frequency.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/Frequencies.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/freqs/FrequencyMethod.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/fft/MainFFTInterface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/fft/Padder.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/Optimizable.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericStatistics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericPoolConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/Niche.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers$PercentageFitnessDiversityChecker.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/NicheComputer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers$ScaledFitnessDiversityChecker.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors$RealFitnessWeightedParentSelector.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/Nicher.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/AbstractNicher.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/ParentSelector.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericPool.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/SimpleNicher.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericPoolEntry.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers$FitnessDiversityChecker.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/DiversityChecker.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericDiversityCheckers.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors$RandomParentSelector.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/genericpool/GenericParentSelectors$FitnessWeightedParentSelector.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/SimpleGenericDarwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/IndividualWriter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/generichistory/GenericHistoryConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/generichistory/GenericHistory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/generichistory/GeneticRecord.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericOperator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericGlobalOptimizationFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/mpi/MPIInterface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/mpi/GenericMPIOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/mpi/MPIInterface$MPIStatus.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericFitnessFunctionBackendWrapper.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/AbstractProblem.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/EmptySanityCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/ContinuousProblem.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericHollandCrossover.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericStepChangingXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericGermanyCrossover.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/BoundedInitializer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericGlobalOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericAbstractLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericMutationAsXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericDarwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericAbsolutePrescreeningLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericAbstractDarwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericCrossover.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericChainedMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericRelativePrescreeningLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/DiscreteProblem.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/MultipleXOverWrapper.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericFitnessFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericChainedXOver.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericAbstractGradFreeLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericInitializer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericChainedFitnessFunc.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericNoLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericFitnessBackend$BOUNDSTYPE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericFitnessBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/AbstractDefaultConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericMultipleGlobOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/MultipleMutationWrapper.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/ObjectCache.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericGlobOptTask$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericSeedTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/TaskFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericOGOLEMOptimization.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericInitTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericSeedTask$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericThreadDispatcher.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericInitTask$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/threading/GenericGlobOptTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/DummyIndividualReader.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/NoCrossover.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericStepChangingMut.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/NoMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/Configuration.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericSanityCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/stats/DummyDetailedStats.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/stats/GenericDetailStatistics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/stats/BasicDetailedBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/stats/DetailedStatistics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/IndividualReader.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/Copyable.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/BoundedGenericMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericPortugalCrossover.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/generic/GenericMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/random/RNGenerator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/random/RandomUtils.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/random/Lottery.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/random/StandardRNG.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/TIP4PEnergyBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/SchafferF7Bench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/SchafferF7GradBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/SchwefelBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/LunacekBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/MixedLJFFEnergyBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AdaptiveLJFFEnergyBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/LunacekGradBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/UFFSurfaceGradientBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AligningBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AdaptiveLJFFGradientBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/SchwefelGradBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/TIP3PEnergyBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/LJFFGradientBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/MatMultBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/MixedLJLocOptBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AckleyBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/WaterTTM3FSmallBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/LJFFEnergyBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/DihedralBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AdvPairwiseCDCheckOnlyBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/SingleMicroBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AdvPairwiseCDBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/WaterTTM3FLargeBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AngleBench2.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/UFFLargeMoleculeGradientBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/RastriginGradBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/NorwayPackingLJBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/CartesianCoordinatesLibrary.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/Mat3x3MultBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/UFFSurfaceEnergyBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/UFFFrozenSurfaceGradientBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/MixedLJFFGradientBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/TIP3PGradientBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/UFFLargeMoleculeEnergyBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/MainMicroBenchmarks.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/TIP4PGradientBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/UFFFrozenSurfaceEnergyBenchmark.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AngleBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/AckleyGradBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/microbenchmarks/RastriginBench.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanner/ScannerDoF$ScannerDoFIterator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanner/ScannerDoF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanner/ScannerCore$State.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanner/ScannerConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanner/ScannerCore.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/scanner/MainScanner.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/ThreadingClientFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericSeedTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/RMICommImpl.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/MainRMIThreader.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericProxyJob.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/RMICodes.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/SwitchInitTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/Result.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/ClientList$ClientCleaner.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/MainRMIProxy.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericInitTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/SwitchGlobOptTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/MainRMIClient.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericProxyJob$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericGlobOptJob.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/DummyTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/EmptyJob.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/RMICodes$JOBSTATE.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/AliveCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend$GlobTaskFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/SwitchGlobOptJob.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/Task.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/MainOgolemRMI.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend$GlobTaskFactory$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/ClientList.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/RMICommunication.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericThreadingClientBackend$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/AliveCheck$AliveChecker.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/Job.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/JobFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/GenericGlobOptTask.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/rmi/TaskQueue.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/IndexSort.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/Machine.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/Fortune.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/Tuple4D.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/StatisticUtils.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/CopyableTuple.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/Tuple.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/helpers/Tuple3D.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FixedValues.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchSchaffer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveMorse.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveConf.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveMorseTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveGUPTA.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchBerndGauss10D.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/DummyFitness.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$CellVolumeProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericCaller$VectorCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/Analytics.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveExternalCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberFF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveUFF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveGateway.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveMopacCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericCaller$MatrixCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/SearchspaceCapturer$SearchspacePoint.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveInteractionTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$ForcesProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/MainOgoAdaptive.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberLJTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ExternalLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$EnergyOrderProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceStressTensorData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericVectorData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceInputData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/FitnessTermConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericScalarData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/GenericFitnessTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGeomData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/PseudoPropertyCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/SerialBatchedPropertyCalculator$PropertyBatch.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/RefBulkModulusData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/GenericFitnessFunction.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericMatrixData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/RefCellVolumeData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferencePoint.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceEnergyOrderData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceDeltaGaugeData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/PropertyCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceDummyData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/EnergyCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceForcesData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/BatchedPropertyCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/SerialGenericFitnessTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceDensityData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/GenericReferencePoint.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/SerialBatchedPropertyCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/genericfitness/ReferenceGenericTensorData.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterWriter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchSchwefels.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveOrcaCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveTotalEnergyShifter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/Output.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveLJFF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveCustomSpillage.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveCustomSpillage$WfnFilter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/StaticGridNiches.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/NumericalGradients.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$DensityProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParamLocOptFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchLunacek.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$DeltaGaugeProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberAngleTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveSWG3BodyTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveNewton.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveCachedBondTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterDiversityCheckers$ParamsDiversityChecker.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$BulkModulusProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveCustomSpillage2.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveParameters.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AbstractAdaptiveBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ArcticAdaptiveCrossover.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveSWG2BodyTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/Input.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericNativeCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FMProfessPseudoPotential$StressTensorProfessCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveBondedHarmonicTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ReferencePointLibrary.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation$Mode.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchSchafferF6.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericNativeCaller$ScalarCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterReader.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/RangedFitFuncToBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericParameterDarwin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/RangedFitFuncToBackend$Range.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveSWGFF.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchAckley.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterDiversityCheckers.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/Adaptivable.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/UnaryGaussianMutation$SubMode.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveConf$StructureDataType.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberFF$AmberMath.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParamGlobOptFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterSanityCheck.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchGriewangkRosenbrock.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/BenchRastrigin.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveSkalevalaCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/SearchspaceCapturer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericCaller$TensorCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/GenericCaller$ScalarCalculator.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AbstractAdaptivable.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterGradient.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/ParameterInit.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptiveAmberDihedralTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/FitFuncToBackend.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/AdaptivePolaris.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/adaptive/DoubleMorse.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/OrcaCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/XTBCaller$METHOD.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/XTBCaller$1.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/GenericInterface.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/XTBCaller$SUBDIRS.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/XTBCaller$OPTLEVEL.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/interfaces/XTBCaller.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/apachehelpers/MultivariateToEnergyProvider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/apachehelpers/MultivariateToGradientProvider.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/BOBYQALocOpt$Adapter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/FleminLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/CGLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/numalhelpers/NumalGradientWrapper.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/numalhelpers/NumalFitnessWrapper.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/RNK1MinLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/BOBYQALocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/NEWUOALocOpt$Adapter.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/FIRELocOpt$BestPoint.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/GenericChainedLocalOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/NEWUOALocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/FIRELocOpt$Scr.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/PraxisLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/LBFGSLocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/FIRELocOpt$FireConfig.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/AbstractLocOptFactory.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/locopt/FIRELocOpt.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/atom2ogo/MainAtom2Ogo.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/atom2ogo/MainOgo2Atom.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/ljreferences/Molpro.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/ljreferences/MainLJRefs.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/ljreferences/Orca.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/ljreferences/TwoBodyTerm.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/org/ogolem/ljreferences/LittleHelpers.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/numal/AP_praxis_method.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/numal/AP_linemin_method.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/numal/Analytic_problems.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/edu/princeton/eac/Grid.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/CholeskyDecomposition.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/test/TestMatrix.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/util/Maths.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/LUDecomposition.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/EigenvalueDecomposition.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/Matrix.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/QRDecomposition.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/jama/SingularValueDecomposition.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/newuoa/TestNewUO.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/newuoa/NEWUOAOptimizer$ScopedPtr.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/newuoa/ChebyQuad.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/newuoa/NEWUOAOptimizer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/newuoa/NEWUOAMethod.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer$ScopedPtr.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/bobyqa/AbstractBOBYQAMethod.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer$DoubleRef.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/bobyqa/BOBYQAMethod.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/bobyqa/BOBYQAOptimizer$IntRef.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/lbfgs/LBFGS$ExceptionWithIflag.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/lbfgs/LBFGS.class</Jar>
+    <Jar>/Users/jmd/software/ogolem-development/build/classes/java/main/contrib/lbfgs/LBFGS$Mcsrch.class</Jar>
+    <AuxClasspathEntry>/Users/jmd/software/ogolem-development/libs/atomdroiduff-3.0.0.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/software/ogolem-development/libs/corrmd.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/software/ogolem-development/libs/evbqmdff.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/software/ogolem-development/libs/lionbench.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/software/ogolem-development/libs/scaTTM3F.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/software/ogolem-development/libs/skalevala.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-math3/3.6.1/e4ba98f1d4b3c80ec46392f25e094a6a2e58fcbf/commons-math3-3.6.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-all/0.43/fd0cb2ceed902255bd58e898af8a754be9ba8be1/ejml-all-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil.netlib/native_ref-java/1.1/408c71ffbc3646dda7bee1e22bf19101e5e9ee90/native_ref-java-1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-ext/1.3.1/29e8262c9bce3f978b608de538f2367ae9192eb8/jgrapht-ext-1.3.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-io/1.3.1/46b561ae08b49aad5967dd2f9310b3809a3e9e19/jgrapht-io-1.3.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jgrapht/jgrapht-core/1.3.1/2a60359a72bea12c2336400408cebd0254b63be/jgrapht-core-1.3.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.scala-lang/scala3-library_3/3.1.0/c04dbffc2e8eb159dcc31e9db3fb2618de13cf0d/scala3-library_3-3.1.0.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-simple/2.0.7/bfa4d4dad645a5b11c022ae0043bac2df6cf16b5/slf4j-simple-2.0.7.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/2.0.7/41eb7184ea9d556f23e18b5cb99cad1f8581fc00/slf4j-api-2.0.7.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-simple/0.43/5da00c4c40eda416e855ee602678b194384cb417/ejml-simple-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fsparse/0.43/3fb64b83f3edbcf047f0ac8992164830f97e0db6/ejml-fsparse-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-fdense/0.43/f226c334951ed5dde97049427a71f874e811d67a/ejml-fdense-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-dsparse/0.43/a6693062f2b99871beb57190e77b6e9c2293e79f/ejml-dsparse-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-ddense/0.43/86d5a1db5b62a533a9a7201e41a8c1ffea0bd23f/ejml-ddense-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-cdense/0.43/7d82a9287d94f64213e5aba991b4a5c4d9169043/ejml-cdense-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-zdense/0.43/be701a6c7c32ad2ae00c37281062e88b84bb7790/ejml-zdense-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.ejml/ejml-core/0.43/98ea303e293db109db87800fbcf939a4e5c48e60/ejml-core-0.43.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil/jniloader/1.1/4840f897eeb54d67ee14e478f8a45cc9937f3ce1/jniloader-1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.fommil.netlib/core/1.1/839e9b8107e43741810e6cf66798ef15543e9f98/core-1.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/net.sourceforge.f2j/arpack_combined_all/0.1/225619a060b42605b4d9fd4af11815664abf26eb/arpack_combined_all-0.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.jheaps/jheaps/0.10/4a85245d16284f555e94dd2a05b6de377f542e9a/jheaps-0.10.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/com.github.vlsi.mxgraph/jgraphx/3.9.8.1/e10723d4811701cc7247dcf0fdac5e5b5daaba17/jgraphx-3.9.8.1.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.antlr/antlr4-runtime/4.7.2/e27d8ab4f984f9d186f54da984a6ab1cccac755e/antlr4-runtime-4.7.2.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-text/1.6/ba72cf0c40cf701e972fe7720ae844629f4ecca2/commons-text-1.6.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.scala-lang/scala-library/2.13.6/ed7a2f528c7389ea65746c22a01031613d98ab3d/scala-library-2.13.6.jar</AuxClasspathEntry>
+    <AuxClasspathEntry>/Users/jmd/.gradle/caches/modules-2/files-2.1/org.apache.commons/commons-lang3/3.8.1/6505a72a097d9270f7a9e7bf42c4238283247755/commons-lang3-3.8.1.jar</AuxClasspathEntry>
+    <SrcDir>/Users/jmd/software/ogolem-development/src/main/resources</SrcDir>
+    <SrcDir>/Users/jmd/software/ogolem-development/src</SrcDir>
   </Project>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="a3f060c702ef4433c38797afa650f7a3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
@@ -1130,7 +1130,7 @@
       <Message>In method contrib.jama.Matrix.read(BufferedReader)</Message>
     </Method>
     <Method classname="java.lang.Double" name="doubleValue" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.lang.Double" start="842" end="842" startBytecode="0" endBytecode="46" sourcefile="Double.java" sourcepath="java/lang/Double.java"/>
+      <SourceLine classname="java.lang.Double" start="1001" end="1001" startBytecode="0" endBytecode="46" sourcefile="Double.java" sourcepath="java/lang/Double.java"/>
       <Message>Called method Double.doubleValue()</Message>
     </Method>
     <Method classname="java.lang.Double" name="parseDouble" signature="(Ljava/lang/String;)J" isStatic="true" role="SHOULD_CALL">
@@ -1154,7 +1154,7 @@
       <Message>In method contrib.jama.Matrix.print(int, int)</Message>
     </Method>
     <Method classname="java.io.PrintWriter" name="&lt;init&gt;" signature="(Ljava/io/OutputStream;Z)V" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.io.PrintWriter" start="149" end="150" startBytecode="0" endBytecode="149" sourcefile="PrintWriter.java" sourcepath="java/io/PrintWriter.java"/>
+      <SourceLine classname="java.io.PrintWriter" start="151" end="152" startBytecode="0" endBytecode="149" sourcefile="PrintWriter.java" sourcepath="java/io/PrintWriter.java"/>
       <Message>Called method new java.io.PrintWriter(OutputStream, boolean)</Message>
     </Method>
     <SourceLine classname="contrib.jama.Matrix" primary="true" start="911" end="911" startBytecode="9" endBytecode="9" sourcefile="Matrix.java" sourcepath="contrib/jama/Matrix.java" relSourcepath="contrib/jama/Matrix.java">
@@ -1175,7 +1175,7 @@
       <Message>In method contrib.jama.Matrix.print(NumberFormat, int)</Message>
     </Method>
     <Method classname="java.io.PrintWriter" name="&lt;init&gt;" signature="(Ljava/io/OutputStream;Z)V" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.io.PrintWriter" start="149" end="150" startBytecode="0" endBytecode="149" sourcefile="PrintWriter.java" sourcepath="java/io/PrintWriter.java"/>
+      <SourceLine classname="java.io.PrintWriter" start="151" end="152" startBytecode="0" endBytecode="149" sourcefile="PrintWriter.java" sourcepath="java/io/PrintWriter.java"/>
       <Message>Called method new java.io.PrintWriter(OutputStream, boolean)</Message>
     </Method>
     <SourceLine classname="contrib.jama.Matrix" primary="true" start="941" end="941" startBytecode="9" endBytecode="9" sourcefile="Matrix.java" sourcepath="contrib/jama/Matrix.java" relSourcepath="contrib/jama/Matrix.java">
@@ -1382,7 +1382,7 @@
       <Message>In method contrib.jama.test.TestMatrix.main(String[])</Message>
     </Method>
     <Method classname="java.io.PrintWriter" name="&lt;init&gt;" signature="(Ljava/io/OutputStream;)V" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.io.PrintWriter" start="130" end="131" startBytecode="0" endBytecode="62" sourcefile="PrintWriter.java" sourcepath="java/io/PrintWriter.java"/>
+      <SourceLine classname="java.io.PrintWriter" start="132" end="133" startBytecode="0" endBytecode="62" sourcefile="PrintWriter.java" sourcepath="java/io/PrintWriter.java"/>
       <Message>Called method new java.io.PrintWriter(OutputStream)</Message>
     </Method>
     <SourceLine classname="contrib.jama.test.TestMatrix" primary="true" start="634" end="634" startBytecode="4104" endBytecode="4104" sourcefile="TestMatrix.java" sourcepath="contrib/jama/test/TestMatrix.java" relSourcepath="contrib/jama/test/TestMatrix.java">
@@ -1446,8 +1446,8 @@
       <Message>In method contrib.jama.test.TestMatrix.main(String[])</Message>
     </Method>
     <Type descriptor="Ljava/io/OutputStream;" role="TYPE_CLOSEIT">
-      <SourceLine classname="java.io.OutputStream" start="52" end="198" sourcefile="OutputStream.java" sourcepath="java/io/OutputStream.java">
-        <Message>At OutputStream.java:[lines 52-198]</Message>
+      <SourceLine classname="java.io.OutputStream" start="52" end="205" sourcefile="OutputStream.java" sourcepath="java/io/OutputStream.java">
+        <Message>At OutputStream.java:[lines 52-205]</Message>
       </SourceLine>
       <Message>Need to close java.io.OutputStream </Message>
     </Type>
@@ -1497,8 +1497,8 @@
     <ShortMessage>Unread field: should this field be static?</ShortMessage>
     <LongMessage>Unread field: contrib.lbfgs.LBFGS.stpmax; should this field be static?</LongMessage>
     <Class classname="contrib.lbfgs.LBFGS" primary="true">
-      <SourceLine classname="contrib.lbfgs.LBFGS" start="115" end="660" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
-        <Message>At LBFGS.java:[lines 115-660]</Message>
+      <SourceLine classname="contrib.lbfgs.LBFGS" start="117" end="664" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
+        <Message>At LBFGS.java:[lines 117-664]</Message>
       </SourceLine>
       <Message>In class contrib.lbfgs.LBFGS</Message>
     </Class>
@@ -1508,16 +1508,16 @@
       </SourceLine>
       <Message>Field contrib.lbfgs.LBFGS.stpmax</Message>
     </Field>
-    <SourceLine classname="contrib.lbfgs.LBFGS" primary="true" start="121" end="121" startBytecode="15" endBytecode="15" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
-      <Message>At LBFGS.java:[line 121]</Message>
+    <SourceLine classname="contrib.lbfgs.LBFGS" primary="true" start="124" end="124" startBytecode="15" endBytecode="15" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
+      <Message>At LBFGS.java:[line 124]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SS_SHOULD_BE_STATIC" priority="2" rank="18" abbrev="SS" category="PERFORMANCE" instanceHash="578323aa6c0460dd541b0f2263ca7e35" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Unread field: should this field be static?</ShortMessage>
     <LongMessage>Unread field: contrib.lbfgs.LBFGS.stpmin; should this field be static?</LongMessage>
     <Class classname="contrib.lbfgs.LBFGS" primary="true">
-      <SourceLine classname="contrib.lbfgs.LBFGS" start="115" end="660" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
-        <Message>At LBFGS.java:[lines 115-660]</Message>
+      <SourceLine classname="contrib.lbfgs.LBFGS" start="117" end="664" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
+        <Message>At LBFGS.java:[lines 117-664]</Message>
       </SourceLine>
       <Message>In class contrib.lbfgs.LBFGS</Message>
     </Class>
@@ -1527,8 +1527,8 @@
       </SourceLine>
       <Message>Field contrib.lbfgs.LBFGS.stpmin</Message>
     </Field>
-    <SourceLine classname="contrib.lbfgs.LBFGS" primary="true" start="115" end="115" startBytecode="8" endBytecode="8" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
-      <Message>At LBFGS.java:[line 115]</Message>
+    <SourceLine classname="contrib.lbfgs.LBFGS" primary="true" start="117" end="117" startBytecode="8" endBytecode="8" sourcefile="LBFGS.java" sourcepath="contrib/lbfgs/LBFGS.java" relSourcepath="contrib/lbfgs/LBFGS.java">
+      <Message>At LBFGS.java:[line 117]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="SF_SWITCH_FALLTHROUGH" priority="2" rank="17" abbrev="SF" category="STYLE" instanceHash="3e963c64684010ac502219296e11a715" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="484">
@@ -1817,13 +1817,13 @@
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
     <LongMessage>new org.ogolem.adaptive.AdaptiveLJFF(boolean, boolean, int, int, int, AdaptiveParameters, boolean, double, double, boolean, boolean) may expose internal representation by storing an externally mutable object into AdaptiveLJFF.params</LongMessage>
     <Class classname="org.ogolem.adaptive.AdaptiveLJFF" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveLJFF" start="60" end="1475" sourcefile="AdaptiveLJFF.java" sourcepath="org/ogolem/adaptive/AdaptiveLJFF.java" relSourcepath="org/ogolem/adaptive/AdaptiveLJFF.java">
-        <Message>At AdaptiveLJFF.java:[lines 60-1475]</Message>
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveLJFF" start="60" end="1476" sourcefile="AdaptiveLJFF.java" sourcepath="org/ogolem/adaptive/AdaptiveLJFF.java" relSourcepath="org/ogolem/adaptive/AdaptiveLJFF.java">
+        <Message>At AdaptiveLJFF.java:[lines 60-1476]</Message>
       </SourceLine>
       <Message>In class org.ogolem.adaptive.AdaptiveLJFF</Message>
     </Class>
     <Method classname="org.ogolem.adaptive.AdaptiveLJFF" name="&lt;init&gt;" signature="(ZZIIILorg/ogolem/adaptive/AdaptiveParameters;ZDDZZ)V" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.adaptive.AdaptiveLJFF" start="116" end="139" startBytecode="0" endBytecode="395" sourcefile="AdaptiveLJFF.java" sourcepath="org/ogolem/adaptive/AdaptiveLJFF.java" relSourcepath="org/ogolem/adaptive/AdaptiveLJFF.java"/>
+      <SourceLine classname="org.ogolem.adaptive.AdaptiveLJFF" start="117" end="140" startBytecode="0" endBytecode="395" sourcefile="AdaptiveLJFF.java" sourcepath="org/ogolem/adaptive/AdaptiveLJFF.java" relSourcepath="org/ogolem/adaptive/AdaptiveLJFF.java"/>
       <Message>In method new org.ogolem.adaptive.AdaptiveLJFF(boolean, boolean, int, int, int, AdaptiveParameters, boolean, double, double, boolean, boolean)</Message>
     </Method>
     <Field classname="org.ogolem.adaptive.AdaptiveLJFF" name="params" signature="Lorg/ogolem/adaptive/AdaptiveParameters;" isStatic="false" primary="true">
@@ -1835,8 +1835,8 @@
     <LocalVariable name="parameters" register="6" pc="127" role="LOCAL_VARIABLE_NAMED">
       <Message>Local variable named parameters</Message>
     </LocalVariable>
-    <SourceLine classname="org.ogolem.adaptive.AdaptiveLJFF" primary="true" start="134" end="134" startBytecode="127" endBytecode="127" sourcefile="AdaptiveLJFF.java" sourcepath="org/ogolem/adaptive/AdaptiveLJFF.java" relSourcepath="org/ogolem/adaptive/AdaptiveLJFF.java">
-      <Message>At AdaptiveLJFF.java:[line 134]</Message>
+    <SourceLine classname="org.ogolem.adaptive.AdaptiveLJFF" primary="true" start="135" end="135" startBytecode="127" endBytecode="127" sourcefile="AdaptiveLJFF.java" sourcepath="org/ogolem/adaptive/AdaptiveLJFF.java" relSourcepath="org/ogolem/adaptive/AdaptiveLJFF.java">
+      <Message>At AdaptiveLJFF.java:[line 135]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="EI_EXPOSE_REP2" priority="2" rank="18" abbrev="EI2" category="MALICIOUS_CODE" instanceHash="822a597f1ed44028175f3fb8b1842eb9" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="374">
@@ -2965,7 +2965,7 @@
       <Message>In method org.ogolem.core.AdvancedGraphBasedDirMut.mutate(Geometry)</Message>
     </Method>
     <Method classname="java.lang.Integer" name="valueOf" signature="(I)Ljava/lang/Integer;" isStatic="true" role="METHOD_CALLED">
-      <SourceLine classname="java.lang.Integer" start="1075" end="1077" startBytecode="0" endBytecode="90" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
+      <SourceLine classname="java.lang.Integer" start="1072" end="1074" startBytecode="0" endBytecode="90" sourcefile="Integer.java" sourcepath="java/lang/Integer.java"/>
       <Message>Called method Integer.valueOf(int)</Message>
     </Method>
     <SourceLine classname="org.ogolem.core.AdvancedGraphBasedDirMut" primary="true" start="343" end="343" startBytecode="914" endBytecode="914" sourcefile="AdvancedGraphBasedDirMut.java" sourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java" relSourcepath="org/ogolem/core/AdvancedGraphBasedDirMut.java">
@@ -4545,7 +4545,7 @@
       <Message>In method org.ogolem.core.Input.configureFromBlock(String[], String, boolean)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextLong" signature="()J" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="356" end="356" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="592" end="592" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextLong()</Message>
     </Method>
     <SourceLine classname="org.ogolem.core.Input" primary="true" start="1200" end="1200" startBytecode="6968" endBytecode="6968" sourcefile="Input.java" sourcepath="org/ogolem/core/Input.java" relSourcepath="org/ogolem/core/Input.java">
@@ -5397,13 +5397,13 @@
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
     <LongMessage>org.ogolem.core.SimpleEnvironment.getEnvironmentCartes() may expose internal representation by returning SimpleEnvironment.cartEnv</LongMessage>
     <Class classname="org.ogolem.core.SimpleEnvironment" primary="true">
-      <SourceLine classname="org.ogolem.core.SimpleEnvironment" start="56" end="826" sourcefile="SimpleEnvironment.java" sourcepath="org/ogolem/core/SimpleEnvironment.java" relSourcepath="org/ogolem/core/SimpleEnvironment.java">
-        <Message>At SimpleEnvironment.java:[lines 56-826]</Message>
+      <SourceLine classname="org.ogolem.core.SimpleEnvironment" start="56" end="825" sourcefile="SimpleEnvironment.java" sourcepath="org/ogolem/core/SimpleEnvironment.java" relSourcepath="org/ogolem/core/SimpleEnvironment.java">
+        <Message>At SimpleEnvironment.java:[lines 56-825]</Message>
       </SourceLine>
       <Message>In class org.ogolem.core.SimpleEnvironment</Message>
     </Class>
     <Method classname="org.ogolem.core.SimpleEnvironment" name="getEnvironmentCartes" signature="()Lorg/ogolem/core/CartesianCoordinates;" isStatic="false" primary="true">
-      <SourceLine classname="org.ogolem.core.SimpleEnvironment" start="721" end="721" startBytecode="0" endBytecode="46" sourcefile="SimpleEnvironment.java" sourcepath="org/ogolem/core/SimpleEnvironment.java" relSourcepath="org/ogolem/core/SimpleEnvironment.java"/>
+      <SourceLine classname="org.ogolem.core.SimpleEnvironment" start="720" end="720" startBytecode="0" endBytecode="46" sourcefile="SimpleEnvironment.java" sourcepath="org/ogolem/core/SimpleEnvironment.java" relSourcepath="org/ogolem/core/SimpleEnvironment.java"/>
       <Message>In method org.ogolem.core.SimpleEnvironment.getEnvironmentCartes()</Message>
     </Method>
     <Field classname="org.ogolem.core.SimpleEnvironment" name="cartEnv" signature="Lorg/ogolem/core/CartesianCoordinates;" isStatic="false" primary="true">
@@ -5412,8 +5412,8 @@
       </SourceLine>
       <Message>Field org.ogolem.core.SimpleEnvironment.cartEnv</Message>
     </Field>
-    <SourceLine classname="org.ogolem.core.SimpleEnvironment" primary="true" start="721" end="721" startBytecode="4" endBytecode="4" sourcefile="SimpleEnvironment.java" sourcepath="org/ogolem/core/SimpleEnvironment.java" relSourcepath="org/ogolem/core/SimpleEnvironment.java">
-      <Message>At SimpleEnvironment.java:[line 721]</Message>
+    <SourceLine classname="org.ogolem.core.SimpleEnvironment" primary="true" start="720" end="720" startBytecode="4" endBytecode="4" sourcefile="SimpleEnvironment.java" sourcepath="org/ogolem/core/SimpleEnvironment.java" relSourcepath="org/ogolem/core/SimpleEnvironment.java">
+      <Message>At SimpleEnvironment.java:[line 720]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE" priority="2" rank="13" abbrev="NP" category="STYLE" instanceHash="266a5923de44ebc6ad413414f264567e" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
@@ -7964,7 +7964,7 @@
       <Message>In method org.ogolem.generic.mpi.GenericMPIOptimization.runAsDrone(MPIInterface, long)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextLong" signature="()J" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="356" end="356" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="592" end="592" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextLong()</Message>
     </Method>
     <SourceLine classname="org.ogolem.generic.mpi.GenericMPIOptimization" primary="true" start="212" end="212" startBytecode="9" endBytecode="9" sourcefile="GenericMPIOptimization.java" sourcepath="org/ogolem/generic/mpi/GenericMPIOptimization.java" relSourcepath="org/ogolem/generic/mpi/GenericMPIOptimization.java">
@@ -8280,7 +8280,7 @@
       <Message>In method org.ogolem.helpers.Fortune.randomFortune()</Message>
     </Method>
     <Method classname="java.util.Random" name="nextInt" signature="(I)I" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="320" end="332" startBytecode="0" endBytecode="212" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="556" end="568" startBytecode="0" endBytecode="212" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextInt(int)</Message>
     </Method>
     <SourceLine classname="org.ogolem.helpers.Fortune" primary="true" start="62" end="62" startBytecode="13" endBytecode="13" sourcefile="Fortune.java" sourcepath="org/ogolem/helpers/Fortune.java" relSourcepath="org/ogolem/helpers/Fortune.java">
@@ -8833,7 +8833,7 @@
       <Message>In method new org.ogolem.microbenchmarks.AckleyBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.AckleyBench" primary="true" start="66" end="66" startBytecode="108" endBytecode="108" sourcefile="AckleyBench.java" sourcepath="org/ogolem/microbenchmarks/AckleyBench.java" relSourcepath="org/ogolem/microbenchmarks/AckleyBench.java">
@@ -8854,7 +8854,7 @@
       <Message>In method new org.ogolem.microbenchmarks.AckleyGradBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.AckleyGradBench" primary="true" start="66" end="66" startBytecode="108" endBytecode="108" sourcefile="AckleyGradBench.java" sourcepath="org/ogolem/microbenchmarks/AckleyGradBench.java" relSourcepath="org/ogolem/microbenchmarks/AckleyGradBench.java">
@@ -9011,7 +9011,7 @@
       <Message>In method new org.ogolem.microbenchmarks.LunacekBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.LunacekBench" primary="true" start="66" end="66" startBytecode="108" endBytecode="108" sourcefile="LunacekBench.java" sourcepath="org/ogolem/microbenchmarks/LunacekBench.java" relSourcepath="org/ogolem/microbenchmarks/LunacekBench.java">
@@ -9032,7 +9032,7 @@
       <Message>In method new org.ogolem.microbenchmarks.LunacekGradBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.LunacekGradBench" primary="true" start="67" end="67" startBytecode="108" endBytecode="108" sourcefile="LunacekGradBench.java" sourcepath="org/ogolem/microbenchmarks/LunacekGradBench.java" relSourcepath="org/ogolem/microbenchmarks/LunacekGradBench.java">
@@ -9053,7 +9053,7 @@
       <Message>In method new org.ogolem.microbenchmarks.Mat3x3MultBenchmark(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.Mat3x3MultBenchmark" primary="true" start="61" end="61" startBytecode="44" endBytecode="44" sourcefile="Mat3x3MultBenchmark.java" sourcepath="org/ogolem/microbenchmarks/Mat3x3MultBenchmark.java" relSourcepath="org/ogolem/microbenchmarks/Mat3x3MultBenchmark.java">
@@ -9080,7 +9080,7 @@
       <Message>In method new org.ogolem.microbenchmarks.MatMultBenchmark(int, int, int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.MatMultBenchmark" primary="true" start="71" end="71" startBytecode="144" endBytecode="144" sourcefile="MatMultBenchmark.java" sourcepath="org/ogolem/microbenchmarks/MatMultBenchmark.java" relSourcepath="org/ogolem/microbenchmarks/MatMultBenchmark.java">
@@ -9104,7 +9104,7 @@
       <Message>In method new org.ogolem.microbenchmarks.RastriginBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.RastriginBench" primary="true" start="66" end="66" startBytecode="108" endBytecode="108" sourcefile="RastriginBench.java" sourcepath="org/ogolem/microbenchmarks/RastriginBench.java" relSourcepath="org/ogolem/microbenchmarks/RastriginBench.java">
@@ -9125,7 +9125,7 @@
       <Message>In method new org.ogolem.microbenchmarks.RastriginGradBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.RastriginGradBench" primary="true" start="67" end="67" startBytecode="109" endBytecode="109" sourcefile="RastriginGradBench.java" sourcepath="org/ogolem/microbenchmarks/RastriginGradBench.java" relSourcepath="org/ogolem/microbenchmarks/RastriginGradBench.java">
@@ -9146,7 +9146,7 @@
       <Message>In method new org.ogolem.microbenchmarks.SchafferF7Bench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.SchafferF7Bench" primary="true" start="66" end="66" startBytecode="109" endBytecode="109" sourcefile="SchafferF7Bench.java" sourcepath="org/ogolem/microbenchmarks/SchafferF7Bench.java" relSourcepath="org/ogolem/microbenchmarks/SchafferF7Bench.java">
@@ -9167,7 +9167,7 @@
       <Message>In method new org.ogolem.microbenchmarks.SchafferF7GradBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.SchafferF7GradBench" primary="true" start="67" end="67" startBytecode="109" endBytecode="109" sourcefile="SchafferF7GradBench.java" sourcepath="org/ogolem/microbenchmarks/SchafferF7GradBench.java" relSourcepath="org/ogolem/microbenchmarks/SchafferF7GradBench.java">
@@ -9188,7 +9188,7 @@
       <Message>In method new org.ogolem.microbenchmarks.SchwefelBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.SchwefelBench" primary="true" start="66" end="66" startBytecode="108" endBytecode="108" sourcefile="SchwefelBench.java" sourcepath="org/ogolem/microbenchmarks/SchwefelBench.java" relSourcepath="org/ogolem/microbenchmarks/SchwefelBench.java">
@@ -9209,7 +9209,7 @@
       <Message>In method new org.ogolem.microbenchmarks.SchwefelGradBench(int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.microbenchmarks.SchwefelGradBench" primary="true" start="67" end="67" startBytecode="108" endBytecode="108" sourcefile="SchwefelGradBench.java" sourcepath="org/ogolem/microbenchmarks/SchwefelGradBench.java" relSourcepath="org/ogolem/microbenchmarks/SchwefelGradBench.java">
@@ -9426,7 +9426,7 @@
       <Message>In method org.ogolem.random.Lottery.getInstance()</Message>
     </Method>
     <Method classname="java.util.Random" name="nextLong" signature="()J" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="356" end="356" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="592" end="592" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextLong()</Message>
     </Method>
     <SourceLine classname="org.ogolem.random.Lottery" primary="true" start="71" end="71" startBytecode="23" endBytecode="23" sourcefile="Lottery.java" sourcepath="org/ogolem/random/Lottery.java" relSourcepath="org/ogolem/random/Lottery.java">
@@ -9447,7 +9447,7 @@
       <Message>In method new org.ogolem.rmi.AliveCheck(RMICommunication, long, int)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextDouble" signature="()D" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="462" end="462" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="698" end="698" startBytecode="0" endBytecode="65" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextDouble()</Message>
     </Method>
     <SourceLine classname="org.ogolem.rmi.AliveCheck" primary="true" start="69" end="69" startBytecode="42" endBytecode="42" sourcefile="AliveCheck.java" sourcepath="org/ogolem/rmi/AliveCheck.java" relSourcepath="org/ogolem/rmi/AliveCheck.java">
@@ -9867,102 +9867,123 @@
       <Message>At GenericThreadingClientBackend.java:[line 552]</Message>
     </SourceLine>
   </BugInstance>
-  <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" rank="6" abbrev="NP" category="CORRECTNESS" instanceHash="88ae0ef3637dfc84199d71171b6ecdd6" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
-    <ShortMessage>Possible null pointer dereference</ShortMessage>
-    <LongMessage>Possible null pointer dereference of comm in org.ogolem.rmi.MainRMIClient.main(String[])</LongMessage>
+  <BugInstance type="DMI_RANDOM_USED_ONLY_ONCE" priority="1" rank="14" abbrev="DMI" category="BAD_PRACTICE" instanceHash="b5c00627ea184bb299d781699b62cfe3" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="440">
+    <ShortMessage>Random object created and used only once</ShortMessage>
+    <LongMessage>Random object created and used only once in org.ogolem.rmi.MainRMIClient.main(String[])</LongMessage>
     <Class classname="org.ogolem.rmi.MainRMIClient" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="51" end="278" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
-        <Message>At MainRMIClient.java:[lines 51-278]</Message>
+      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="57" end="349" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
+        <Message>At MainRMIClient.java:[lines 57-349]</Message>
       </SourceLine>
       <Message>In class org.ogolem.rmi.MainRMIClient</Message>
     </Class>
     <Method classname="org.ogolem.rmi.MainRMIClient" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="60" end="278" startBytecode="0" endBytecode="2311" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java"/>
+      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="66" end="349" startBytecode="0" endBytecode="2500" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java"/>
+      <Message>In method org.ogolem.rmi.MainRMIClient.main(String[])</Message>
+    </Method>
+    <Method classname="java.util.Random" name="nextLong" signature="()J" isStatic="false" role="METHOD_CALLED">
+      <SourceLine classname="java.util.Random" start="592" end="592" startBytecode="0" endBytecode="60" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <Message>Called method java.util.Random.nextLong()</Message>
+    </Method>
+    <SourceLine classname="org.ogolem.rmi.MainRMIClient" primary="true" start="183" end="183" startBytecode="498" endBytecode="498" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
+      <Message>At MainRMIClient.java:[line 183]</Message>
+    </SourceLine>
+  </BugInstance>
+  <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" rank="6" abbrev="NP" category="CORRECTNESS" instanceHash="88ae0ef3637dfc84199d71171b6ecdd6" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
+    <ShortMessage>Possible null pointer dereference</ShortMessage>
+    <LongMessage>Possible null pointer dereference of comm in org.ogolem.rmi.MainRMIClient.main(String[])</LongMessage>
+    <Class classname="org.ogolem.rmi.MainRMIClient" primary="true">
+      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="57" end="349" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
+        <Message>At MainRMIClient.java:[lines 57-349]</Message>
+      </SourceLine>
+      <Message>In class org.ogolem.rmi.MainRMIClient</Message>
+    </Class>
+    <Method classname="org.ogolem.rmi.MainRMIClient" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
+      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="66" end="349" startBytecode="0" endBytecode="2500" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java"/>
       <Message>In method org.ogolem.rmi.MainRMIClient.main(String[])</Message>
     </Method>
     <LocalVariable name="comm" register="11" pc="306" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from comm</Message>
     </LocalVariable>
-    <SourceLine classname="org.ogolem.rmi.MainRMIClient" primary="true" start="126" end="126" startBytecode="308" endBytecode="308" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_LINE_DEREF">
-      <Message>Dereferenced at MainRMIClient.java:[line 126]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIClient" primary="true" start="135" end="135" startBytecode="308" endBytecode="308" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_LINE_DEREF">
+      <Message>Dereferenced at MainRMIClient.java:[line 135]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="121" end="121" startBytecode="293" endBytecode="293" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_LINE_NULL_VALUE">
-      <Message>Null value at MainRMIClient.java:[line 121]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="130" end="130" startBytecode="293" endBytecode="293" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_LINE_NULL_VALUE">
+      <Message>Null value at MainRMIClient.java:[line 130]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="122" end="122" startBytecode="296" endBytecode="296" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_LINE_KNOWN_NULL">
-      <Message>Known null at MainRMIClient.java:[line 122]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="131" end="131" startBytecode="296" endBytecode="296" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_LINE_KNOWN_NULL">
+      <Message>Known null at MainRMIClient.java:[line 131]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="UC_USELESS_CONDITION" priority="1" rank="14" abbrev="UC" category="STYLE" instanceHash="dd71164fe06ad8d929a716db0382676e" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it&apos;s known that attempt != 3 at this point</LongMessage>
     <Class classname="org.ogolem.rmi.MainRMIClient" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="51" end="278" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
-        <Message>At MainRMIClient.java:[lines 51-278]</Message>
+      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="57" end="349" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
+        <Message>At MainRMIClient.java:[lines 57-349]</Message>
       </SourceLine>
       <Message>In class org.ogolem.rmi.MainRMIClient</Message>
     </Class>
     <Method classname="org.ogolem.rmi.MainRMIClient" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="60" end="278" startBytecode="0" endBytecode="2311" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java"/>
+      <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="66" end="349" startBytecode="0" endBytecode="2500" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java"/>
       <Message>In method org.ogolem.rmi.MainRMIClient.main(String[])</Message>
     </Method>
     <String value="attempt != 3">
       <Message>Value attempt != 3</Message>
     </String>
-    <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="151" end="151" startBytecode="435" endBytecode="435" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_UNREACHABLE_CODE">
-      <Message>Unreachable code at MainRMIClient.java:[line 151]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIClient" start="167" end="167" startBytecode="435" endBytecode="435" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java" role="SOURCE_UNREACHABLE_CODE">
+      <Message>Unreachable code at MainRMIClient.java:[line 167]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.rmi.MainRMIClient" primary="true" start="150" end="150" startBytecode="432" endBytecode="432" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
-      <Message>At MainRMIClient.java:[line 150]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIClient" primary="true" start="166" end="166" startBytecode="432" endBytecode="432" sourcefile="MainRMIClient.java" sourcepath="org/ogolem/rmi/MainRMIClient.java" relSourcepath="org/ogolem/rmi/MainRMIClient.java">
+      <Message>At MainRMIClient.java:[line 166]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" rank="6" abbrev="NP" category="CORRECTNESS" instanceHash="76646f4f234f8db0692a9b566a8d36d7" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
     <ShortMessage>Possible null pointer dereference</ShortMessage>
     <LongMessage>Possible null pointer dereference of serverComm in org.ogolem.rmi.MainRMIProxy.main(String[])</LongMessage>
     <Class classname="org.ogolem.rmi.MainRMIProxy" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="55" end="288" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java">
-        <Message>At MainRMIProxy.java:[lines 55-288]</Message>
+      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="56" end="311" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java">
+        <Message>At MainRMIProxy.java:[lines 56-311]</Message>
       </SourceLine>
       <Message>In class org.ogolem.rmi.MainRMIProxy</Message>
     </Class>
     <Method classname="org.ogolem.rmi.MainRMIProxy" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="75" end="288" startBytecode="0" endBytecode="2540" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java"/>
+      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="75" end="311" startBytecode="0" endBytecode="2569" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java"/>
       <Message>In method org.ogolem.rmi.MainRMIProxy.main(String[])</Message>
     </Method>
-    <LocalVariable name="serverComm" register="20" pc="560" role="LOCAL_VARIABLE_VALUE_OF">
+    <LocalVariable name="serverComm" register="20" pc="544" role="LOCAL_VARIABLE_VALUE_OF">
       <Message>Value loaded from serverComm</Message>
     </LocalVariable>
-    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" primary="true" start="177" end="177" startBytecode="562" endBytecode="562" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_LINE_DEREF">
-      <Message>Dereferenced at MainRMIProxy.java:[line 177]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" primary="true" start="180" end="180" startBytecode="546" endBytecode="546" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_LINE_DEREF">
+      <Message>Dereferenced at MainRMIProxy.java:[line 180]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="172" end="172" startBytecode="547" endBytecode="547" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_LINE_NULL_VALUE">
-      <Message>Null value at MainRMIProxy.java:[line 172]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="175" end="175" startBytecode="531" endBytecode="531" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_LINE_NULL_VALUE">
+      <Message>Null value at MainRMIProxy.java:[line 175]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="173" end="173" startBytecode="550" endBytecode="550" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_LINE_KNOWN_NULL">
-      <Message>Known null at MainRMIProxy.java:[line 173]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="176" end="176" startBytecode="534" endBytecode="534" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_LINE_KNOWN_NULL">
+      <Message>Known null at MainRMIProxy.java:[line 176]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="UC_USELESS_CONDITION" priority="1" rank="14" abbrev="UC" category="STYLE" instanceHash="a94d20f0cfc5cc3e68faeb33942634ae" instanceOccurrenceNum="0" instanceOccurrenceMax="0">
     <ShortMessage>Condition has no effect</ShortMessage>
     <LongMessage>Useless condition: it&apos;s known that attempt != 3 at this point</LongMessage>
     <Class classname="org.ogolem.rmi.MainRMIProxy" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="55" end="288" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java">
-        <Message>At MainRMIProxy.java:[lines 55-288]</Message>
+      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="56" end="311" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java">
+        <Message>At MainRMIProxy.java:[lines 56-311]</Message>
       </SourceLine>
       <Message>In class org.ogolem.rmi.MainRMIProxy</Message>
     </Class>
     <Method classname="org.ogolem.rmi.MainRMIProxy" name="main" signature="([Ljava/lang/String;)V" isStatic="true" primary="true">
-      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="75" end="288" startBytecode="0" endBytecode="2540" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java"/>
+      <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="75" end="311" startBytecode="0" endBytecode="2569" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java"/>
       <Message>In method org.ogolem.rmi.MainRMIProxy.main(String[])</Message>
     </Method>
     <String value="attempt != 3">
       <Message>Value attempt != 3</Message>
     </String>
-    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="201" end="201" startBytecode="691" endBytecode="691" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_UNREACHABLE_CODE">
-      <Message>Unreachable code at MainRMIProxy.java:[line 201]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" start="211" end="211" startBytecode="675" endBytecode="675" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java" role="SOURCE_UNREACHABLE_CODE">
+      <Message>Unreachable code at MainRMIProxy.java:[line 211]</Message>
     </SourceLine>
-    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" primary="true" start="200" end="200" startBytecode="688" endBytecode="688" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java">
-      <Message>At MainRMIProxy.java:[line 200]</Message>
+    <SourceLine classname="org.ogolem.rmi.MainRMIProxy" primary="true" start="210" end="210" startBytecode="672" endBytecode="672" sourcefile="MainRMIProxy.java" sourcepath="org/ogolem/rmi/MainRMIProxy.java" relSourcepath="org/ogolem/rmi/MainRMIProxy.java">
+      <Message>At MainRMIProxy.java:[line 210]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance type="NP_NULL_ON_SOME_PATH" priority="1" rank="6" abbrev="NP" category="CORRECTNESS" instanceHash="e5522ac16509dec8dd6c02c9e7db1223" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="476">
@@ -10250,7 +10271,7 @@
       <Message>In method org.ogolem.switches.ColorPalette.getRandomColor()</Message>
     </Method>
     <Method classname="java.util.Random" name="nextInt" signature="(I)I" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="320" end="332" startBytecode="0" endBytecode="212" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="556" end="568" startBytecode="0" endBytecode="212" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextInt(int)</Message>
     </Method>
     <SourceLine classname="org.ogolem.switches.ColorPalette" primary="true" start="94" end="94" startBytecode="47" endBytecode="47" sourcefile="ColorPalette.java" sourcepath="org/ogolem/switches/ColorPalette.java" relSourcepath="org/ogolem/switches/ColorPalette.java">
@@ -10271,7 +10292,7 @@
       <Message>In method org.ogolem.switches.GlobOptAtomics.genotypeMutation(ArrayList, boolean)</Message>
     </Method>
     <Method classname="java.util.Random" name="nextInt" signature="(I)I" isStatic="false" role="METHOD_CALLED">
-      <SourceLine classname="java.util.Random" start="320" end="332" startBytecode="0" endBytecode="212" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
+      <SourceLine classname="java.util.Random" start="556" end="568" startBytecode="0" endBytecode="212" sourcefile="Random.java" sourcepath="java/util/Random.java"/>
       <Message>Called method java.util.Random.nextInt(int)</Message>
     </Method>
     <SourceLine classname="org.ogolem.switches.GlobOptAtomics" primary="true" start="85" end="85" startBytecode="11" endBytecode="11" sourcefile="GlobOptAtomics.java" sourcepath="org/ogolem/switches/GlobOptAtomics.java" relSourcepath="org/ogolem/switches/GlobOptAtomics.java">
@@ -11286,15 +11307,10 @@ closed.</p>
   <BugCode abbrev="FE">
     <Description>Test for floating point equality</Description>
   </BugCode>
-  <Errors errors="0" missingClasses="6">
-    <MissingClass>java.lang.foreign.FunctionDescriptor</MissingClass>
-    <MissingClass>java.lang.foreign.Linker</MissingClass>
-    <MissingClass>java.lang.foreign.MemorySegment</MissingClass>
+  <Errors errors="0" missingClasses="1">
     <MissingClass>java.lang.foreign.MemorySession</MissingClass>
-    <MissingClass>java.lang.foreign.SymbolLookup</MissingClass>
-    <MissingClass>java.lang.foreign.ValueLayout</MissingClass>
   </Errors>
-  <FindBugsSummary timestamp="Wed, 16 Nov 2022 14:57:49 -0600" total_classes="0" referenced_classes="0" total_bugs="428" total_size="0" num_packages="35" java_version="18.0.2-ea" vm_version="18.0.2-ea+9-Ubuntu-222.04" cpu_seconds="133.63" clock_seconds="25.67" peak_mbytes="1538.81" alloc_mbytes="24128.00" gc_seconds="0.33" priority_2="380" priority_1="48">
+  <FindBugsSummary timestamp="Mon, 4 Sep 2023 15:59:53 -0500" total_classes="0" referenced_classes="0" total_bugs="429" total_size="0" num_packages="35" java_version="20.0.2" vm_version="20.0.2+9-78" cpu_seconds="39.06" clock_seconds="16.48" peak_mbytes="741.40" alloc_mbytes="2048.00" gc_seconds="0.55" priority_2="380" priority_1="49">
     <FileStats path="contrib/bobyqa/BOBYQAOptimizer.java" bugCount="5" size="0" bugHash="02df92db8a0d632e485370f73e6e1b33"/>
     <FileStats path="contrib/edu/princeton/eac/Grid.java" bugCount="6" size="0" bugHash="9e1b3935d488701dd2cb654d0648cd01"/>
     <FileStats path="contrib/jama/CholeskyDecomposition.java" bugCount="1" size="0" bugHash="41d37c4a6cddaa062ff3ee500d7f0d16"/>
@@ -11303,7 +11319,7 @@ closed.</p>
     <FileStats path="contrib/jama/Matrix.java" bugCount="7" size="0" bugHash="89bc77b9b83dbfb0defe6129ac729905"/>
     <FileStats path="contrib/jama/SingularValueDecomposition.java" bugCount="3" size="0" bugHash="fe455f3e47c78f262cef159696391903"/>
     <FileStats path="contrib/jama/test/TestMatrix.java" bugCount="8" size="0" bugHash="ce2f1d8eb13041f55fbfea7b1dec9606"/>
-    <FileStats path="contrib/lbfgs/LBFGS.java" bugCount="2" size="0" bugHash="ab3e7aed1d2a3a25823e7b9409414e04"/>
+    <FileStats path="contrib/lbfgs/LBFGS.java" bugCount="2" size="0" bugHash="c1e6889706e7d1e26756e3fa15db5f26"/>
     <FileStats path="contrib/newuoa/NEWUOAOptimizer.java" bugCount="1" size="0" bugHash="296db4da1b5fc70a1451aa33993ecea1"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveAmberFF.java" bugCount="1" size="0" bugHash="4b227dd68bdd180d5fd9a9ab533f0bc3"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveAmberLJTerm.java" bugCount="3" size="0" bugHash="6799109d7c76449a4fa2ffdc256b40c8"/>
@@ -11311,7 +11327,7 @@ closed.</p>
     <FileStats path="org/ogolem/adaptive/AdaptiveCustomSpillage.java" bugCount="2" size="0" bugHash="ce6384a14c02f705b16f4ed1de67041c"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveCustomSpillage2.java" bugCount="2" size="0" bugHash="cc968ed9d7d308bbdcd689752b67e3cd"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveGUPTA.java" bugCount="3" size="0" bugHash="82b1c2c209ff0632d3bcb8cd0585adbd"/>
-    <FileStats path="org/ogolem/adaptive/AdaptiveLJFF.java" bugCount="1" size="0" bugHash="ad7b33751f95937e233d4eb8b818380b"/>
+    <FileStats path="org/ogolem/adaptive/AdaptiveLJFF.java" bugCount="1" size="0" bugHash="1e0e3e2a445b81130d417a1cbe798ac8"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveMorse.java" bugCount="1" size="0" bugHash="bc8bfbae6b6c8399b2cc64ca809c38f4"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveParameters.java" bugCount="7" size="0" bugHash="33fa91b5f7f85103f7a9fe5f51b83763"/>
     <FileStats path="org/ogolem/adaptive/AdaptiveSWGFF.java" bugCount="1" size="0" bugHash="e8418a28106055fac84dea9b28c0fe6f"/>
@@ -11370,7 +11386,7 @@ closed.</p>
     <FileStats path="org/ogolem/core/RigidBodyCoordinates.java" bugCount="1" size="0" bugHash="c70aaa7b339ccdd9dde017d65b750a63"/>
     <FileStats path="org/ogolem/core/ScaTTM3FBackend.java" bugCount="1" size="0" bugHash="62f1c31a668a07b8ee2dd0a56ec848a6"/>
     <FileStats path="org/ogolem/core/SimpleBondInfo.java" bugCount="2" size="0" bugHash="580383e634a1d701b24520d59d1f8ecd"/>
-    <FileStats path="org/ogolem/core/SimpleEnvironment.java" bugCount="1" size="0" bugHash="3f0fb9a7ec0e3e2e54918141bc3cc290"/>
+    <FileStats path="org/ogolem/core/SimpleEnvironment.java" bugCount="1" size="0" bugHash="582501419acbd966a61033a709e69eea"/>
     <FileStats path="org/ogolem/core/SingleGeomSpectralFitnessFunction.java" bugCount="2" size="0" bugHash="1f8977969eab840dbff6d58d37418bc7"/>
     <FileStats path="org/ogolem/core/SnaefellsjoekullGeometryXOver.java" bugCount="2" size="0" bugHash="c1ddbd7c2d8f534e54c11a8331ee4530"/>
     <FileStats path="org/ogolem/core/SurfaceDetection.java" bugCount="3" size="0" bugHash="039ece6a27c90dfd780c9b3dfc0c9382"/>
@@ -11455,8 +11471,8 @@ closed.</p>
     <FileStats path="org/ogolem/rmi/GenericProxyJob.java" bugCount="6" size="0" bugHash="2abf9ec0c14a61934a0e17e9388614fd"/>
     <FileStats path="org/ogolem/rmi/GenericSeedTask.java" bugCount="2" size="0" bugHash="1ddfeb56a25805cb80b6258a457eaad6"/>
     <FileStats path="org/ogolem/rmi/GenericThreadingClientBackend.java" bugCount="2" size="0" bugHash="d67d87c666f5f9dd74e15216890a7d46"/>
-    <FileStats path="org/ogolem/rmi/MainRMIClient.java" bugCount="2" size="0" bugHash="a184606b1c3d904776b3b0b0a0b14c2e"/>
-    <FileStats path="org/ogolem/rmi/MainRMIProxy.java" bugCount="2" size="0" bugHash="141fcffe9f3562132063772784bfeee0"/>
+    <FileStats path="org/ogolem/rmi/MainRMIClient.java" bugCount="3" size="0" bugHash="57db0cbb85e105abae0f07050aa97773"/>
+    <FileStats path="org/ogolem/rmi/MainRMIProxy.java" bugCount="2" size="0" bugHash="91074eb17121f29fd3f115d703afe86d"/>
     <FileStats path="org/ogolem/rmi/MainRMIThreader.java" bugCount="2" size="0" bugHash="2c23a4806088a39c9a396e935e7e27f1"/>
     <FileStats path="org/ogolem/rmi/SwitchGlobOptJob.java" bugCount="2" size="0" bugHash="b24b45967470f11302076ba51fd28e4f"/>
     <FileStats path="org/ogolem/rmi/SwitchGlobOptTask.java" bugCount="1" size="0" bugHash="887e92aa6a05d2fac5f91d4945c1937a"/>

--- a/src/org/ogolem/rmi/MainRMIClient.java
+++ b/src/org/ogolem/rmi/MainRMIClient.java
@@ -1,7 +1,7 @@
-/**
+/*
 Copyright (c) 2009-2010, J. M. Dieterich and B. Hartke
               2010-2011, J. M. Dieterich
-              2015-2020, J. M. Dieterich and B. Hartke
+              2015-2023, J. M. Dieterich and B. Hartke
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -38,242 +38,313 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.ogolem.rmi;
 
+import static org.ogolem.rmi.RMICodes.JOBSTATE.*;
+
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+import java.util.Random;
 import org.ogolem.helpers.Tuple;
-import static org.ogolem.rmi.RMICodes.JOBSTATE.*;
+import org.ogolem.random.Lottery;
+import org.ogolem.random.RNGenerator;
+import org.ogolem.random.StandardRNG;
 
 /**
  * The entry to the client part of OGOLEM's RMI.
+ *
  * @author Johannes Dieterich
- * @version 2020-06-23
+ * @version 2023-09-04
  */
 public class MainRMIClient {
 
-    private static final boolean DEBUG = false;
-    private static final int DEFAULTSLEEPINGTIMEFORNEWTASK = 5000;
+  private static final boolean DEBUG = false;
+  private static final int DEFAULTSLEEPINGTIMEFORNEWTASK = 5000;
 
-    @SuppressWarnings({"rawtypes","unchecked"}) // Generics suck sometimes...
-    public static void main(String args[]) {
-        
-        //XXX fix...
-        if (args == null || args[0].equalsIgnoreCase("--help")) {
-            System.out.println("Sorry, no help yet...");
-            System.exit(0);
+  @SuppressWarnings({"rawtypes", "unchecked"}) // Generics suck sometimes...
+  public static void main(String args[]) {
+
+    // XXX fix...
+    if (args == null || args[0].equalsIgnoreCase("--help")) {
+      System.out.println("Sorry, no help yet...");
+      System.exit(0);
+    }
+
+    String server = null;
+    String name = "RMICommunication";
+    long sleepTime = 5000;
+    int port = 1099;
+    int taskWaitTime = DEFAULTSLEEPINGTIMEFORNEWTASK;
+
+    for (int argID = 0; argID < args.length; argID++) {
+      final String arg = args[argID];
+      if (arg.equalsIgnoreCase("--server")) {
+        argID++;
+        server = args[argID];
+      } else if (arg.equalsIgnoreCase("--commname")) {
+        argID++;
+        name = args[argID];
+      } else if (arg.equalsIgnoreCase("--sleeptime")) {
+        argID++;
+        sleepTime = Long.parseLong(args[argID]) * 1000;
+      } else if (arg.equalsIgnoreCase("--taskwaittime")) {
+        argID++;
+        taskWaitTime = Integer.parseInt(args[argID]) * 1000;
+      } else if (arg.equalsIgnoreCase("--serverregistryport")) {
+        argID++;
+        port = Integer.parseInt(args[argID]);
+      } else {
+        System.err.println("Unknown argument " + arg + ". Shutting down.");
+        System.exit(1);
+      }
+    }
+
+    // check for mandatory settings
+    if (server == null) {
+      System.err.println("No server specified.");
+      System.exit(2);
+    }
+
+    String keySuffix = System.getenv("OGO_RMIKEY");
+    if (keySuffix == null) {
+      keySuffix = "Super secret password: Nakatomi Socrates";
+    }
+
+    final String key = "Client speaking, I am here. " + keySuffix;
+
+    // first we try to connect to our server and exchange keys
+    final long waittimeClientMS = 2000; // two seconds.
+    RMICommunication<?> comm = null;
+    int myID = -1;
+    for (int attempt = 0; attempt < 3; attempt++) {
+      try {
+        final Registry registry = LocateRegistry.getRegistry(server, port);
+
+        if (DEBUG) {
+          final String[] sa = registry.list();
+          System.out.println("DEBUG: List of remote objects in registry:");
+          for (final String s : sa) {
+            System.out.println("DEBUG: " + s);
+          }
+        }
+        comm = (RMICommunication<?>) registry.lookup(name);
+
+        if (comm == null) {
+          System.err.println("WARNING: Communication object is null. Trying again....");
         }
 
-        String server = null;
-        String name = "RMICommunication";
-        long sleepTime = 5000;
-        int port = 1099;
-        int taskWaitTime = DEFAULTSLEEPINGTIMEFORNEWTASK;
-        
-        for(int argID = 0; argID < args.length; argID++){
-            final String arg = args[argID];
-            if(arg.equalsIgnoreCase("--server")){
-                argID++;
-                server = args[argID];
-            } else if(arg.equalsIgnoreCase("--commname")){
-                argID++;
-                name = args[argID];
-            } else if(arg.equalsIgnoreCase("--sleeptime")){
-                argID++;
-                sleepTime = Long.parseLong(args[argID])*1000;
-            } else if(arg.equalsIgnoreCase("--taskwaittime")){
-                argID++;
-                taskWaitTime = Integer.parseInt(args[argID])*1000;
-            } else if(arg.equalsIgnoreCase("--serverregistryport")){
-                argID++;
-                port = Integer.parseInt(args[argID]);
-            } else {
-                System.err.println("Unknown argument " + arg + ". Shutting down.");
-                System.exit(1);
-            }
+        // exchange keys
+        final Tuple<String, Integer> answer = comm.registerWithServer(key);
+        if (!answer
+            .getObject1()
+            .equalsIgnoreCase("Server speaking, everything fine. " + keySuffix)) {
+          // not good, exit (we want to avoid double registration...)
+          System.err.println(
+              "ERROR: Wrong answer from server. Aborting client. Server was "
+                  + server
+                  + ". Answer was "
+                  + answer.getObject1());
+          System.exit(27);
+        } else {
+          myID = answer.getObject2();
+          // yup, ID assigned!
+          break;
         }
 
-        // check for mandatory settings
-        if(server == null){System.err.println("No server specified."); System.exit(2);}
-        
-        String keySuffix = System.getenv("OGO_RMIKEY");
-        if(keySuffix == null){
-            keySuffix = "Super secret password: Nakatomi Socrates";
+      } catch (Exception e) {
+        System.err.println(
+            "RMI exception: " + e.getMessage() + ". Trying again... Server is " + server);
+        e.printStackTrace(System.err);
+      }
+
+      // sleep for a bit...
+      try {
+        Thread.sleep(waittimeClientMS);
+      } catch (Exception e) {
+        // whatever...
+        e.printStackTrace(System.err);
+      }
+
+      if (attempt == 3) {
+        System.err.println(
+            "ERROR: Failure to connect to initial server happened three times. Giving up...");
+        System.exit(42);
+      }
+    }
+
+    // explicit check whether either the communication or the global configuration are null not
+    // needed
+    assert (comm != null);
+
+    // the check for the aliveness of the server
+    final AliveCheck aliveCheck = new AliveCheck(comm, sleepTime, myID);
+
+    // init Lottery - it is unreasonable to assume a distributed job could synchronize Lottery,
+    // hence default init
+    final Random r = new Random();
+    final long seed = r.nextLong();
+    final RNGenerator rng = new StandardRNG(seed);
+    Lottery.setGenerator(rng);
+
+    WorkLoop:
+    for (; ; ) {
+
+      Task<?> task = null;
+      try {
+        task = comm.getWorkTask(myID);
+      } catch (Exception e) {
+        System.err.println("ERROR: Can't get the task for working. " + "Aborting." + e.toString());
+        e.printStackTrace(System.err);
+        System.exit(11);
+      }
+
+      if (DEBUG && task == null) {
+        System.out.println("DEBUG: Client " + myID + " task was null.");
+      }
+
+      RMICodes.JOBSTATE whatNext = WAITING;
+      if (task != null) {
+        // raw type used on purpose, <?> can't be used and we do not know what we get
+        Result res = task.executeTask(myID);
+
+        if (res != null) {
+          // try to return the result
+          try {
+            whatNext = comm.returnResult(res);
+          } catch (Exception e) {
+            System.err.println(
+                "ERROR: Can't hand solution over. "
+                    + e.toString()
+                    + " Sleeping and trying again. My ID is "
+                    + myID
+                    + ".");
+            try {
+              // XXX ugly!
+              Thread.sleep(taskWaitTime);
+              whatNext = comm.returnResult(res);
+            } catch (Exception e2) {
+              System.err.println(
+                  "ERROR: Can't hand solution over for the second time. Aborting. "
+                      + e2.toString()
+                      + " My ID is "
+                      + myID
+                      + ".");
+              e2.printStackTrace(System.err);
+              System.exit(9);
+            }
+          }
+        } else {
+          System.err.println(
+              "ERROR: The result is null. This is a problem. Aborting. My ID is " + myID + ".");
+          System.exit(10);
         }
-        
-        final String key = "Client speaking, I am here. " + keySuffix;
+      }
 
-        // first we try to connect to our server and exchange keys
-        final long waittimeClientMS = 2000; // two seconds.
-        RMICommunication<?> comm = null;
-        int myID = -1;
-        for(int attempt = 0; attempt < 3; attempt++){
-            try{
-                final Registry registry = LocateRegistry.getRegistry(server,port);
-            
-                if(DEBUG){
-                    final String[] sa = registry.list();
-                    System.out.println("DEBUG: List of remote objects in registry:");
-                    for(final String s : sa){
-                        System.out.println("DEBUG: " + s);
-                    }
-                }
-                comm = (RMICommunication<?>) registry.lookup(name);
-            
-                if(comm == null){
-                    System.err.println("WARNING: Communication object is null. Trying again....");
-                }
-            
-                // exchange keys
-                final Tuple<String,Integer> answer = comm.registerWithServer(key);
-                if(!answer.getObject1().equalsIgnoreCase("Server speaking, everything fine. " + keySuffix)){
-                    // not good, exit (we want to avoid double registration...)
-                    System.err.println("ERROR: Wrong answer from server. Aborting client. Server was " + server + ". Answer was " + answer.getObject1());
-                    System.exit(27);
-                } else{
-                    myID = answer.getObject2();
-                    // yup, ID assigned!
-                    break;
-                }
+      if (DEBUG) {
+        System.out.println("DEBUG: Client " + myID + " got as next task: " + whatNext);
+      }
 
-            } catch(Exception e){
-                System.err.println("RMI exception: " + e.getMessage() + ". Trying again... Server is " + server);
-                e.printStackTrace(System.err);
+      if (whatNext == CONTINUE) {
+        // we loop on
+        continue WorkLoop;
+      } else if (whatNext == WAITING) {
+        // waiting for something on the server side
+        while (true) {
+
+          try {
+            whatNext = comm.whatNext(myID);
+          } catch (Exception e) {
+            System.err.println(
+                "ERROR: Can't hand solution over. Aborting. "
+                    + e.toString()
+                    + " My ID is "
+                    + myID
+                    + ".");
+            e.printStackTrace(System.err);
+            System.exit(8);
+          }
+
+          if (DEBUG) {
+            System.out.println("DEBUG: Client " + myID + " got as next task (II): " + whatNext);
+          }
+
+          if (whatNext == CONTINUE) {
+            continue WorkLoop;
+          } else if (whatNext == WAITING) {
+            // no new information. sleep and then loop on.
+          } else if (whatNext == FINISH) {
+            System.out.println(
+                "INFO: Shutting down gracefully. Thanks and bye. :-) My ID is " + myID + ".");
+            try {
+              aliveCheck.done();
+              break WorkLoop;
+            } catch (Exception e) {
+              System.err.println(
+                  "WARNING: Couldn't properly shut the "
+                      + "AliveCheck down. Exiting now. "
+                      + e.toString()
+                      + " My ID is "
+                      + myID
+                      + ".");
+              e.printStackTrace(System.err);
+              System.exit(0);
             }
-            
-            // sleep for a bit...
-            try{
-                Thread.sleep(waittimeClientMS);
-            } catch (Exception e){
-                // whatever...
-                e.printStackTrace(System.err);
-            }
-            
-            if(attempt == 3){
-                System.err.println("ERROR: Failure to connect to initial server happened three times. Giving up...");
-                System.exit(42);
-            }
+          } else if (whatNext == SNAFU) {
+            System.err.println(
+                "ERROR: Shutting down ungracefully, server required so. My ID is " + myID + ".");
+            System.exit(33);
+          } else {
+            // unknown state, once more
+            System.err.println(
+                "ERROR: Unknown return code after handing "
+                    + "result over. Aborting. My ID is "
+                    + myID
+                    + ".");
+            System.exit(55);
+          }
+
+          try {
+            // XXX ugly!
+            Thread.sleep(taskWaitTime);
+          } catch (Exception e) {
+            System.err.println(
+                "ERROR: Client doesn't go to sleep. Aborting. "
+                    + e.toString()
+                    + " My ID is "
+                    + myID
+                    + ".");
+            e.printStackTrace(System.err);
+            System.exit(390);
+          }
         }
-
-        // explicit check whether either the communication or the global configuration are null not needed
-        assert(comm != null);
-
-        // the check for the aliveness of the server
-        final AliveCheck aliveCheck = new AliveCheck(comm, sleepTime, myID);
-
-        WorkLoop:
-        for(;;){
-
-            Task<?> task = null;
-            try{
-                task = comm.getWorkTask(myID);
-            } catch(Exception e){
-                System.err.println("ERROR: Can't get the task for working. "
-                        + "Aborting." + e.toString());
-                e.printStackTrace(System.err);
-                System.exit(11);
-            }
-            
-            if(DEBUG && task == null){System.out.println("DEBUG: Client " + myID + " task was null.");}
-
-            RMICodes.JOBSTATE whatNext = WAITING;
-            if(task != null){
-                // raw type used on purpose, <?> can't be used and we do not know what we get
-                Result res = task.executeTask(myID);
-
-                if(res != null){
-                    // try to return the result
-                    try{
-                        whatNext = comm.returnResult(res);
-                    } catch(Exception e){
-                        System.err.println("ERROR: Can't hand solution over. "  + e.toString() + " Sleeping and trying again. My ID is " + myID + ".");
-                        try{
-                            //XXX ugly!
-                            Thread.sleep(taskWaitTime);
-                            whatNext = comm.returnResult(res);
-                        } catch(Exception e2){
-                            System.err.println("ERROR: Can't hand solution over for the second time. Aborting. "  + e2.toString() + " My ID is " + myID + ".");
-                            e2.printStackTrace(System.err);
-                            System.exit(9);
-                        }
-                    }
-                } else{
-                    System.err.println("ERROR: The result is null. This is a problem. Aborting. My ID is " + myID + ".");
-                    System.exit(10);
-                }
-            }
-
-            if(DEBUG){System.out.println("DEBUG: Client " + myID + " got as next task: " + whatNext);}
-            
-            if(whatNext == CONTINUE){
-                // we loop on
-                continue WorkLoop;
-            } else if(whatNext == WAITING){
-                // waiting for something on the server side
-                while(true){
-
-                    try{
-                        whatNext = comm.whatNext(myID);
-                    } catch(Exception e){
-                        System.err.println("ERROR: Can't hand solution over. Aborting. " + e.toString() + " My ID is " + myID + ".");
-                        e.printStackTrace(System.err);
-                        System.exit(8);
-                    }
-
-                    if(DEBUG){System.out.println("DEBUG: Client " + myID + " got as next task (II): " + whatNext);}
-                    
-                    if(whatNext == CONTINUE){
-                        continue WorkLoop;
-                    } else if(whatNext == WAITING){
-                        // no new information. sleep and then loop on.
-                    } else if(whatNext == FINISH){
-                        System.out.println("INFO: Shutting down gracefully. Thanks and bye. :-) My ID is " + myID + ".");
-                        try {
-                            aliveCheck.done();
-                            break WorkLoop;
-                        } catch (Exception e) {
-                            System.err.println("WARNING: Couldn't properly shut the "
-                                    + "AliveCheck down. Exiting now. " + e.toString() + " My ID is " + myID + ".");
-                            e.printStackTrace(System.err);
-                            System.exit(0);
-                        }
-                    } else if (whatNext == SNAFU) {
-                        System.err.println("ERROR: Shutting down ungracefully, server required so. My ID is " + myID + ".");
-                        System.exit(33);
-                    } else {
-                        // unknown state, once more
-                        System.err.println("ERROR: Unknown return code after handing "
-                                + "result over. Aborting. My ID is " + myID + ".");
-                        System.exit(55);
-                    }
-
-                    try{
-                        //XXX ugly!
-                        Thread.sleep(taskWaitTime);
-                    } catch(Exception e){
-                        System.err.println("ERROR: Client doesn't go to sleep. Aborting. " + e.toString() + " My ID is " + myID + ".");
-                        e.printStackTrace(System.err);
-                        System.exit(390);
-                    }
-                }
-            } else if(whatNext == FINISH){
-                System.out.println("INFO: Shutting down gracefully. Thanks and bye. :-) My ID is " + myID + ".");
-                try{
-                    aliveCheck.done();
-                    break WorkLoop;
-                } catch(Exception e){
-                    System.err.println("WARNING: Couldn't properly shut the " +
-                            "AliveCheck down. Exiting now. " + e.toString() + " My ID is " + myID + ".");
-                    e.printStackTrace(System.err);
-                    System.exit(0);
-                }
-            } else if(whatNext == SNAFU){
-                System.err.println("ERROR: Shutting down ungracefully, server required so. My ID is " + myID + ".");
-                System.exit(33);
-            } else{
-                // unknown state, once more
-                System.err.println("ERROR: Unknown return code after handing " +
-                        "result over. Aborting. My ID is " + myID + ".");
-                System.exit(55);
-            }
+      } else if (whatNext == FINISH) {
+        System.out.println(
+            "INFO: Shutting down gracefully. Thanks and bye. :-) My ID is " + myID + ".");
+        try {
+          aliveCheck.done();
+          break WorkLoop;
+        } catch (Exception e) {
+          System.err.println(
+              "WARNING: Couldn't properly shut the "
+                  + "AliveCheck down. Exiting now. "
+                  + e.toString()
+                  + " My ID is "
+                  + myID
+                  + ".");
+          e.printStackTrace(System.err);
+          System.exit(0);
         }
-     }
+      } else if (whatNext == SNAFU) {
+        System.err.println(
+            "ERROR: Shutting down ungracefully, server required so. My ID is " + myID + ".");
+        System.exit(33);
+      } else {
+        // unknown state, once more
+        System.err.println(
+            "ERROR: Unknown return code after handing "
+                + "result over. Aborting. My ID is "
+                + myID
+                + ".");
+        System.exit(55);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This gets rid of a runtime warning that Lottery hasn't been initialized. We however trade this for a build-time spotbugs warning that we use Random to create the seed only once.