### PR TITLE
Add a markdown manual converter.

### DIFF
--- a/manual/README.md
+++ b/manual/README.md
@@ -1,0 +1,44 @@
+# OGOLEM Manual
+
+LaTeX source for the OGOLEM manual (input formats, keywords, backends, and usage).
+
+## How to get the manual
+
+- **Pre-built PDF**  
+  The manual is built automatically on every push/PR. To get the PDF:
+  1. Open the **Actions** tab of this repository (on GitHub).
+  2. Open the latest successful workflow run.
+  3. Download the **ogolem_artifacts** artifact; it contains `manual.pdf` (along with the jar and other build outputs).
+
+- **Build locally**  
+  From the repository root:
+  ```bash
+  cd manual && pdflatex manual.tex && bibtex manual && pdflatex manual.tex && pdflatex manual.tex
+  ```
+  Then open or copy `manual/manual.pdf`.
+
+## Markdown version (GitHub-friendly)
+
+A Markdown version of the manual lives in **[md/](md/)**. It is split into one file per chapter with internal links, so you can read and navigate it directly on GitHub (no build step).
+
+- **Index:** [md/README.md](md/README.md) — links to all chapters.
+- **Regenerate from LaTeX:** Install [pandoc](https://pandoc.org/), then from this directory run:
+  ```bash
+  python3 tex2md.py
+  ```
+  This overwrites the contents of `md/` with a fresh conversion from `manual.tex`. Commit the updated `md/` files to keep the on-GitHub manual in sync with the LaTeX source.
+
+## Contents
+
+The manual covers:
+
+- Building and running OGOLEM, command-line modes, and JRE requirements  
+- Global optimization of clusters: input structure, building blocks, constraints, keywords, local optimizers and backends  
+- Global parametrization (potentials, pseudopotentials, etc.)  
+- Molecular design (switchable molecules, general design)  
+- Lionbench meta-benchmarking  
+- Lid/threshold capabilities  
+- JVM-based distributed parallelization (RMI)  
+- FAQs and troubleshooting  
+
+For a quick start, see the main [README](../README.md) in the repository root.

--- a/manual/md/01-general-remarks.md
+++ b/manual/md/01-general-remarks.md
@@ -1,0 +1,184 @@
+# General remarks
+
+## This manual
+
+Is alpha and might not include everything you would like to know. If this is true, contact <span class="smallcaps">ogolem</span> via webpage and mail. If you happen to find any kind of error or uncertainty, please do also contact us.
+
+## Licensing
+
+<span class="smallcaps">ogolem</span> is distributed under the following license
+
+    Copyright (c) 2009-2023, J. M. Dieterich and B. Hartke
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above copyright
+          notice, this list of conditions and the following disclaimer in the
+          documentation and/or other materials provided with the distribution.
+
+        * All advertising materials mentioning features or use of this software
+          must display the following acknowledgement:
+
+          This product includes software of the ogolem.org project developed by
+          J. M. Dieterich and B. Hartke (Christian-Albrechts-University Kiel,
+          Germany) and contributors.
+
+        * Neither the name of the ogolem.org project, the University of Kiel
+          nor the names of its contributors may be used to endorse or promote
+          products derived from this software without specific prior written
+          permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ''AS IS'' AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+in the hope to help people crack problems and enable interesting science. We do ask you to cite our papers introducing the framework and techniques you use in your publications(Dieterich and Hartke 2010, 2011, 2012, 2014; Carstensen et al. 2011; Dieterich et al. 2011; Buck et al. 2014; Forck et al. 2012; Dieterich, Clever, et al. 2012; Frank et al. 2013; Dieterich, Gerke, et al. 2012). Depending on what is used in or through <span class="smallcaps">ogolem</span> additional citations to papers describing these methods may be required.
+
+We encourage all collaborations, external implementations, usages of <span class="smallcaps">ogolem</span> as a library for any purposes. We are open for discussions regarding uses of <span class="smallcaps">ogolem</span> under `developers@ogolem.org`.
+
+## External libraries and code contributions
+
+<span class="smallcaps">ogolem</span> is grateful for the following codes it uses or took inspiration from (in random oder):
+
+- Atomdroid by J. Feldt, R. A. Mata and J. M. Dieterich (proprietary
+  license)
+
+- Lionbench by M. Kammler and J. M. Dieterich (4-clause BSD)
+
+- L-BFGS from RISO by J. Nocedal and R. Dodier (Apache/public domain)
+
+- BOBYQA from the Apache Software Foundation (Apache)
+
+- NEWUOA code by J. Feldt and J. M. Dieterich, original by M. J. D.
+  Powell (public domain)
+
+- JAMA
+
+- Apache Commons Math
+
+- Scala
+
+- openJDK
+
+- Numal
+
+- Arpack/Netlib
+
+- SL4J
+
+- JGraphT
+
+- mpiJava
+
+- phenix v0-42
+
+- Tinker
+
+## Financial Acknowledgements
+
+The authors would like to acknowledge the following affiliations:
+
+- J. M. Dieterich
+
+  - *2008-2010:*  
+    Institute for Physical Chemistry  
+    Christian-Albrechts-University Kiel  
+    Germany, Europe
+
+  - *2010-2012:*  
+    Institute for Physical Chemistry  
+    Georg-August-University Göttingen  
+    Germany, Europe
+
+  - *2015-2018*  
+    Department of Mechanical&Aerospace Engineering  
+    Princeton University  
+    USA
+
+- B. Hartke
+
+  - *2008-now:*  
+    Institute for Physical Chemistry  
+    Christian-Albrechts-University Kiel  
+    Germany, Europe
+
+## The <span class="smallcaps">ogolem</span>-jar
+
+<span class="smallcaps">ogolem</span> is distributed as a single jar file. By invoking
+
+    java -jar ogolem.jar
+
+followed by a single mandatory flag deciding which program part to use. These flags are
+
+       --adaptive
+         for global parameter optimization
+       --beswitched
+         for extracting intermediate switch optimization results
+       --clusteroverlap
+         for checking if two cluster structures are identical
+       --core
+         for MPI parallelized cluster structure optimization
+       --corrfunc
+         to compute correlation functions from MD trajectories
+       --help
+         to display this overview
+       --md
+         for running simple molecular dynamics
+       --molecules
+         to optimize molecules with respect to a or multiple properties
+       --parameters
+         for extracting intermediate parametrization results
+       --rmiserver
+         for starting an OGOLEM RMI server
+       --rmiproxy
+         for starting an OGOLEM RMI proxy
+       --rmiclient
+         for starting an OGOLEM RMI client
+       --rmithreader
+         for starting an OGOLEM RMI threading client
+       --shmem
+         for thread-based cluster structure optimization
+       --switches
+         for thread-based molecular switch optimization
+       --tests
+         for testing and development purposes
+       --version
+         for the OGOLEM snapshot version
+
+Please note here that you should have installed a Java runtime environment (JRE) complying at least to the JAVA21 standard. Additionally, for above command to work, the java binary should be in your path, otherwise you will need to explicitly specify the path to it.
+
+If you have a choice, use the newest openJDK (currently openJDK21) in server mode (the latter is really important for general performance and seems to be the default for most JREs for most UNIX incarnations). Also, the author(s) want to note that they could not see any performance gain on standard hardware with proprietary JREs like JRockit or IBM JDK.
+
+## General notes
+
+### Units
+
+All units within <span class="smallcaps">ogolem</span> are (if applicable) atomic units. As a secondary system, we provide SI units as a convinience. Therefore, input and output is (unless explicitly stated otherwise) in atomic units. Obviously, this only applies for the case of data having a physical meaning, otherwise input/output is system dependent and typically unit-free.
+
+## Bugs and problems
+
+Since <span class="smallcaps">ogolem</span> is a relatively new program that is still changing rapidly, we unfortunately can only guarantee that you will probably hit bugs and problems.
+
+In case you hit a bug:
+
+- Relax.
+
+- Mail `developers@ogolem.org` describing the problem and how to
+  reproduce it. Please attach input and error messages (in particular:
+  stack traces).
+
+- Wait for the bugfix which will be rolled automatically in the next
+  autobuild.
+

--- a/manual/md/02-global-optimization-of-clusters.md
+++ b/manual/md/02-global-optimization-of-clusters.md
@@ -1,0 +1,1504 @@
+# Global optimization of clusters
+
+For the global optimization of cluster structures on a shared memory basis, invoke
+
+    java -jar ogolem.jar --shmem input.ogo 2
+
+where `input.ogo` is your input file, needing to have `.ogo` as a suffix, followed by the number of threads you want to use, 2 in this case.
+
+If you want to make use of the MPI frontend, please see notes in `mpi_helper/HOWTORUNMPI.md` on how to link <span class="smallcaps">ogolem</span> to a MPI implementation. In general, using the shared memory parallelization will be easier and is preferred for multi-CPU, single-node jobs.
+
+See Chapter. <a href="#rmi" data-reference-type="ref" data-reference="rmi">8</a> for a JVM-based substitute for MPI with some more advanced distribution of computing tasks and stability. However, this feature requires some setup! Please contact the authors for help with this.
+
+## General input structure
+
+Every input file needs to start with the line
+
+    ###OGOLEM###
+
+for <span class="smallcaps">ogolem</span> to recognize that this is supposed to be a valid input file. Now you can add some input keywords and the building block input. This includes the actual cluster building blocks (atoms or molecules) as well as (if applicable) spins and charges.
+
+In case of explicit degree of freedom searches or constraints, more input blocks are necessary.
+
+## Building block input
+
+In general, any combination of any building blocks is possible in principle. The only thing you should have for the easiest case is the number of building blocks and xyz-files of all your units.
+
+The input starts with an opening tag followed by the number of building blocks in the next line, 5 in this example
+
+    <GEOMETRY>
+    NumberOfParticles=5
+
+The building blocks (named molecules) are now put there in a similar form after each other, for example
+
+    <MOLECULE>
+    MoleculePath=water.xyz
+    </MOLECULE>
+    <MOLECULE>
+    MoleculePath=ethanol.xyz
+    </MOLECULE>
+    <MOLECULE>
+    MoleculePath=citronacid.xyz
+    </MOLECULE>
+    <MOLECULE>
+    MoleculePath=quinine.xyz
+    </MOLECULE>
+    <MOLECULE>
+    MoleculePath=water.xyz
+    </MOLECULE>
+
+The number of molecules and the `NumberOfParticles` needs to agree, otherwise an exception will be raised.
+
+If the molecule consists of a single atom, another input option might be easier
+
+    <MOLECULE>
+    Na;0.0;0.0;0.0
+    </MOLECULE>
+
+where the 0.0s are internal xyz values.
+
+In case of the molecule having internal degrees of freedom that should be explicitly optimized, the molecule path must point to a z-Matrix and the first line in the definition is the flexy keyword
+
+    <MOLECULE>
+    flexy
+    MoleculePath=methanol.zmat
+    </MOLECULE>
+
+It should be noted that the zmat-format chosen is of form
+
+    6
+
+    C
+    O  1.4   1
+    H  0.95  2  109.471 1
+    H  1.089 1  109.471 2  120.0 3
+    H  1.089 1  109.471 2  240.0 3
+    H  1.089 1  109.471 2  0.0   3
+
+A bond matrix for the building block may be specified by the user through the `BondMatrix=` keyword. It must only be used following the `MoleculePath=` keyword in both flexible and non-flexible input. This path is relative to the location of the `.ogo` file and must point to a file containing the bond matrix definition, either as a complete matrix or as a bond list. This input option must be used if the molecule does not only contain single bonds or if the automatic bond detection (see output) fails to correctly assign bonds. Examples:
+
+    <MOLECULE>
+    flexy
+    MoleculePath=water.zmat
+    BondMatrix=waterbonds.mat
+    </MOLECULE>
+
+where `waterbonds.mat` (name must not end with `.list` and is otherwise not important) contains
+
+    1 1 1
+    1 1 0
+    1 0 1
+
+where 1 denotes a single bond, 0 denotes no bond. The bonds on the diagonal are arbitrary. Allowed bonds are: 0 for no bond, 1 for a single, 2 for a double, and 3 for a triple bond. We will add more bond types as backends make use of them.
+
+Another example usage:
+
+    <MOLECULE>
+    MoleculePath=water.zmat
+    BondMatrix=waterbonds.list
+    </MOLECULE>
+
+where `waterbonds.list` (files containing bond lists must end in `.list`) contains
+
+    0 1 1
+    0 2 1
+
+do denote a single bond between atoms 0 and 1 and 0 and 2 in the molecule.
+
+Obviously the list-based input is less verbose/redundant and should be used in general. Please note once more that the counting starts with zero! Both list-based and matrix-based input may be used in both the flexible and non-flexible context.
+
+The geometry definition is closed using a line with a
+
+    </GEOMETRY>
+
+tag. Please note that the numbering of molecules for all subsequent inputs starts from 0.
+
+This is followed by, if applicable, input concerning spins and charges. Charges are defined as follows
+
+    <CHARGES>
+    MOLECULENO;ATOMNO;CHARGE
+    </CHARGES>
+
+for example
+
+    <CHARGES>
+    0;0;1
+    1;3;-2
+    </CHARGES>
+
+Above example would put a single positive charge at the first atom of the first molecule and two negative ones at the fourth atom of the second molecule. It is important to note here that, since arrays in the Java language start with 0 and not 1 as in some prehistoric languages, our counting also starts at 0.
+
+A similar input structure exists for the spins in the system, namely
+
+    <SPINS>
+    MOLECULENO;ATOMNO;SPIN
+    </SPINS>
+
+for example
+
+    <SPINS>
+    0;2;1
+    1;3;-1
+    </SPINS>
+
+where the above example would put a single spin up at atom 0 of molecule 2 and a spin down at atom 3 of molecule 1.
+
+Should there be no spins or charges in the studied system, no spins or charges block is necessary.
+
+Note for larger systems build from only a few building blocks: one can add inside the `<MOLECULE>` block the `MoleculeRepetitions=` keyword and set it to the number of species of this type. Please note two things: 1) the `NumberOfParticles=` setting must still match the total number of species and 2) the spins/charges/... are automatically reproduced for all species of one type. An example:
+
+    GEOMETRY>
+    NumberOfParticles=24
+    <MOLECULE>
+    MoleculeRepetitions=23
+    MoleculePath=water.xyz
+    </MOLECULE>
+    <MOLECULE>
+    MoleculeRepetitions=1
+    MoleculePath=water.xyz
+    </MOLECULE>
+    </GEOMETRY>
+    <CHARGES>
+    0;0;0
+    1;0;-1
+    </CHARGES>
+
+would put 23 neutral water molecules and 1 negatively charged one into the cluster. The first charge line is not needed.
+
+## Constraints and explicit degrees of freedom
+
+Constraints can be specified based on Cartesian coordinates. Although <span class="smallcaps">ogolem</span> internally allows for arbitrary constraints to be specified, the backend carrying out the local optimization might not like that. In this case, a warning should appear.
+
+In general, the constraints are specified similar to the spins and charges, through tags of form
+
+    <CONSTRAINTS>
+    MOLECULENO;ATOMNO;COORDINATE
+    </CONSTRAINTS>
+
+where the cartesian coordinate is chosen through an integer value (0 is x, 1 is y and 2 is z). Additionally, special input exists to constrain a whole molecule or all x, y or z coordinates of a molecule. Some example are
+
+    <CONSTRAINTS>
+    0;all
+    1;allx
+    2;ally
+    3;allz
+    4;1;0
+    4;2;1
+    5;0;2
+    </CONSTRAINTS>
+
+The first one constraining all cartesian coordinates of molecule 0, the second only the x coordinates of molecule 1, the third the y coordinates of molecule 2 and the fourth the z coordinates of molecule 3. Then the x coordinate of atom 1 in molecule 4 is constrained, followed by y coordinate of atom 2 in molecule 4 and the z coordinate of atom 0 in molecule 5. Any logical combination of the above described input possibilities is allowed and supported by <span class="smallcaps">ogolem</span>.
+
+Constraints are currently only supported in the following interfaces:
+
+- DFTB+  
+  in this case the constraint is actually a restraint and the
+  convergence threshold needs to be increased since the gradient along
+  the restraint is included in the calculation
+
+- lotriff
+
+- MOPAC
+
+- Orca
+
+Again, if your preferred level of theory does not support constraints in <span class="smallcaps">ogolem</span> and you would like to use that feature, contact us (preferably with reference input for that particular program) or send us patches.
+
+Explicit degrees of freedom are a rather untested feature, therefore one unfortunaltely needs to expect some rough edges. Also it should be noted that you cannot put constraints and explicit degrees of freedom on the same molecule.
+
+As said before, you need to enable flexibility on the molecule with explicit degrees of freedom in the building block input and need to speify a z-Matrix instead of cartesian coordinates. When this has been ensured, the specification of explicit degrees of freedom is relatively straightforward. Again, it includes definitions of type
+
+    <DOF>
+    MOLECULENO;ATOMNO;COORDINATE
+    </DOF>
+
+where the coordinate is a choice for the coordinate in the z-Matrix (i.e., distance, angle, dihedral). For example
+
+    <DOF>
+    0;1;dihedral
+    2;3;distance
+    4;2;angle
+    </DOF>
+
+where the first line would make the dihedral of atom 1 in molecule 1, the second would make the bond distance of atom 3 in molecule 2 and the third would make the angle of atom 2 in molecule 4 an explicit DoF. Alternatively, one may use the syntax
+
+    <DOF>
+    0;all
+
+to enable explicit degrees of freedom for all DoFs of molecule 0.
+
+Please let us know about any experiences with explicit DoFs, may they be good or bad.
+
+## Input keywords
+
+There are a lot of possible tunables in the <span class="smallcaps">ogolem</span> framework. Some of them are more important than others and should actually be adjusted to the studied system.
+
+- `DebugLevel=` the debug level: controls additional output of some code
+  parts. Please set to 1 or higher <span class="smallcaps">first</span>
+  if you ever have unexpected failures or problems. Defaults to 0.
+
+- `BlowBondDetect=`  
+  a collision is detected if any of the non-bonded atoms in the
+  structure are getting closer to each other than this blow factor times
+  their added radii. Defaults to 1.2, which is a rather conservative
+  choice.
+
+- `BlowFacDissoc=`  
+  the blow factor for the dissociation detection. Defaults to 3.0 which
+  should be decreased for LJ systems (e.g. 2.0 seems to be a reasonable
+  choice). Notice that this setting has changed since the last version!
+
+- `BlowInitialBonds=`  
+  the blow factor for the initial bond detection. Since these bonds are
+  the basis for both the post sanity check and the CD, the factor
+  normally should be equal to `BlowBondDetect=`. Also defaults to 1.2.
+
+- `CellSize=`  
+  how big the initial cell should be for the initial structure
+  generation. Defaults to a `9;9;9` bohrs which is too small for bigger
+  systems.
+
+- `InitialFillAlgo=`  
+  how the intial individuals should be generated. Defaults to
+  `packrandomly`, which is a randomized packing init w/o considering
+  molecular size. If that should be yielding too densly packed (or
+  spherical) structures, change to `randomwithoutdd`, which is a
+  randomized init w/o dissociation detection or `randomwithdd`, which is
+  a randomized init w/ DD.
+
+- `MaxIterLocOpt=`  
+  how many iterations the local optimization is allowed to carry out.
+  Defaults to 2000.
+
+- `NumberOfGlobIterations=`  
+  how many global optimization steps should be carried out. Defaults to
+  1000 which is just sufficient for the most trivial cases. This value
+  must be increased for production jobs!
+
+- `PoolSize=`  
+  one of the most important keywords. Specifies how big the genetic pool
+  is allowed to be. Defaults to 100 individuals.
+
+- `AcceptableFitness=`  
+  <span id="page1:acceptableFitness"
+  label="page1:acceptableFitness"></span> what fitness is acceptable and
+  once reached makes the threading version of
+  <span class="smallcaps">ogolem</span> finish. Set to negative infinity
+  per default and should only be set for benchmarking purposes and only
+  if you are know your way around the
+  <span class="smallcaps">ogolem</span> program code extremely well.
+
+- `CollisionDetection=`  
+  which collision detection to use. Defaults to `simplepairwise`, which
+  is a pairwise collision detection engine. Keep.
+
+- `CrossoverPossibility=`  
+  chances for crossover in the global optimization. Defaults to 1.0
+  (100%).
+
+- `DissociationDetection=`  
+  which dissociation detection to use. Defaults to `dfs`, which is a
+  recursive quadratic scaling algorithm. Keep.
+
+- `DoGeometryNiching=`  
+  if a niching algorithm should be used for this run. Defaults to false.
+
+- `GeneticRecordBufferSize=`  
+  number of steps till a summary of the genetic records are flushed to
+  the output file. Defaults to 1000.
+
+- `GeneticRecordsToSerial=`  
+  number of steps till the genetic records are written to disk. Defaults
+  to 1000.
+
+- `GeometriesToSerial=`  
+  number of steps till the pool is written to disk. Defaults to 99,
+  which is too small for big systems with a lot of steps and causes an
+  1/O bottleneck and should be increased then.
+
+- `SerializeAfterNewBest=`  
+  if the pool shall be serialized whenever a new best individual has
+  been added. Defaults to true.
+
+- `GeometryChoice=`  
+  how the parent individuals should be selected. Three options exist:
+
+  - `random:`  
+    both parent individuals are randomly selected. With the additional
+    option `stepat=X.X` (with $`0\leq`$`X.X`$`\leq 1`$) this is turned
+    into a step-function selector for the first X.X percent of the
+    sorted pool. With `stepat1=X.X,stepat2=Y.Y`, you can assign
+    different step functions to parent1 and parent2. When no steps are
+    given/desired, this corresponds to `X.X`=`Y.Y`=1
+
+  - `fitnessrankbased:`  
+    one or both parents are selected based on a Gaussian over their
+    ranked fitness. Valid, comma separated options: `bothfitness`:
+    choose both parents fitness based (default: no), `gausswidth=X.X`
+    sets the width of the Gaussian to X.X (default: 0.5). If you want to
+    select parent1 and parent2 with Gaussians of different width, simply
+    use `gausswidth1=X.X` and `gausswidth2=Y.Y`. Our default selector
+    with a Gaussian width of 0.05.  
+    **THIS SETTING WILL VERY LIKELY CHANGE IN THE VERY NEAR FUTURE!**
+
+  - `fitnessvaluebased:`  
+    one or both parents are selected based on their fitness value.
+    Valid, comma separated options: `bothfitness`: choose both parents
+    fitness based (default: no), `usegausshape`: use a Gaussian shaped
+    random number for the selection (default: linear), `tailprob=X.X`
+    sets the tail probability to X.X (default: 0.1). The tail
+    probability is defined as the probability for the last element in
+    the pool to be chosen with the head probability (i.e., the
+    probability for the fittest individual) being 1.0.
+
+- `GlobOptTries=`  
+  how many tries the global optimization algorithm should carry out at
+  any step that cause either collision and/or dissociation before
+  proceding with the next parents. Defaults to 200 which is suitable for
+  bigger systems with more degrees of freedom.
+
+- `GrowCell=`  
+  whether the cell of the starting structure is allowed to grow.
+  Defaults to `false`. If you are having problems with the randomized
+  structure preparation, specify a bigger cell and/or set this to
+  `true`.
+
+- `IntLocOptMaxStep=`  
+  the maximum step length for the internal BFGS. Defaults to 1E0 which
+  seems to be reasonable.
+
+- `IndividualsPerNicheAtMax=`  
+  how many individuals are maximally allowed per niche, if niching is
+  enabled. Defaults to 50.
+
+- `MaxBondStretch=`  
+  how much a bond is allowed to be streched as a factor. Defaults to 1.3
+  which seems to be reasonable.
+
+- `MolecularCDInInit=`  
+  whether there should be a molecular collision detection in the
+  geometry initialization. Defaults to true.
+
+- `MolecularCoordinateMutation=`  
+  how the coordinates should be mutated. Defaults to `some`, which
+  always mutates a couple of them at the same time. `one` just mutates a
+  single one at any time.
+
+- `MutationPossibility=`  
+  chances for mutation of an individual during the global optimization.
+  Defaults to 0.05 (5%).
+
+- `NichingAddsToStats=`  
+  how many individuals shall be added to niches (if enabled) before
+  statistics are printed to command line. Defaults to 50.
+
+- `PostSanityCD=`  
+  if post-local optimization sanity checks are enabled, should the
+  resulting structure be checked for collisions? Defaults to false.
+
+- `PostSanityDD=`  
+  if post-local optimization sanity checks are enabled, should the
+  resulting structure be checked for dissociation? Defaults to false.
+
+- `PostSanityCheck=`  
+  whether the structure should be checked for sanity after the local
+  optimization. Defaults to `true` which is reasonable for most cases.
+
+- `PrintGeomsBeforeLocOpt=`  
+  whether the geometries should be printed to the command line after the
+  global optimization operators, before the local optimization. Useful
+  for setup purposes. Defaults to false.
+
+- `RatioExplDoFInit=`  
+  what fraction of the explicit degrees of freedom should be randomized
+  in the initialization. Applied per molecule with explicit DoFs.
+  Defaults to 1.0, which might be too big for big molecules with a lot
+  of explicit DoFs. If <span class="smallcaps">ogolem</span> seems to be
+  stalled in the init, this might be a reason.
+
+- `SeedingPath=`  
+  if the initial pool should be seeded with some structures set this to
+  the folder containing these structures in the xyz-file format.
+  <span class="smallcaps">ogolem</span> will try to read in all files in
+  this folder so there must only be xyz files present.
+
+- `ThreshLocOptCoord=`  
+  which threshold is acceptable for the coordinates in the local
+  optimization. Defaults to 1E-8 which should be kept, if one is
+  uncertain.
+
+- `ThreshLocOptGradient=`  
+  which threshold is acceptable for the gradient in the local
+  optimization. Defaults to 1E-8 which should be kept, if one is
+  uncertain.
+
+Some special keywords for restarts are
+
+- `restart=`  
+  Whether this run is supposed to be restarted or not. Defaults to
+  `false`. If set to `true`, some other keywords need to be set as well
+
+- `InitialFill=`  
+  Defaults to `true` and defines whether we should make an initial fill.
+  Will be automagically set by the restart keyword.
+
+- `InitialLocOpt=`  
+  Defaults to `true` and defines whether the read in pool should be
+  locally optimized in a first step.
+
+- `GlobalOptimization=`  
+  Defaults to `true` and defines whether there should be any global
+  optimization steps.
+
+- `NamingOffset=`  
+  which ID to start from. Increase to the number of steps of your
+  previous run.
+
+However, we have found it superior to use (part of) the results of a previous run as seeds for a subsequent run. Hence, these options may vanish in the future.
+
+Within the block of keywords, one can comment lines using either `#` or `//`.
+
+## Local optimization and external backends
+
+<span class="smallcaps">ogolem</span> supports a variety of program packages through interfaces. We hope that this satisfies most users. If there should be a (preferably free) program that you want to see supported and/or the methods listed here to do not satisfy you, feel free to write a mail to developers@ogolem.org .
+
+In general, most methods are easily called through input of form
+
+    LocOptAlgo=PACKAGE:METHOD
+
+In general, there are thoughts to change this input for something more flexible so future versions might behave different. Also it should be noted that of course <span class="smallcaps">ogolem</span> might not support any revision of the programs mentioned if their input changes. If you should hit such a case and are not working with some ancient version (e.g. there is for sure no PM6 in MOPAC7), please contact us and wait for a fix.
+
+### Interface to ADFSuite
+
+An experimental interface to the ADFSuite of programs exists. It is chosen by setting `LocOptAlgo=adf:JOBKEY`, where `JOBKEY` can either be a build-in job identifier, such as `GO` or `DFTB-GO`, or the file name of an adf stub file, e.g., `mylocopt.adf`. In the later case, this file name must end in `.adf` and be present in the working directory.
+
+A stub file can be created using, e.g., `adfjobs` and tuned to the particular computational needs of the system under study.
+
+**IMPORTANT:** <span class="smallcaps">ogolem</span> will **NOT** adjust anything except for the geometry coordinates in the job stub file. Therefore, a charged system or a system with spin does require creation of a fitting job stub file. Likewise, convergence thresholds will not be propagated from within <span class="smallcaps">ogolem</span> to ADF and must be set in the job stub file!
+
+Please note, you must have all the usual ADF/SCM environment variables properly setup, e.g., `SCMLICENSE` and `ADFBIN`. This can be done by sourcing the correct setup file for your platform. Obviously, a valid license for the codes to be run is required.
+
+### Interface to AMBER
+
+The interface to AMBER is called through `LocOptAlgo=amber`, followed by the optional choice `:implicitwater`, if implicit solvation is wanted or needed.
+
+The `sander` executable needs to be in the path and named such.
+
+Additionally, there needs to be a fitting amber parameter file named `input.prmtop`, where `input` is the prefix of your `input.ogo` file.
+
+The AMBER interface in its current state is not suitable for molecule only optimizations. This does currently not have any effect on <span class="smallcaps">ogolem</span>.
+
+### Interface to CP2K
+
+The interface to CP2K is called through `LocOptAlgo=cp2k:`, followed by a sequence of keywords to specify the level of theory. Supported levels of theory at the moment are
+
+- `B3LYP`
+
+- `BLYP`
+
+- `BP`
+
+- `HCTH120`
+
+- `OLYP`
+
+- `PADE`
+
+- `PBE`
+
+- `PBE0`
+
+- `TPSS`
+
+The `cp2k.sopt` executable needs to be in the path and named such.
+
+Additionally, an `input-cp2k.aux` file is required, where `input` is the prefix of your `ogo`-file. This auxiliary file needs to start with a line
+
+    ###OGOLEMAUX###
+
+followed by a range of lines specifying in three whitespace-separated columns which atom should use which basis set and which potential. These potentials and basis sets need to be present in the directory.
+
+### Interface to CPMD
+
+The interface to CPMD is called through `LocOptAlgo=cpmd:`, followed by a sequence of keywords to specify the level of theory. Supported levels of theory at the moment are
+
+- `SONLY`
+
+- `LDA`
+
+- `BONLY`
+
+- `BP`
+
+- `BLYP`
+
+- `XLYP`
+
+- `GGA`
+
+- `PBE`
+
+- `PBES`
+
+- `REVPBE`
+
+- `HCTH`
+
+- `OPTX`
+
+- `OLYP`
+
+- `TPSS`
+
+- `PBE0`
+
+- `B1LYP`
+
+- `B3LYP`
+
+- `X3LYP`
+
+- `CUSTOM`
+
+The `cpmd.x` executable needs to be in the path and named such.
+
+Additionally, an `input-cpmd.aux` file is required, where `input` is the prefix of your `ogo`-file. This auxiliary file needs to start with
+
+    ###OGOLEMAUX###
+    70
+    15;15;15
+
+Where the second line is the cutoff in Rydberg and the third line is the cell size to be used (if line is empty it will be estimated for each geometry, based on the assumption of a clustered system!). This is followed by a range of lines specifying in three whitespace-separated columns which atom should use which pseudopotential and which lmax. The pseudopotentials need to be present in the directory. Please note that no extra lines are allowed.
+
+### Interface to DFTB+
+
+The interface to DFTB+ is called through `LocOptAlgo=dftb+:`, followed by a sequence of keywords to specify some needed parameters for the local optimization employed by DFTB+
+
+- `steepest`  
+  use a steepest descent algorithm
+
+- `conjugate`  
+  use a conjugate gradient algorithm
+
+- `steepest,scc`  
+  use a steepest descent algorithm with SCC approximation
+
+- `conjugate,scc`  
+  use a conjugate gradient algorithm with SCC approximation
+
+The DFTB+ executable needs to be in your path and named `dftb+`.
+
+Additionally, you need to make sure to have all Slater-Koster files for all interactions in your system in the directory your `ogo`-input file is. This is needed for <span class="smallcaps">ogolem</span> using the SK-files for the DFTB+ input.
+
+### Interface to GROMACS
+
+The interface to GROMACS is called through `LocOptAlgo=gromacs`. It is followed by an optional choice of the QM backend to be used. Choices are
+
+- empty/whitespace  
+  no QM backend
+
+- `:mopac`  
+  use MOPAC7 as a backend. Please note that MOPAC7 only provides AM1 and
+  PM3.
+
+- `:orca`  
+  use Orca as a backend.
+
+- `:gaussian`  
+  use Gaussian as a backend.
+
+- `:gamess-uk`  
+  use Gamess-UK as a backend.
+
+In all cases, the GROMACS binaries need to be recompiled according to the GROMACS documentation depending on the chosen backend.
+
+The path to the `grompp` and `mdrun` excecutables needs to be exported through the environment variables `OGO_GROMACSMPP` and `OGO_GROMACSCMD`, e.g. in bash syntax
+
+    export OGO_GROMACSMPP=$HOME/software/gromacs/grompp
+    export OGO_GROMACSCMD=$HOME/software/gromacs/mdrun
+
+Additionally, the files
+
+- `gromacs-topology.top`,
+
+- `gromacs-parameters.mdp` and
+
+- `gromacs-index.ndx`
+
+need to present and correct for the system under study. These files are also responsible for all GROMACS related configuration, e.g. constraints and QM/MM partitioning. The file
+
+    INPUTNAME-gromacs.aux
+
+needs to contain in the first line the identifier `###OGOLEMAUX###` followed by the first half of a `.g96` file of the system (residue and atom-IDs).
+
+If one uses Orca as a QM-backend for Gromacs, one also needs to export the path to the orca excecutables and the basename of the optimization job. This is e.g. in bash syntax accomplished through
+
+    export ORCA_PATH=$HOME/software/orca
+    export BASENAME=topol
+
+where the `BASENAME` is always `topol`! Additionally, the file `gromacs-orca.aux` needs to contain the input keywords, as described in the GROMACS manual.
+
+### Interface to lotriff
+
+Lotriff is an in-house development by Bernd Hartke. If you are in desperate need of this FF engine, contact him via mail. If you obtained the `lotriff` executable you can use `LocOptAlgo=lotriff`.
+
+The path to the lotriff executable needs to be exported in the `OGO_LOTRIFFCMD` environment variable, e.g. in bash syntax
+
+    export OGO_LOTRIFFCMD=$HOME/software/lotriff/lotriff
+
+If this variable should be not set, <span class="smallcaps">ogolem</span> will assume the binary to be in your path.
+
+Additionally, a correct `lotriff.in` file and a correct `hetero.def` file need to be present in your directory, the constrained building blocks are supposed to be specified first in the building block input.
+
+A mapping of atom types in an auxiliary file `input-lotriff.aux`, where input is the prefix of your input file name, needs to be present. First line of this file needs to be
+
+    ###OGOLEMAUX###
+
+followed by a column of force field types as present in your lotriff input.
+
+The lotriff interface in its current state is not suitable for molecule only optimizations. This does currently not have any effect on <span class="smallcaps">ogolem</span>.
+
+### Interface to MNDO
+
+The interface to MNDO is called through `LocOptAlgo=mndo:`, followed by a sequence of keywords to specify the method. Builtin support exists at the moment for the following levels of theory
+
+- `mndod`
+
+- `om1`
+
+- `om2`
+
+- `om3`
+
+- `pm3`
+
+- `am1`
+
+- `mndoc`
+
+- `mndo`
+
+- `mindo3`
+
+- `cndo2`
+
+- `scc-dftb`
+
+- `scc-dftbj`  
+  Jørgensen DFTB
+
+all of the above can make use of implicit solvation using COSMO when appending `:cosmo`.
+
+Since the MNDO program is rather unique when it comes to input and output, it was ultimately decided to call not MNDO directly but instead to always call a shell-script which just wraps that. This obviously just works on UNIX machines but MNDO is also just available for them to our knowledge.
+
+The shell script, named `mndo.sh`, needs to be in the path and include something alike to the following
+
+    #!/bin/sh
+    $1 > mndo > $2
+
+### Interface to MOLPRO
+
+The interface to MOLPRO is called through `LocOptAlgo=molpro:`, followed by a sequence of keywords to specify the method. Builtin support exists at the moment for the following levels of theory
+
+- `hf/vdz`
+
+- `b86/vdz`
+
+- `mp2/avtz`
+
+- `custom`  
+  Requiring you to provide an input stub `YOURINPUT-molpro.aux`
+  containing all relevant input and instead of the geometry the key
+  `OGOCOORDS`.
+
+- `custom,nolocopt`  
+  Just like above, an auxiliary file is required, with the `nolocopt`
+  flag signaling that no local optimization takes place, interesting for
+  chained local optimizations.
+
+Additionally, the location of the MOLPRO executable needs to be exported in the environment variable `OGO_MOLPROCMD`, e.g. in bash syntax
+
+    export OGO_MOLPROCMD=$HOME/software/molpro2010.1/bin/molpro
+
+If this variable should be not set, <span class="smallcaps">ogolem</span> will assume the binary to be in your path.
+
+Since MOLPRO is a closed-source program it is only supported on the platforms the official MOLPRO release supports.
+
+### Interface to MOPAC
+
+The interface to MOPAC is called through `LocOptAlgo=mopac:`, followed by a sequence of keywords to specify the method. Builtin support exists at the moment for the following levels of theory
+
+- `mndo`
+
+- `am1`
+
+- `pm3`
+
+- `pm5`
+
+- `pm6`
+
+- `mndo,cosmo(ethanol)`
+
+- `am1,cosmo(ethanol)`
+
+- `pm3,cosmo(ethanol)`
+
+- `pm5,cosmo(ethanol)`
+
+- `pm6,cosmo(ethanol)`
+
+- `mndo,cosmo(water)`
+
+- `am1,cosmo(water)`
+
+- `pm3,cosmo(water)`
+
+- `pm5,cosmo(water)`
+
+- `pm6,cosmo(water)`
+
+Additionally, the location of the MOPAC executable needs to be exported in the environment variable `OGO_MOPACCMD`, e.g. in bash syntax
+
+    export OGO_MOPACCMD=$HOME/software/mopac2010/mopac
+
+If this variable should be not set, <span class="smallcaps">ogolem</span> will assume the binary to be in your path.
+
+Since MOPAC is a closed-source program it is only supported on the platforms the official MOPAC release supports.
+
+### Interface to NAMD
+
+The interface to NAMD is called through `LocOptAlgo=namd`.
+
+The `namd2` executable needs to be in the path and named such.
+
+Additionally, there needs to be a fitting amber parameter file (yes, this is not an error!) named `input.prmtop`, where `input` is the prefix of your `input.ogo` file.
+
+The NAMD interface in its current state is not suitable for molecule only optimizations. This does currently not have any effect on <span class="smallcaps">ogolem</span>.
+
+### Interface to OpenBabel
+
+The interface to OpenBabel is called through `LocOptAlgo=openbabel:`, followed by a sequence of keywords to specify which force field to use. Currently supported are
+
+- `ghemical`  
+  the usage of this FF is highly encouraged since it is finnish
+  technology ;-)
+
+- `mmff94s`
+
+- `mmff94`
+
+- `uff`
+
+The `obminimize` executable needs to be in the path and named so.
+
+As a side note, the atom type recognition is done by OpenBabel automagically. This might be error prone and it is recommended to be checked in advance to a full global optimization.
+
+### Interface to Orca
+
+The interface to Orca is called through `LocOptAlgo=orca:`, followed by a sequence of keywords to specify the method. Builtin support exists at the moment for the following levels of theory
+
+- `mndo`
+
+- `am1`
+
+- `pm3`
+
+- `b3lyp/vdz`
+
+- `bp86/svp`
+
+- `bp86/tzvp`
+
+- `ubp86/tzvp`  
+  forces unrestricted Kohn-Sham
+
+- `b3lyp/6-31+g**`
+
+- `mp2/aug-cc-pVDZ`
+
+- `ccsd(t)/tzvpp`  
+  only use this if you have way too much computing time
+
+- `custom`  
+  Requiring you to provide an input stub `YOURINPUT-orca.aux` containing
+  all relevant input before the geometry block. Please note, that this
+  input needs to contain the constraints, if wanted.
+
+- `custom,nolocopt`  
+  Just like above, an auxiliary file is required, with the `nolopt` flag
+  signaling that no local optimization takes place, interesting for
+  chained local optimizations.
+
+Additionally, the location of the orca executable needs to be exported in the environment variable `OGO_ORCACMD`, e.g. in bash syntax
+
+    export OGO_ORCACMD=$HOME/software/orca_v2.8.0/orca
+
+If this variable should be not set, <span class="smallcaps">ogolem</span> will assume the binary to be in your path.
+
+Since Orca is a free, albeit closed-source program, it is only supported on the platforms the official Orca release supports (at the moment: Linux, Solaris, Windows).
+
+### Interface to Tinker
+
+The interface to Tinker is called through `LocOptAlgo=tinker:`, followed by a sequence of keywords to specify some needed parameters for the local optimization employed by Tinker
+
+- `minimize`  
+  use Tinkers minimize program for local optimization
+
+- `newton`  
+  use Tinkers newton program for local optimization
+
+- `optimize`  
+  use Tinkers optimize program for local optimization
+
+- `custom`  
+  use a custom command and options for the local optimization
+
+For the earlier three, the Tinker executables need to be in your path and named `minimize`, `newton` and `optimize`. For the last option, one needs to export the system variables `OGO_TINKERCMD` and `OGO_TINKEROPT`, e.g. in bash syntax
+
+    export OGO_TINKERCMD=$HOME/software/tinker_patched/optimize
+    export OGO_TINKEROPT="0.01"
+
+Additionally, you need to have a file called `input-tinker.aux`, where `input` is the prefix of your input file in the same directory as the `ogo`-file. This file needs to start with a line
+
+    ###OGOLEMAUX###
+
+followed by a line with the name of the tinker parameter file to use (e.g. `mm3.prm`), which also needs to be in the directory. Then the force field types for all atoms in your systems (same order as in the building block definition). The first column being some arbirtray identifier, followed by whitespace and the force field type ID as in the parameter file.
+
+Occasionally, the setup described above does not work but results in error messages like this:
+
+    WARNING: Error in Tinker: optimize locopt. Returning non-optimized geometry. 
+    org.ogolem.core.ConvergenceException: Tinker has a problem (local optimization).
+
+If this happens, first make sure that Tinker in stand-alone mode (w/o <span class="smallcaps">ogolem</span>) can really do the intended calculations, using the input files automatically generated by <span class="smallcaps">ogolem</span>. If Tinker does work in stand-alone mode, the above error may be related to system I/O issues on certain Linux systems. As a possible fix, you are then encouraged to try this workaround:
+
+- replace the direct invocation of the desired Tinker routine (e.g.,
+  `optimize`), with a script of this contents:
+
+      #!/bin/sh
+      base=`basename $1 .xyz`
+      out=$base".out"
+      /path/to/your/tinker/executables/optimize $@ > $out
+
+  For example, you can name this script “optimize” and put it in a   directory that occurs early in your `PATH`-variable (e.g.,   `$HOME/bin`), before the normal Tinker executables (to be on the safe   side, remove the Tinker executables from your `PATH`). Alternatively,   you can also let `OGO_TINKERCMD` point to this script.
+
+- additionally, in the $`\ast`$.ogo input file, call the Tinker
+  interface with
+
+      LocOptAlgo=tinker:optimize,fileout
+
+This (or obvious variations of this recipe for the other Tinker routines) may get rid of the above error.
+
+The Tinker interface in its current state is not suitable for molecule only optimizations. This does currently not have any effect on <span class="smallcaps">ogolem</span>.
+
+### Interface to xtb
+
+The interface to xtb is called through `LocOptAlgo=xtb:`, followed by a sequence of optional keywords adjusting its behavior.
+
+- `method=`  
+  Set the xtb method to be used. Options are: `gfn-ff`, `gfn0-xtb`,
+  `gfn1-xtb`, `gfn2-xtb`. Default is GFN2.
+
+- `optlevel=`  
+  Set the convergence level of local optimizations in xtb. Options are:
+  `crude`, `sloppy`, `loose`, `normal`, `tight`, `verytigth`. Default is
+  `normal`.
+
+- `dontserialize`  
+  Do not set the environment to force xtb to only use one thread.
+
+- `xcontrol=`  
+  Path to an xtb control file to be used for the local optimizations.
+  Path is relative to <span class="smallcaps">ogolem</span> input file
+  location. Default: no additional input file is used.
+
+### Interfacing to **any** other program (package)
+
+Although <span class="smallcaps">ogolem</span> provides a numerous set of interfaces to programs implementing methods ranging from force fields to wavefunction methods, we cannot implement an interface to every code that we find interesting. Additionally, if one of the interfaced codes changes input or output structure in a non-compatible manner, we will need to chase that.
+
+But fear not as there is an easy solution to interface **any** other code to <span class="smallcaps">ogolem</span> with a little bit of simple scripting. This interface can be requested by setting `LocOptAlgo=generic`. Additionally, the environment variables `OGO_GENERALCMD` will need to be set to the command to be called for the actual local optimization. Additionally, if `OGO_GENERALOPTS` are set, these options will be appended to the called command.
+
+If this interface is chosen, <span class="smallcaps">ogolem</span> will create individual directories for each local optimization task. In such directory, a file `input.xyz` within the initial guess coordinates in xyz-format will be created. Subsequently, the `OGO_GENERALCMD` will be executed within the directory (optinally with the options appended) which is supposed to read in the coordinates, run the local optimization and return the results in an xyz-formatted file `output.xyz`. In this file, the second line is supposed to contain the fitness of the optimized structure in kJ/mol as the second token.
+
+Happy <span class="smallcaps">ogolem</span> scripting!
+
+### Chaining multiple local optimizations
+
+Any number of local optimizations can be chained. This is easily achieved by specifying `LocOptAlgo= chained:` followed by a -separated (pipe-separated) list of the local optimization options (inluding their possible options) to be chained.
+
+### Build-in local optimizations
+
+A variety of local optimization algorithms are available build-in in <span class="smallcaps">ogolem</span>. They all have in common that they require a backend specification as described in the following sections.
+
+Please note that not all of the local optimization algorithms now described are classically seen as local optimization but some of them are used in other groups as global optimizations engines. Despite the semantics, we are convinced that coupling mutliple global optimization engines can be benefical. No bigger offense should be taken by naming them local optimizations.
+
+A word on syntax: unless otherwise noted, options to local optimizations are semicolon separated. Classic choices for the local optimizations include:
+
+- `chained:XXX|YYY` which chains the local optimizations `XXX` and
+  `YYY`. Any number of local optimizations can be chained and are *pipe*
+  \| separated.
+
+- `none:backend=XXX` which uses the backend `XXX` for single-point only
+  evaluations.
+
+- `lbfgs:` to use a L-BFGS optimization through RISO’s version of the
+  original Nocedal implementation. Recommended choice. Options are:
+
+  - `backend=XXX` uses backend `XXX` for this optimization. Mandatory
+    option.
+
+  - `maxiter=XXX` sets the maximal number of iterations for this local
+    optimization to `XXX`. Default: global default. Optional input.
+
+  - `lineiter=XXX` sets the number of line search iterations to `XXX`.
+    Default: 50. Optional input.
+
+  - `gtol=X.X` sets the gradient tolerance to `X.X`. Default: 0.9.
+    Optional input.
+
+  - `nocorrs=X` sets the number of corrections to `X`. Default: 7.
+    Optional input.
+
+  - `absconvthresh=X.XX` sets the absolute convergence threshold to
+    `X.XX`. Default: global default. Optional input.
+
+  - `tryresets=X` sets the number of resets of the L-BFGS state to `X`.
+    Default: 3. Optional input.
+
+- `apachecg:` to use Apache’s conjugate gradient local optimization,
+  options include:
+
+  - `backend=XXX` uses backend `XXX` for this optimization. Mandatory
+    option.
+
+  - `maxiter=XXX` sets the maximal number of iterations for this local
+    optimization to `XXX`. Default: global default. Optional input.
+
+  - `usefletcher=true` enables Fletcher-Reeves updates over
+    Polak-Ribiere updates. Default: Polak-Ribiere. Optional input.
+
+  - `absconvthresh=X.XX` sets the absolute convergence threshold to
+    `X.XX`. Default: global default. Optional input.
+
+- `fire:` to use the Fast Inertial Relaxation Engine (FIRE). Options
+  are:
+
+  - `backend=XXX` uses backend `XXX` for this optimization. Mandatory
+    option. Note that FIRE benefits greatly from backends that support
+    history functionality.
+
+  - `maxiter=XXX` sets the maximal number of iterations for this local
+    optimization to `XXX`. Default: global default. Optional input.
+
+  - `fmax=X.X` sets the convergence criterion to `X.X`. Default: global
+    default. Optional input.
+
+  - `maxmove=X.X` sets the maximum movement in one iteration to `X.X`.
+    Default: 0.2. Optional input.
+
+  - `dt=X.X` sets the initial time step size to `X.X`. Default: 0.1.
+    Optional input.
+
+  - `dtmax=X.X` sets the maximum time step size to `X.X`. Default: 1.0.
+    Optional input.
+
+  - `nmin=X` sets the number of steps without step increase to `X`.
+    Default: 5. Optional input.
+
+  - `finc=X.X` sets the factor for time step increase to `X.X`. Default:
+    1.1. Optional input.
+
+  - `fdec=X.X` sets the factor for time step decrease to `X.X`. Default:
+    0.5. Optional input.
+
+  - `astart=X.X` sets the starting acceleration mixing factor to `X.X`.
+    Default: 0.1. Optional input.
+
+  - `fa=X.X` sets the factor for acceleration mixing increase to `X.X`.
+    Default: 0.99. Optional input.
+
+  - `a=X.X` sets the initial acceleration mixing factor to `X.X`.
+    Default: 0.1. Optional input.
+
+  - `tryresets=X` sets the maximum number of resets if too many trials
+    fail to improve the result to `X`. Default: 2. Optional Input.
+
+  - `maxtrials=X` sets the number of trials without improvement before a
+    reset is initiated to `X`. Default: 20. Optional input.
+
+  - `resettostable=false` turns off resets to stable states. Default:
+    true. Optional input.
+
+  - `resettobestpoint=true` turns on resets to remembered points in
+    history. Requires a backend that supports history functionality.
+    Default: false. Optional input.
+
+- `flemin:` to use NUMAL’s flemin optimization. Options:
+
+  - `backend=XXX` uses backend `XXX` for this optimization. Mandatory
+    option.
+
+  - `maxiter=XXX` sets the maximal number of iterations for this local
+    optimization to `XXX`. Default: global default. Optional input.
+
+  - `convthresh=X.XX` sets the convergence threshold in the fitness to
+    `X.XX`. Default: global default. Optional input.
+
+  - `convthreshgrad=X.XX` sets the convergence threshold in the gradient
+    to `X.XX`. Default: global default. Optional input.
+
+- `rnk1min:` to use NUMAL’s rnk1min optimization. Options:
+
+  - `backend=XXX` uses backend `XXX` for this optimization. Mandatory
+    option.
+
+  - `maxiter=XXX` sets the maximal number of iterations for this local
+    optimization to `XXX`. Default: global default. Optional input.
+
+  - `convthresh=X.XX` sets the convergence threshold in the fitness to
+    `X.XX`. Default: global default. Optional input.
+
+  - `maxstep=X.X` sets the maximal step to `X.XX`. Default: 0.1.
+    Optional input.
+
+  - `convthreshgrad=X.XX` sets the convergence threshold in the gradient
+    to `X.XX`. Default: global default. Optional input.
+
+<!-- -->
+
+- 
+
+Please note that the `flemin`, `praxis`, `rnk1min` algorithms may only be used if you are in possession of Lau’s Java Numal book(Lau 2003) (and therefore the accompanying source code and jar-file). In this case, you can add the numal.jar to the classpath prior to <span class="smallcaps">ogolem</span> excecution and make use of the optimization algorithms implemented in Numal.
+
+### Local heat pulses
+
+One of the global optimization algorithms included in <span class="smallcaps">ogolem</span> are local heat pulses, as originally developed by Arnulf Moebius. The version in <span class="smallcaps">ogolem</span> is fairly customized in comparison to the original, and was described and tested in detail (Dieterich and Hartke 2017). Local heat pulses can be used either as a geometry mutation (cf. section <a href="#sec:geomglobopt" data-reference-type="ref" data-reference="sec:geomglobopt">2.7</a>), or as pre-stage to the actual local optimization. In the former case, it will come into effect only with the mutation probability (and possibly as one of several mutations); in the latter case it will influence every newly generated geometry. Both choices lead to the same algorithmic machinery used in the end, hence the options are the same (described below). There are quite a few options because the originally proposed heat pulses are a full-blown global optimization algorithm in themselves, borrowing features from MCM/basin-hopping and simulated annealing. The latter features lead to annealing-style options.
+
+You can specify local head pulses as local optimization pre-stage by inserting `localheat:` with its options, followed by the actual local optimization (may be any of the ones available in <span class="smallcaps">ogolem</span>) after a “;”, in this way: `localheat:OPTIONS;lbfgs:backend=xyz:lennardjones`. The options are keyword=value pairs, from the following list:
+
+- `choosemode=` the mode for the local heat pulses. We support the
+  following choices: (default `pick5`)
+
+  - `pick5`: move 5 randomly choosen atoms/COMs
+
+  - `upto5`: move 0 to 5 atoms/COMs
+
+  - `10percent`: move 10% of the atoms/COMs
+
+  - `upto10percent`: move 0% to 10% of the atoms/COMs
+
+  - `onsphere`: move atoms/COMs within a 3D-Gaussian centered at a point
+    on a spherical surface enclosing the cluster
+
+  - `insphere`: move atoms/COMs within a 3D-Gaussian centered somewhere
+    inside the whole cluster
+
+  - `incenter`: move atoms/COMs within a 3D-Gaussian around the cluster
+    center
+
+- `doCDDD=` if we should check the geometry’s sanity after heat pulse
+  perturbation, using CD/DD. Default: false.
+
+- `movemode=` `coms` for moving the COMs of the building blocks, or
+  `cartesians` for moving atoms. Default: `coms`
+
+- `iters=` the number of iterative repetitions of the local heat pulses.
+  Default: 10.
+
+- `eqIters=` the number of equilibration iterations before cooling the
+  movement amplitudes. Of course, we should normally have `iters` $`>`$
+  `eqIters`. Default: 3.
+
+- `startAmpl=` what the start amplitude for atom/COM perturbation should
+  be. Default: 2Å
+
+- `startEuler=` the initial amplitude for Euler angle perturbation.
+  Default: 0.5.
+
+- `scaleFac=` how we scale amplitudes, temperature and Euler angle
+  amplitudes in annealing-style cooling. Default: 0.9.
+
+- `useMetropolis=` if we use the Metropolis criterion (also allowing
+  energy-upward moves) instead of the simplistic downward-only
+  criterion. Default: true (use Metropolis).
+
+- `temperature=` when we use a Metropolis criterion, what the start
+  temperature (in Kelvin) should be. Default: 50.
+
+- `sigmaX=`,`sigmaY=`,`sigmaZ=` the x,y,z-width of the 3D Gaussian in
+  the modes `onsphere`, `insphere` and `incenter`. Default: 0.1.
+
+## Internal and external backends
+
+As discussed above, all internal local optimizations require a backend definition. This backend definition can be either directly inlined or pre-defined and tagged. Please note that we prefer the pre-defined version discussed here over direct inlining.
+
+In order to define a backend a `CLUSTERBACKEND` block must be in the input. Options include:
+
+- `BackendTag=XYZ` to name this backend defintion `XYZ`. Tag must be
+  unique. Mandatory option.
+
+- `Backend=XXX` to provide the fully qualified backend definition.
+  Mandatory option.
+
+As an example:
+
+    <CLUSTERBACKEND>
+    BackendTag=lj
+    Backend=xyz:lennardjones
+    </CLUSTERBACKEND>
+
+would be used to assign a Cartesian-based LJ force-field the tag `lj`. Subsequently, the tag `lj` could be used to refer to this backend in the local optimization definitions.
+
+Actual backend definitions will be covered in the next sections.
+
+#### Internal LJ force field
+
+Very simple, based on standard parameters for *homogenous* LJ clusters of noble gases (excluding radon). Again, this does *not* include any mixing and can therefore only be used for homogenous clusters. Specify `lennardjones` as the backend.
+
+#### Internal mixed LJ force field
+
+Also simple, based on standard parameters for *heterogenous* LJ clusters of noble gases. Through the use of Lorentz-Berthelot mixing rules, any mixed cluster of noble gases (excluding radon) can be studied. Specify `mixedlj` as the backend.
+
+#### scaTTM3F
+
+The <span class="smallcaps">ogolem</span> contains a Scala-based implementation of the TTM3F force field by Xantheas *et al.*. Despite being significantly faster than the reference implementation, this force field is equivalent in behaviour to said original. To use it, simply specify `scattm3f:X,Y.Y`, where `X` is the number of water molecules your system contains (our implementation also pre-allocates some scratch arrays) and `Y.Y` is an energy cutoff in $`E_h`$. This cutoff is of importance, as (like the reference implementation) the induced dipols may converge to unphysical solutions which can be very low in energy. It is recommended to scale the cutoff with system size.
+
+Please also note that the implementation assumes your cluster to only contain water molecules with internal atom order O/H/H.
+
+#### (EVB-)QMDFF
+
+Thanks Stefan Grimme, we include his QMD force field natively in <span class="smallcaps">ogolem</span>. Additionally, we support the EVB-QMDFF extension by Bernd Hartke and Stefan Grimme. Before running <span class="smallcaps">ogolem</span>, a force field parameter must be created file with the official tools from Stefan Grimme. Subsequently, QMDFF can be configured as `qmdff:` followed by a , (comma) separated list of options:
+
+- `params=XXX` sets the path to the parameter file to `XXX`. Default:
+  `solvent`.
+
+- `addterm=XXX` add an additional term to QMDFF. Currently only
+  supported: `electrostatic:PATHTOCHARGEFILE`. Default: no additional
+  term.
+
+To configure EVB-QMDFF, specify `evb-qmdff:` followed by any of the following options:
+
+- `evb=`
+
+- `qmdffs=`
+
+Please note that we are in the testing phase for both EVB-QMDFF and QMDFF for structure global optimization and cannot make any guarantees as to the physical sensibility of obtained results!
+
+#### Adaptive choices
+
+Adaptive choices are in more detail described in section <a href="#parameterfit" data-reference-type="ref" data-reference="parameterfit">[parameterfit]</a> *Global parametrization of potentials*.
+
+## Global optimization algorithms
+
+All global optimization algorithms are chosen through the `GlobOptAlgo=` keyword. The grammar is as follows: `cluster`$`\{`$`xover(GEOMXOVERALGO:OPTS)mutation(GEOMMUTATIONALGO:OPTS)`$`\}`$`molecules`$`\{`$` xover(MOLXOVERALGO:OPTS)mutation(MOLMUTATIONALGO:OPTS)`$`\}`$. The cluster algorithm specification is required, the molecule specification (for explicit degrees of freedom) is optional. Algorithmic choices must end with a colon, options are optional and comma-separated.
+
+Valid choices for `GEOMXOVERALGO` are:
+
+- `germany:` a very basic one-point genotype crossover. Options:
+
+  - `gausswidth=X.X` sets the width of the Gaussian deciding for the
+    cutting spot to X.X, default 0.3.
+
+- `portugal:` a $`N`$-point genotype crossover.
+
+  - `nocuts=X` sets the number of cuts to `X`. Default: 1.
+
+- `sweden:` our $`N`$-species phenotype crossover.
+
+  - `cutstyle=` specifies the cutting style, valid choices 0, 1 or 2. 0:
+    cutting plane is always through the total COM of the cluster. 1:
+    Gauss-distributed cutting plane. 2: normal-distributed cutting
+    plane. Default: 2.
+
+- `lapland:` a phenotype crossover with implicit exchange.
+
+  - `cutstyle=`, valid choices 0, 1 or 2. Default: 2.
+
+- `iceland:` a merging phenotype operator.
+
+  - `cutstyle=X`, valid choices 0, 1 or 2. Default: 2.
+
+  - `colldetect=X` Choses a collision detection engine. See global
+    option for valid choices. Default: global setting.
+
+  - `blowcoll=X.X` specifies the collision blow factor to be `X.X`.
+    Default: global setting.
+
+  - `blowdiss=X.X` specifies the dissociation blow factor to be `X.X`.
+    Default: global setting.
+
+  - `inittrust=X.X` specifies the initial trust radius for the merge.
+    Default: 0.1.
+
+  - `stoptrust=X.X` specifies the stopping trust radius for the merge.
+    Default: 1E-5.
+
+  - `mergeiter=X` specifies the number of iteration for the merge.
+    Default: 100.
+
+  - `nointerpoints=X` specifies the number of interpolation points for
+    the merging. Default: 5.
+
+  - `optbounds=` specifies the optimization bounds for the merging as a
+    $`/`$-separated array. Order: lower translation bound, higher
+    translation bound, lower rotation bound, higher rotation bound.
+    Defaults: `0.0/15.0/0.0/2*pi`
+
+- `aland:` a fitness-based phenotype operator with optional merging.
+
+  - `cutstyle=X`, valid choices 0, 1 or 2. Default: 2.
+
+  - `mergingpheno`, enables merging. Default: off.
+
+  - `colldetect=X` Choses a collision detection engine. See global
+    option for valid choices. Default: global setting.
+
+  - `blowcoll=X.X` specifies the collision blow factor to be `X.X`.
+    Default: global setting.
+
+  - `blowdiss=X.X` specifies the dissociation blow factor to be `X.X`.
+    Default: global setting.
+
+  - `inittrust=X.X` specifies the initial trust radius for the merge.
+    Default: 0.1.
+
+  - `stoptrust=X.X` specifies the stopping trust radius for the merge.
+    Default: 1E-5.
+
+  - `mergeiter=X` specifies the number of iteration for the merge.
+    Default: 100.
+
+  - `nointerpoints=X` specifies the number of interpolation points for
+    the merging. Default: 5.
+
+  - `optbounds=` specifies the optimization bounds for the merging as a
+    $`/`$-separated array. Order: lower translation bound, higher
+    translation bound, lower rotation bound, higher rotation bound.
+    Defaults: `0.0/15.0/0.0/2*pi`
+
+- `snaefellsjoekull:`
+
+  - `cutstyle=X` specifies a cut style. Allowed: 0 (full random), 1
+    (Gauss-distributed), 2 (inverted Gauss-distributed). Default: 0.
+
+  - `gausswidth=X.X` the standard deviation if a Gauss-cut is chosen.
+    Default: 1.0.
+
+  - `adjustradius=true/false` if the radius of the spheres should be
+    adjusted. Default: false.
+
+- `noxover:` disables crossovers in the global optimization.
+
+- `mutationasxover:GEOMMUTATIONALGO:OPTS` uses the mutation specified by
+  `GEOMMUTATIONALGO` as a crossover.
+
+- `multiple:XX%GEOMXOVER1:OPTS|YY%GEOMXOVER2:OPTS...` couples multiple
+  crossover operators together. Each definition starts with the percent
+  probabilty for this operator to be used. Different operators are
+  separated by pipes \|. The percentages must add up to 100%.
+
+- `chained:XX%GEOMXOVER1:OPTS|YY%GEOMXOVER2:OPTS...` chains multiple
+  crossover operators together. Each definition starts with the percent
+  probabilty for this operator to be used in the chain. Different
+  operators are separated by pipes \|. Each percentage is independent.
+
+We do recommend to choose `sweden` if one is not certain what the best crossover is.
+
+Valid choices for `GEOMMUTATIONALGO` are:
+
+- `germany:` for a basic genotype mutation of the COMs and rotations for
+  the molecules.
+
+  - `lowcom=X.X` the minimal translation for the COMs. Default: 0.5
+    bohr.
+
+  - `highcom=X.X` the maximal translation for the COMs. Default: 1.5
+    bohr.
+
+  - `widthCOM=X.X` the width of the Gaussian centered between the two.
+    Default: 0.1.
+
+  - `loweuler=X.X` the minimal rotation of the COMs. Default: 0.0 (in
+    the specific Euler angles definition.
+
+  - `higheuler=X.X` the maximal rotation of the COM. Default: 1.0 (in
+    the specific Euler angles definition.
+
+  - `widtheuler=X.X` the width of the Gaussian centered between the two
+    Euler borders. Default: 0.1.
+
+- `montecarlo:` for a Monte-Carlo based mutation in the atomic space.
+
+  - `mode=` to adjust the move mode. Valid choices: `all`, `some`,
+    `one`.
+
+  - `maxmove=X` specifies the maximum move. Default: 0.2 (in bohr).
+
+- `finland:` for a one-parent phenotype crossover.
+
+  - `cutstyle=X`, valid choices 0, 1, 2. Default: 2.
+
+  - `blowcoll=X.X` to set the blow factor for the collision detection.
+    Default: global setting.
+
+  - `blowdiss=X.X` to set the blow factor for the dissociation
+    detection. Default: global setting.
+
+- `norway:` for a one-parent packing operator.
+
+  - `colldetect=` to set the collision detection algorithm. Default:
+    global setting.
+
+  - `dissdetect=` to set the dissociation detection algorithm. Default:
+    global setting.
+
+  - `blowcoll=X.X` to set the blow factor for the collision detection.
+    Default: global setting.
+
+  - `blowdiss=X.X` to set the blow factor for the dissociation
+    detection. Default: global setting.
+
+- `xchangemut:` for an explicit exchange mutation.
+
+  - `mode=` the exchange mode. Valid choices: `single`, `multiple`.
+    Default: `single`.
+
+  - `gausswidth=X.X` if multiple is chosen, the width of the Gaussian
+    used to determine how many should be exchanged. Default: 0.4.
+
+- `graphbasedmut:` the original GDM doing a graph-based analysis of the
+  cluster to determine the least connected building block and move it to
+  a better position.
+
+  - 
+
+- `localheat:` local heat pulses can be selected as local
+  pre-optimization or as mutation, cf. section
+  <a href="#sec:localheat" data-reference-type="ref"
+  data-reference="sec:localheat">2.5.19</a>
+
+To be continued...
+
+### HACTAR
+
+HACTAR is...... **not yet ready for prime time. Please do not use!**
+
+Input syntax: `hactar`$`\{`$`HACTAROPTIONS`$`\}`$`cluster`$`\{`$`xover()mutation()`$`\}`$. The cluster specifications for both `xover()` and `mutation()` can (and should) contain more than one algorithmic definition. These definitions follow the `multiple:` syntax explained above, without the leading `multiple:` keyword.
+
+Currently no molecular HACTAR exists. `HACTAROPTION` are a series of optional, comma-separated options. The following input keywords exists:
+
+- `mode=` Wich moving mode to use. Possible modes are `all`, `some`,
+  `one`. Default: `some`.
+
+- `dometropolis` To enable the Metropolis criterion. Default: accept
+  steps that lower the energy, no Metropolis criterion.
+
+- `beta=X.X` If the Metropolis criterion is enabled, which beta factor
+  to use. Default: 1.0.
+
+- `maxtoreset=X` After how many unsuccessful operations a reset to the
+  initial algorithmic configuration should take place. Default: 100.
+
+- `stepstopring=X` After how many steps we print the current algorithmic
+  configuration to standard out. Default: 1000.
+
+- `maxpercstep=X.X` What is the maximum percentage the configuration is
+  allowed to be moved in one step. Default: 1%.
+
+- `dopercentages` evaluate the improvements as a percentage, not as the
+  absolute.
+
+## Diversity checkers
+
+In order to maintain a sufficient diversity in the genetic pool, we use so called diversity checkers. Their quality (and performance) are crucial for the success of your global optimization.
+
+The default is a fitness-based diversity criterion with a threshold of $`1\cdot10^{-6}\:E_h`$. This threshold may be too tight for your optimization and is related to the convergence threshold of the local optimization. To change the default, the `DiversityCheck=` keyword must be used. Options are:
+
+- `fitnessbased:X.X`  
+  which is the simple fitness-based diversity checker with a threshold
+  of `X.X`.
+
+- `percfitnessbased:X.X`  
+  which is the simple fitness diversity checker based on the percentage
+  difference w.r.t. the individual with the smaller fitness. `X.X` is
+  the percentage in the interval \[0,100\].
+
+- `hundtoverlap:CONFIG`  
+  to use Hundt’s overlap check as a diversity criterion using the
+  configuration options in `CONFIG`, semicolon separated.
+
+- `fitnesshundtoverlap:X.X,CONFIG`  
+  to use a fitness-prescreened version (with threshold `X.X`) of Hundt’s
+  overlap check as a diversity criterion using the configuration options
+  in `CONFIG`, semicolon separated.
+
+## Running the job
+
+After calling, e.g.,
+
+    java -jar ogolem.jar --shmem MYJOB.ogo 2
+
+there will, potentially, appear (a lot of files) in the directory the job was started from. Additionally, depending upon the number of threads allowed, a java process will start eating up CPU time. Concerning the latter: it is not recommended to use all CPUs on a workstation which is supposed to be still used for anything else.
+
+<span class="smallcaps">ogolem</span> will clean up all automagically generated input files and/or directories for other programs in case of a sucessfull call to that program. In case that something unexpected (e.g. failing convergence) happens, the files will be left for inspection.
+
+Interesting datafiles are the folder named like your input file, where structures and output (the latter one is to be inspected to see whether all input keywords are correctly read in) are collected. Additionally, there is a log file containing timestamps and informations whenever a new individual took the first rank in the pool.
+
+Once the run is complete, there will be a lot of files of form `rankNUMBERgeometryNUMBER.xyz` appearing in that folder. This is the final pool of structures, where the first number is the rank in the pool (best candidate has rank 0) and the second is the ID of the geometry to give a measure when it was found in the run.
+
+<span class="smallcaps">ogolem</span> might throw warnings or errors. These will be written to System.out and System.err and are of interest.
+
+## Cluster analysis
+
+<span class="smallcaps">ogolem</span> provides some, admittingly very trivial, means to analyze the outcome of a global optimization of clusters and, perhaps more important, to check a running job using the written restart files. For this, you call the `ogolem.jar` with the
+
+    --clusters
+
+option.
+
+The analysis program needs a binary pool, either the final `pool.bin` or a temporary `IntermediateClusterPool.bin`. This is specified using the `-i` flag followed by whitespace, e.g.
+
+    java -jar ogolem.jar --clusters -i IntermediateClusterPool.bin
+
+Some other options are possible
+
+- `-binstructs`  
+  bin structures by number of structures instead of energies (which is
+  the default)
+
+- `-dissblow`  
+  the blow factor for the dissociation detection, defaults to 1.8.
+
+- `-getstructs`  
+  create a directory named `structs` and write the structures of this
+  pool there in the xyz-file format. Good option for intermediate
+  checks.
+
+- `-ljstrains`  
+  calculate strain energies for LJ clusters. Defaults to off.
+
+- `-nocomdiffs`  
+  disable analysis of COM differences (on by default).
+
+- `-nodissdetect`  
+  disable dissociation detection (on by default).
+
+- `-noenergies`  
+  disable scanning of energies (on by default).
+
+- `-noinertias`  
+  disable moments of inertia analysis (on by default).
+
+- `-noofbins`  
+  the number of bins for structure binning. Defaults to 100.
+
+- `-threshdiff`  
+  threshold for moments of inertia, defining when they are considered to
+  be different. Defaults to 2.5E-1.
+
+- `-threshequal`  
+  threshold for moments of inertia, defining when they are considered to
+  be same. Defaults to 1E-1.
+
+We want to encourage you here to contribute to the <span class="smallcaps">ogolem</span> by proposing cluster analysis techniques that are of interest to you!
+

--- a/manual/md/03-global-parametrization-of-potentials-pseudopotentials.md
+++ b/manual/md/03-global-parametrization-of-potentials-pseudopotentials.md
@@ -1,0 +1,708 @@
+# Global parametrization of potentials, pseudopotentials, ...
+
+This part of <span class="smallcaps">ogolem</span> started as a way to globally optimize potentials in a system-specific fashion to later use them for cluster structure optimization. It has since significantly evolved from that basis towards optimizing potentials, pseudopotentials, and test benchmark functions. However, some traces of its ancestry are still present, i.e., in the names of keywords.
+
+**IMPORTANT:   This part of the manual is not complete yet and does, e.g., not cover all possible adaptivable choices! It also is outdated as the input syntax has been adjusted.**
+
+The part for the global optimization of potentials in the <span class="smallcaps">ogolem</span> was primarily designed with the idea in mind to allow for a system-specific parametrization of potentials against a reference for later usage in the geometry structure optimization part. Therefore, it is strongly coupled to that part.
+
+Of importance is the definition of the fitness in this part. In the easiest case (no weights, no penalty functions, exact computation), it is ``` math \begin{equation} F=\sum_{i=0}^{N}abs\left( E_{i,fit}-E_{i,ref} \right) \end{equation} ``` where $`N`$ is the number of reference points with their reference energies $`E_{i,ref}`$ and the fitted energies $`E_{i,fit}`$. Therefore, an exact agreement between reference and fitted energies causes the fitness to vanish, making 0.0 the optimal one.
+
+<span id="parameterfit" label="parameterfit"></span>
+
+## General input structure
+
+Due to the tight interaction between this part and the geometry optimization part, all direct input for the parameter optimization resides in the `.ogo` file. Therefore, there *needs* to be a geometry definition. This is useful if one wants to use the feature of automatical generated reference structures and is otherwise only a small nuissance.
+
+All direct input is encapsulated into `<ADAPTIVE>` tags, e.g.,
+
+    ###OGOLEM###
+    <GEOMETRY>
+    NumberOfParticles=2
+    <MOLECULE>
+    Ar;0.0;0.0;0.0
+    </MOLECULE>
+    <MOLECULE>
+    Ar;0.0;0.0;0.0
+    </MOLECULE>
+    </GEOMETRY>
+
+    <ADAPTIVE>
+    AcceptableFitness=1E-8
+    <REFERENCE>
+    <PATH>
+    arar_2.xyz
+    </PATH>
+    <ENERGY>
+    1E-5
+    </ENERGY>
+    </REFERENCE>
+    <REFERENCE>
+    <PATH>
+    arar_22.xyz
+    </PATH>
+    <ENERGY>
+    1.2E-5
+    </ENERGY>
+    </REFERENCE>
+    </ADAPTIVE>
+
+If one does not use the by default disabled feature of automatic reference point generation, the geometry definition does not need to be identical to the reference points. Also, in general the reference points may (depending on the adaptivable chosen) have different compositions and number of atoms.
+
+Additionally, there exists an optional file specific to the parametrization part. This file defines lower and upper boundaries to each parameter and will be used for this purpose if present, otherwise default borders will be used which might be very inefficient for your specific purpose.
+
+The file should be named `yourinputname-borders.aux`, where `yourinputname` is the prefix of the used `.ogo` file, and the general format is
+
+    ###OGOLEMAUX###
+    -3.0        2.0
+    0.1         0.2
+    1E3         1E5
+    -1E3        -1E1
+
+where for each individual parameter a lower boundary is assigned on the left and a upper one on the right side. These bounds typically (exceptions are mentioned in the corresponding paragraph of the adaptivable choice) are in atomic units.
+
+It is important to note that to-date the length of the specified array of borders needs to agree with the overall number of parameters for the fit and the order needs to agree with the internal representation. Depending on the actual interface chosen, it may therefore by reasonable to start <span class="smallcaps">ogolem</span> with default borders to figure these things out.
+
+The automatic calculation, how many parameters and which parameters are needed for a given set of reference points may be too conservative and generate too many parameters. This of course highers the problem dimensionality and makes the genetic operations and local optimizations be less efficient. If this is the case for you, you may provide a file named `yourinputname-stub.aux`, where `yourinputname` is the prefix of the used `.ogo` file. This file will then be used as a reference stub for the global optimization. Please be aware that any errors here can cause really nasty behaviour of the optimization. In general, the format of this file should follow the later described parameter output format. The numerical values of the parameters given can be any floating point number and do not have any effect on the optimization. Again, this potentially very harmful option should only be used if one knows what one is doing!
+
+## Input of reference points
+
+The reference points are handed over through input of form
+
+    <REFERENCE>
+    <PATH>
+    pathToCartesianReference.xyz
+    </PATH>
+    <ENERGY>
+    0.1
+    </ENERGY>
+    <REFCHARGES>
+    0;1;2
+    </REFCHARGES>
+    <REFSPINS>
+    0;2;1
+    </REFSPINS>
+    <REFBONDS>
+    bonds.list
+    </REFBONDS>
+    <REFWEIGHT>
+    2.4
+    </REFWEIGHT>
+    <REFMAXDIFF>
+    1E-5
+    </REFMAXDIFF>
+    </REFERENCE>
+
+All adaptive backends support energy fits currently (this may change in the future) and for these `<PATH>` and `<ENERGY>` tags are mandatory and hold the path to the Cartesian structure and its energy (in hartree) of this reference point. The other tags are optional with both `<REFSPINS>` and `<REFCHARGES>` following the exact same input syntax as described above for the geometry structure optimization.
+
+Please note that the `<PATH>` tags must always be located before any other tags!
+
+The `<REFBONDS>` tags may contain the path to either a list or a full matrix of the bonds in this reference geometry. If the file suffix is `.list`, a list will be assumed, otherwise a full matrix needs to be in the file (in most cases, one wants to use the list option). If these tags are not given, <span class="smallcaps">ogolem</span> makes estimates based on a distance criterion. The list needs to be in format
+
+    0 1
+    6 5
+    2 3
+    4 5
+
+where each row specifies the two atoms (once more counting starts at 0) between a bond exists. Empty lines are permitted, no order needs to be pertained. If a full matrix needs to be read in, the file should contain
+
+    true true true
+    true true false
+    true false true
+
+for (in this case) a water molecule. No empty lines are permitted.
+
+The `<REFWEIGHT>` tag assigns a weight to this specific point, a feature that might be usable if e.g. the description of a certain region is important. The `<REFMAXDIFF>` tag defines how much the fitted energy is allowed to differ from the reference before a penalty is applied. This last tag obviously must be used with a penalty function enabled separatly.
+
+There is growing support for other properties. Please check if your problem supports the following. If not, patches are welcome!
+
+### Parametrizing energy order
+
+Energy order refers to the ordering of different atomic arrangements (e.g., crystal structures). It can be input as follows:
+
+    <REFERENCE>
+    <ENERGYORDER>
+    ConsiderRelativeEnergies
+    First;pathtofirst.xyz;-945.64
+    Second;pathtosecond.xyz;-1213.3
+    </ENERGYORDER>
+    </REFERENCE>
+
+where `ConsiderRelativeEnergies` is an optional tag (must be in first line if used) to not use total energies for the parametrization but only relative ones. Followed by arrangements having a tag as the first element, a semicolon as a separator, the path (relative or absolute) to the atomic positions in either xyz or z-matrix format, another semicolon separator, and the energy (typically in Hartree, can be relative if above relative energies were requested).
+
+### Parametrizing bulk modulus
+
+Bulk moduli are of importance for condensed matter applications. They can be input as follows:
+
+    <REFERENCE>
+    <BULKMODULUS>
+    Li(bcc):150.624
+    </BULKMODULUS>
+    </REFERENCE>
+
+where `Li(bcc)` refers to the bcc phase of lithium, followed by colon and the bulk modulus (typically in atomic units).
+
+### Parametrizing equilibrium volume
+
+Equilibrium cell volumes are of importance for condensed matter applications. They can be input as follows:
+
+    <REFERENCE>
+    <CELLVOLUME>
+    Li(bcc):42.4242
+    </CELLVOLUME>
+    </REFERENCE>
+
+where `Li(bcc)` refers to the bcc phase of lithium, followed by colon and the equilibrium cell volume (typically in atomic units).
+
+### Parametrizing nuclear forces
+
+Nuclear forces can be input as follows:
+
+    <REFERENCE>
+    <PATH>
+    ...
+    </PATH>
+    <FORCES>
+    ForcesFile=pathtoforces.dat
+    </FORCES>
+    </REFERENCE>
+
+where `ForcesFile=` points to a file (relative or absolute path) containing the forces for the current reference in a Cartesian xyz format. The forces input requires also a `<PATH>` environment with atomic positions as defined above.
+
+### Parametrizing $`\delta`$ gauge
+
+$`\delta`$ gauges are of importance for condensed matter applications. They can be input as follows:
+
+    <REFERENCE>
+    <PATH>
+    ...
+    </PATH>
+    <DELTAGAUGE>
+    Li(bcc):0.0
+    </DELTAGAUGE>
+    </REFERENCE>
+
+where `Li(bcc)` refers to the bcc phase of lithium, followed by colon and the $`\delta`$ gauge (typically 0.0 in atomic units). Currently, the $`\delta`$ gauge requires also a `<PATH>` environment with atomic positions as defined above.
+
+### Parametrizing electron density
+
+Electron density (on a grid) can be input as follows:
+
+    <REFERENCE>
+    <PATH>
+    ...
+    </PATH>
+    <DENSITY>
+    DensityFile=pathtodensity.dat
+    ReferenceTag=myTag
+    </DENSITY>
+    </REFERENCE>
+
+where `DensityFile=` points to a file (relative or absolute path) containing the density on a grid for the current reference. First line contains the Cartesian grid dimensions (whitespace separated) and subsequent lines contain one data point on that grid. The electron density input requires also a `<PATH>` environment with atomic positions as defined above. The second line of the `<REFERENCE>` environment must define a tag for this density using `ReferenceTag=`.
+
+### Mixing properties for the same reference
+
+Some of the above properties can be mixed if the same reference is meant (the definition of that is somewhat backend dependent!). For this, simply add multiple property tags (e.g., `<CELLVOLUME>` `BULKMODULUS` in the same `<REFERENCE>` environment.
+
+## Input keywords
+
+Again, there are a lot of tunables to this part of <span class="smallcaps">ogolem</span> with some of them more important than others. It is important to note that a certain setting might be optimal for one fit but not for another.
+
+- `AcceptableFitness=`  
+  <span id="page2:acceptableFitness"
+  label="page2:acceptableFitness"></span> which fitness is considered to
+  be acceptable and causes the optimization to stop. Defaults to 0.0
+  which is by our definition total agreement between all references and
+  the fit.
+
+- `AdaptivableChoice=`  
+  what to adapt/parametrize. See details below.
+
+- `AllRefsSameChargesAndSpins=`  
+  set to true if all reference geometries have the same charge and spin.
+  Use with extraordinary care only!
+
+- `AnyParamHistory=`  
+  set to true if the genetic history of parameters should be tracked.
+  This implies a higher use of memory.
+
+- `DoNiching=`  
+
+- `DoubleMorseDMax=`  
+  if the double morse adaptivable is used, the $`d_{max}`$ value.
+  Deprecated! set to true if niching should be enabled.
+
+- `NichesPerDim=`  
+  if niching is enabled, the number of niches per (static) grid
+  dimension.
+
+- `MaxIndividualsPerNiche=`  
+  if niching is enabled, the maximum number of individuals per niche.
+
+- `MaxNonConvSteps=`  
+  maximum number of steps w/o fitness progress in the internal local
+  optimization. Defaults to 100.
+
+- `MaxTasksToSubmit=`  
+  maximum number of tasks that are submitted to the threadpool at once.
+  Defaults to 1000000. Please keep this setting if you are not
+  absolutely certain that you benefit from a change.
+
+- `ParamBorderPrint=`  
+  set to false if the parameter borders should be printed.
+
+- `ParameterDetailedStats=`  
+  set to true if detailed statistics for the global optimization are
+  wanted.
+
+- `ParamEnergyDiv=`  
+  the minimal fitness diversity needing to exist between two individuals
+  in the pool. Defaults to 1E-8 which might be (depending on e.g. the
+  convergence criterion of the local optimization) too small and cause
+  premature convergence of the pool.
+
+- `ParamGlobOptIter=`  
+  the number of global optimization steps. Defaults to 9900. Must be
+  increased for production runs!
+
+- `ParamLinesearchEnergyDecr=`  
+  threshold for the fitness decrease in the linesearch. Defaults to
+  1E-10.
+
+- `ParameterGlobOpt=`  
+  which global optimization ingredients to use. Syntax is
+  `parameters{xover()mutation()}`. Choices include: `portugal:` with
+  optional `nocuts=N` argument for an N-point genotype xover. and
+  `germany:` for both mutation and xover. Details below.
+
+- `ParamLocOptIter=`  
+  maximum number of iterations for the parameter local optimization.
+  Defaults to 5000.
+
+- `ParameterLocOpt=`  
+  which local optimization engine should be used for the local
+  optimization. Choices include: apachecg (for Apache’s conjugate
+  gradient implementation), lbfgs (for an L-BFGS), and bobyqa (for
+  Powell’s BOBYQA).
+
+- `ParamLocOptMaxStep=`  
+  maximum stepsize in the local optimization. Defaults to 1E-5.
+
+- `ParamSeedingFolder=`  
+  specify the folder where seeds for a seeding initialization are
+  located.
+
+- `ParamSerializeAfterNewBest=`  
+  set to false if the genetic pool should not be stored to disk after
+  each new best individual found.
+
+- `ParamThreshDiv=`  
+  the minimal difference between the same gene of two individuals.
+  Applies only if the corresponding diversity check is enabled. Defaults
+  to 1E-8 which might be (depending on e.g. the convergence criterion of
+  the local optimization) too small and cause premature convergence of
+  the pool.
+
+- `ParamThreshLocOptGradient=`  
+  threshold for the gradient convergence. Defaults to 1E-8.
+
+- `ParamThreshLocOptParam=`  
+  threshold for the parameter convergence. Defaults to 1E-8.
+
+- `ParamsToBorders=`  
+  whether the parameters should be put back into their borders.
+  Otherwise, a local optimization may cause the parameters to run out of
+  the borders. Defaults to false.
+
+- `ParamsToSerial=`  
+  After how may steps a binary intermediate parameter pool is written to
+  disk. Defaults to 10000;
+
+- `PercentageForDiffs=`  
+  if percentage-scaled differences are enabled, what percentage should
+  be used. Default: 1 \[in percent\].
+
+- `PopulationSize=`  
+  the pool size for the parameter fit. Defaults to 100.
+
+- `UsePercentageScaledDiffs=`  
+  set to true to enable percentage-scaled differences for the maximum
+  allowed difference.
+
+- `WhichNicher=`  
+  selects the niching protocol being used. First an integer selection
+  for the niching algorithm, followed by a semicolon and the nicher.
+  Choices are 0 for static grid niches without ratio consideration and 1
+  for static grid niches with ratio consideration.
+
+- `WhichDiversityCheck=`  
+  integer choice which diversity check is to be used. Defaults to 0,
+  which is a fitness based diversity check. Also possible: 2, which
+  compares the individuals based on their gene values.
+
+## Adaptivable choices
+
+<span class="smallcaps">ogolem</span> supports a to-date only a few adaptivable choices. If there should be a (preferably free) program that you want to see supported and/or the methods listed here to do not satisfy you, feel free to write a mail to dieterich@ogolem.org . It is necessary to provide reference in- and output to the program you want to see support for and (in case that it is no freeware) at least a binary of the program/engine is required.
+
+In general, all adaptivable choices are easily called through input of form
+
+    AdaptivableChoice=IDENTIFIER:FLAGS
+
+### Adaptive GUPTA potential
+
+The adaptive GUPTA potential can be called using `adaptivegupta:DISTBLOW,ENABLECACHE`, where `DISTBLOW` is a blow factor defining when to neglect contributions. `ENABLECACHE` is a boolean defining whether or not to enable the internal caching procedures. The later should only be used when all geometries are of precisely the same system. In general, it can and should be anabled for cluster global optimization and may be enable for parameter global optimization if (and *only* if) all reference structures are of the same system. Using caching provides a significant speedup in comparision to the uncached procedures.
+
+The used function definition is as follows: ``` math \begin{equation} E(a,b)=A(a,b)\cdot \exp{\left[-p(a,b)\left(\dfrac{r_{ab}}{r_0(a,b)}-1\right)\right]} -\sqrt{\chi(a,b)^2\cdot\exp{\left[-2\cdot q(a,b) \left(\dfrac{r_{ab}}{r_0(a,b)}-1\right)\right]}} \end{equation} ``` where $`r_{ab}`$ is the distance between atoms $`a`$ and $`b`$.
+
+The implementation loops over all atoms in the system, independent whether they are bonded or not. Therefore, this should primarily be used for e.g. metal clusters. The output parameters are in the order $`A(a,b)`$, $`p(a,b)`$, $`r_0(a,b)`$, $`\chi(a,b)`$ and $`q(a,b)`$ for each possible pair in atomic units. The implementation does feature an analytical gradient for both coordinates and parameters for enhanced performance of the local optimizations.
+
+### Adaptive LJ potential
+
+### Adaptive Morse potential
+
+The adaptive Morse potential can be called using `adaptivemorse:CLOSEBLOW,DISTBLOW`, where `CLOSEBLOW` is a blow factor defining when to use a cutoff for close cases and `DISTBLOW` defines when to neglect contributions.
+
+The implementation loops over all atoms in the system, independent whether they are bonded or not. Therefore, this should primarily be used for e.g. metal clusters. The output parameters are in the order $`D_e`$, $`a`$ and $`r_e`$ for each possible pair in atomic units. The implementation does feature an analytical gradient for both coordinates and parameters (suboptimal implementation) for enhanced performance of the local optimizations.
+
+Please note that currently no caching is implemented in the Morse potential. If you want to use this potential for bigger systems, please contact the author(s) whether this can be implemented.
+
+### Benchmark: Ackley
+
+### Benchmark: Schaffer F6
+
+### Benchmark: Schaffer F7
+
+### Benchmark: Lunacek
+
+### goLPS parametrization using PROFESS
+
+<span class="smallcaps">ogolem</span> can be used to fit local pseudopotentials following the goLPS formalism. Our current implementation requires PROFESS (open-source) for the actual OFDFT calculations with the modified pseudopotential and a set of helper scripts designed to translate from <span class="smallcaps">ogolem</span> output to PROFESS input and from PROFESS output back to <span class="smallcaps">ogolem</span> input. We will document here only the data exchange protocol, not the scripts themselves. The current recommendation is to write them based on the problem to be fitted yourself. If assistance with this step is required, please contact the author(s) of the original goLPS publication.
+
+In the following, the properties to-be-fitted are individually discussed. Please note that this feature is experimental and we do NOT recommend fitting goLPSss for multiple atoms simulaneously.
+
+#### Energy
+
+If a reference contains the energy (i.e., total energy), a directory following the scheme `professenergycalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format
+
+- a file `atompos.xyz` containing the atom positions of the reference in
+  xyz format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_energy_calc.sh` a script to be called (name can be overridden
+  by setting the environment variable `OGO_PROFESSENERGYSCRIPT` to the
+  wanted name).
+
+Subsequently, the script will be executed, using `XXX` as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated energy (in the same units as the reference) as a simple number in a file `energy.dat`).
+
+#### Energy order
+
+If a reference contains the energy order of different atomic arrangements (e.g., crystal structures), for each crystal structure a directory following the scheme `professenergycalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format
+
+- a file `atompos.xyz` containing the atom positions of the reference in
+  xyz format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_energy_calc.sh` a script to be called (name can be overridden
+  by setting the environment variable `OGO_PROFESSENERGYSCRIPT` to the
+  wanted name).
+
+Subsequently, the script will be executed for each structure, using the defined key for this arrangement as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated energy (in the same units as the reference) as a simple number in a file `energy.dat`). It will internally rank the energies.
+
+#### Bulk modulus
+
+If a reference contains the bulk modulus, a directory following the scheme `professbulkcalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_bulk_calc.sh` a script to be called (name can be overridden
+  by setting the environment variable `OGO_PROFESSBULKSCRIPT` to the
+  wanted name).
+
+Subsequently, the script will be executed, using the crystal symmetry (e.g., fcc) of the reference as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated bulk modulus (in the same units as the reference) as a simple number in a file `bulk.modulus`).
+
+#### Equilibrium volume
+
+If a reference contains the equilibrium volume, a directory following the scheme `professcellvolcalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_cellvol_calc.sh` a script to be called (name can be
+  overridden by setting the environment variable
+  `OGO_PROFESSCELLVOLSCRIPT` to the wanted name).
+
+Subsequently, the script will be executed, using the crystal symmetry (e.g., fcc) of the reference as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated equilibrium volume (in the same units as the reference) as a simple number in a file `cell.volume`).
+
+#### Combined energy, bulk modulus, and equilibrium volume calculations
+
+If the same reference contains total energy, bulk modulus, and equilibrium volume, they will be evaluated simulaneously. A directory following the scheme `professcombcalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format
+
+- a file `atompos.xyz` containing the atom positions of the reference in
+  xyz format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_combined_calc.sh` a script to be called (name cannot be
+  overridden).
+
+Subsequently, the script will be executed, using the crystal symmetry (e.g., fcc) of the reference as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated equilibrium volume (in the same units as the reference) as a simple number in a file `cell.volume`), the calculated bulk modulus (in the same units as the reference) as a simple number in a file `bulk.modulus`), and the calculated energy (in the same units as the reference) as a simple number in a file `energy.dat`).
+
+#### $`\delta`$ gauge
+
+If a reference contains the $`\delta`$ gauge, a directory following the scheme `professdeltagaugecalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_deltagauge_calc.sh` a script to be called (name can be
+  overridden by setting the environment variable
+  `OGO_PROFESSDELTAGAUGESCRIPT` to the wanted name).
+
+Subsequently, the script will be executed, using the crystal symmetry (e.g., fcc) of the reference as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated $`\delta`$ gauge (in the same units as the reference) as a simple number in a file `Delta.out`).
+
+#### Forces
+
+If a reference contains nuclear forces, a directory following the scheme `professforcescalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format
+
+- a file `atompos.xyz` containing the atom positions of the reference in
+  xyz format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_forces_calc.sh` a script to be called (name can be overridden
+  by setting the environment variable `OGO_PROFESSFORCESSCRIPT` to the
+  wanted name).
+
+Subsequently, the script will be executed, using `XXX` as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated nuclear forces (in the same units as the reference) as a simple number in a file `forces.out`). The format is as follows: first five lines are ignored, sixth line onwards contains the forces (same order as reference) in columns two (x-component) to four (z-component).
+
+#### Electron density
+
+If a reference contains the electron density, a directory following the scheme `professdensitycalc_RUNNINGNUMNER_TIMESTAMP` will be created. In it, the following files will be created:
+
+- a file `pseudopot_ATOMNAME.recpot` for each ATOMNAME to be optimized,
+  containing the current goLPS trial in PROFESS format
+
+- a file `atompos.xyz` containing the atom positions of the reference in
+  xyz format.
+
+The following files will be copied from the directory in which <span class="smallcaps">ogolem</span> is executed
+
+- `profess_density_calc.sh` a script to be called (name can be
+  overridden by setting the environment variable
+  `OGO_PROFESSDENSITYSCRIPT` to the wanted name).
+
+Subsequently, the script will be executed, using the defined tag for this reference as the first argument. When execution of this script finishes, <span class="smallcaps">ogolem</span> expects the calculated energy (in the same units as the reference) as a simple number in a file `density.out`). The format is as follows (please note, this is PROFESS’s fault!): a single (!), white space separated line, containing the grid dimensions as values two, four, six, and density values (same order as reference) as values 11 and later. Negative density values will be ignored.
+
+### Interface to Polaris
+
+A word of prelimenary caution is needed here. This interface was written for a single and special purpose. Therefore, it will not work for general-purpose tasks by design.
+
+The interface to Polaris is called through `AdaptivableChoice=polaris`, followed by the choices `:totalenergy` or `:waterinteraction` defining which energy holds as reference. The references need to be adjusted accordingly and must be in $`E_h`$.
+
+Additionally, some auxiliary input and file stubs are required. Both a `MET.FFM` and `REP.FFM` file need to be present in the input directory, where all parameters that are to be fitted are replaced by the string `OGOPARAM`. A reference `donee` file needs to be present, starting from
+
+    -----------------------
+    |   Options energie   |
+    -----------------------
+
+and named `donee-ref.aux`. If there are other files to be copied for the Polaris jobs, they need to be present in the input directory and their name needs to be mentioned in a file `adaptive-polaris.aux` of form
+
+    ###OGOLEMAUX###
+    filenametocopy1
+    filenametocopy2
+
+Since Polaris requires more than just a simple xyz-file as input, we assume that for each reference point the following files exist:
+
+- `GEOM.xyz_NUMBER` and
+
+- `GEOM.sle_NUMBER`
+
+where number is the the position in the references starting from zero.
+
+It is highly recommended to use a custom border file as explained above where the parameters start with the `MET.FFM` parameters followed by the `REP.FFM` parameters. Due to the parameters not being known by <span class="smallcaps">ogolem</span> in advance, the borders and parameter values in <span class="smallcaps">ogolem</span> are in the same units as in Polaris.
+
+Last but not least, the path to the Polaris command needs to be exported through an environment variable named `OGO_POLARISCMD`.
+
+Again, this interface was written for a single usage scenario and is not designed to be used for other purposes.
+
+## Global optimization algorithms
+
+All global optimization algorithms are chosen through the `ParameterGlobOpt=` keyword. The input syntax follows the grammar as described in Section <a href="#sec:geomglobopt" data-reference-type="ref" data-reference="sec:geomglobopt">2.7</a>, it is `parameters``xover()mutation()`.
+
+Possible crossover choices are:
+
+- `germany:` a basic single cut, Gaussian distributed genotype
+  crossover. Valid options:
+
+  - `gausswidth=X.X` Sets the width of the Gaussian to `X.X`. Default:
+    0.3.
+
+- `portugal:` a genotype, normal-distributed crossover.
+
+  - `nocuts=X` sets the number of genotype cuts to `X`. Default: 1.
+
+- `noxover:` disables crossover operations.
+
+- `multiple:` uses multiple crossover operators. Syntax identical to the
+  one described in Section
+  <a href="#sec:geomglobopt" data-reference-type="ref"
+  data-reference="sec:geomglobopt">2.7</a>.
+
+- `chained:` chains multiple crossover operators. Syntax identical to
+  the one described in Section
+  <a href="#sec:geomglobopt" data-reference-type="ref"
+  data-reference="sec:geomglobopt">2.7</a>.
+
+- `mutationasxover:` uses a mutation operator instead of a crossover
+  operator for the xover step. Keyword must be followed by a valid
+  mutation as described below.
+
+After some prelimenary testing we are of the opinion that the exact crossover (when using local optimization steps) is not important. Therefore we recommend to use either `germany` or `portugal` with a low number of cuts.
+
+In some cases (e.g. for a hypersurface with a lot of minima) it seems to be a good idea to aggressively mutate the parameters, making `france` or `spain` with a low number of cuts the methods of choice.
+
+Possible mutation choices are:
+
+- `germany:` a basic genotype mutation. Valid options:
+
+  - `mode=` sets the strength of the mutation. Valid input: `all` or
+    `one`. Default: `one`.
+
+- `nomutation:` disables mutation operations.
+
+- `multiple:` uses multiple mutation operators. Syntax identical to the
+  one described in Section
+  <a href="#sec:geomglobopt" data-reference-type="ref"
+  data-reference="sec:geomglobopt">2.7</a>
+
+- `chained:` chains multiple crossover operators. Syntax identical to
+  the one described in Section
+  <a href="#sec:geomglobopt" data-reference-type="ref"
+  data-reference="sec:geomglobopt">2.7</a>.
+
+### HACTAR
+
+Please see Section <a href="#sec:geomhactar" data-reference-type="ref" data-reference="sec:geomhactar">2.7.1</a> for a description of the input format.
+
+## Local optimization algorithms
+
+All local optimization algorithms are chosen through the `ParameterLocOpt=` keyword. In general, the same choices are available as mentioned in Sec. <a href="#sec:geomlocopt" data-reference-type="ref" data-reference="sec:geomlocopt">2.5.18</a>. Please note that the same restrictions concerning the methods obtained through the NUMAL interface apply as mentioned there.
+
+In difference to the cluster structure optimization, the `backend=` definition present in the local optimization definitions has a somewhat restricted feature set. Either, one can specify `alldefault` to default to the classic setup of the fitness function. Note however, this option may well chance in the future! More future-proof is a pre-definition of fitness functions as defined in Sec. <a href="#sec:paramfitfuncdef" data-reference-type="ref" data-reference="sec:paramfitfuncdef">3.7</a>.
+
+## Defining fitness functions
+
+Fitness functions can be defined in between `<PARAMFITNESSFUNCTION>` tags. Per fitness function definition, one set of tags is required. Configuration options inside the tags are:
+
+- `FitFunctionTag=XYZ` assigns tag `XYZ` to this fitness function.
+  Mandatory.
+
+- `FitnessFunction=` specifies the fitness function to be used. At the
+  moment, only `default` is allowed. Mandatory.
+
+- `FitnessFunctionStyle=` specifies the fitness function style to be
+  used. `full` choses all parameters to be exposed always. `ranged:`
+  followed by range definitions (example: 1/3-4/7-8) specifies only
+  these parts of the parameters to be exposed. Optional, default:
+  `full`.
+
+## Parameter output format
+
+Both the inital and final population are written in a human-readable format. This format, as most input and output formats of <span class="smallcaps">ogolem</span> uses an XML-like formatting. The general format is as follows
+
+    <PARAMETERSFOR>
+    methodID
+    </PARAMETERSFOR>
+    <PARAMETERFITNESS>
+    1.23E-1
+    </PARAMETERFITNESS>
+    <PARAMETERS>
+    <ATOM>
+    Key
+    </ATOM>
+    <VALUES>
+     -0.4636119053304735
+     -0.5097016790211515
+     -1.5220016461819896
+     -0.5629664946696742
+     -3.541843106605196
+     -3.5394934242499287
+     0.5378639455382299
+     -3.5096479279350183
+     0.2614123652818187
+     -2.399411743051027
+     -3.51017085778294
+     1.4941457394022188
+     -2.539798139301017
+     -4.5084460220195215
+     -0.5152036256889749
+     -3.511654320068149
+     -4.456450012737577
+     -3.52578457936217
+     -2.539843561431608
+     1.477287999076277
+    </VALUES>
+    </PARAMETERS>
+
+where the method ID resembles the fitted potential. The parameter fitness is in hartree and a *reasonable* fitness depends on the settings, the dimensionality and form of the problem. E.g. the fitness of a high dimensional problem with a lot of reference points employing a steep penalty function accepting only a small deviation from the reference is surely higher than, e.g., a two-body LJ(6,12,6) fit.
+
+In general, as pointed out before, the best fitness is *per definitionem* 0.0. This is, except for benchmark functions, in general not reachable.
+
+This is followed by (depending on the potential and reference data) a number of `<PARAMETER>` tags each uniquely identified by the key in between the `<ATOM>` tags. The tag is somewhat misleading since depending on the potential, it might not be a atom but, e.g., a three-body interaction. The actual key transparently informs about such cases. Each `<PARAMETER>` section contains in between the `<VALUES>` tags all raw values for the specific key. Which parameter means what depends on the potential and is explained in detail in the corresponding section of this manual.
+
+Although we consider this format to be rather final, we do not guarantee that it stays unchanged in later revisions of <span class="smallcaps">ogolem</span>.
+
+## Running the job
+
+After calling, e.g.,
+
+    java -jar ogolem.jar --adaptive input.ogo 2
+
+Depending on the adaptivable backend chosen, there might be a lot of files appearing in the directory and the specified amount of CPUs be used. Concerning the latter: it is not recommended to use all CPUs on a workstation which is supposed to be still used for something else.
+
+<span class="smallcaps">ogolem</span> will clean up all automagically generated input files and/or directories for other programs in case of a sucessfull call to that program. In case that something unexpected (e.g. failing convergence) happens, the files will be left for inspection.
+
+Interesting datafiles are the intermediate binary pool (`IntermediateParamPool.bin`) as well as the human-readable parameter initial files `locrankRANKparamID.prm` and the final files `rankRANKparamID.prm`, where `RANK` is the rank of the parameter set (0 being the global minimum) and `ID` denotes when the specified set was found.
+
+<span class="smallcaps">ogolem</span> might throw warnings or errors. These will be written to System.out and System.err and are of interest.
+
+## Parameter analysis
+
+<span class="smallcaps">ogolem</span> provides some possibilities for parameter analysis. The most useful application of them to-date is probably the intermediate check of parameters and genetic progress at runtime. For this, you call the `ogolem.jar` with the
+
+    --parameters
+
+option.
+
+The analysis program needs a binary pool, either the final `paramPool.bin` or the temporary `IntermediateParamPool.bin`. This is specified using the `-pool=` flag directly followed by the filename, e.g.
+
+    java -jar ogolem.jar --parameters -pool=IntermediateParamPool.bin
+
+Another option is possible
+
+- `-dontgetparams`  
+  Do not write the parameters out. Currently a rather useless option.
+
+Once more, we want to encourage you here to contribute to the <span class="smallcaps">ogolem</span> by proposing some analysis techniques!
+

--- a/manual/md/04-molecular-design-switchable-molecules.md
+++ b/manual/md/04-molecular-design-switchable-molecules.md
@@ -1,0 +1,26 @@
+# Molecular design: Switchable molecules
+
+**IMPORTANT:   This part of the manual is not complete yet!**
+
+## Switch analysis
+
+<span class="smallcaps">ogolem</span> provides means to check a running switch design job using the written restart files. For this, you call the `ogolem.jar` with the
+
+    --beswitched
+
+option.
+
+The analysis program needs a binary pool, either the final `switchespool.bin` or the temporary `snapswitchpool.bin`. This is specified using the `-i` flag followed by whitespace, e.g.
+
+    java -jar ogolem.jar --beswitched -i snapswitchpool.bin
+
+Some other options are possible
+
+- `-collblow`  
+  the blow factor for the collision detection (needed for sidechain
+  glueing), defaults to 1.4.
+
+- `-getswitches`  
+  create a directory named `switches` and write the switched of this
+  pool there in the human-readable format.
+

--- a/manual/md/05-molecular-design-general-molecular-design.md
+++ b/manual/md/05-molecular-design-general-molecular-design.md
@@ -1,0 +1,4 @@
+# Molecular design: General molecular design
+
+**IMPORTANT:   This part of the manual is not complete yet!**
+

--- a/manual/md/06-meta-benchmarking-ogolem-using-lionbench.md
+++ b/manual/md/06-meta-benchmarking-ogolem-using-lionbench.md
@@ -1,0 +1,93 @@
+# Meta-benchmarking <span class="smallcaps">ogolem</span> using Lionbench
+
+## Introduction
+
+Lionbench is a Scala-code developed by Marvin Kammler and Johannes Dieterich at the Georg-August-University Göttingen and has been embedded into the ogolem.jar. It is designed to automatically create <span class="smallcaps">ogolem</span> input, run and analyze the performance based on all combinations of input settings. It is therefore possible to e.g. determine optimal input settings for a series of smaller cluster structure optimizations to use them for larger optimizations and save considerable amounts of computing time. Also, it allows to benchmark new algorithms against a set of known problems and in comparison to other algorithms.
+
+Currently, no set of benchmark problems exists. Any contribution in this respect is very welcome!
+
+## Usage within <span class="smallcaps">ogolem</span>
+
+Access to Lionbench is simply realized by calling the ogolem.jar with the `--lionbench` flag followed by the Lionbench configuration file and the number of CPUs to be used for all <span class="smallcaps">ogolem</span>runs.
+
+Lionbench is calling ogolem through a runOGOLEM file which must be present and executable. It automatically sniffs through all subdirectories of the directory it has been started in and searches for <span class="smallcaps">ogolem</span> input files to run them.
+
+## Input file format: Main Lionbench configuration
+
+In general, the Lionbench configuration file contains keywords followed by whitespace and the option(s).
+
+- `NumberOfSamples`  
+  The number of independent runs on each input configuration for
+  statistics. Default: 5.
+
+- `ReadLocalOpts`  
+  If the number of local optimizations should be read. Default: false.
+
+- `ExitOnFirstNotFound`  
+  If Lionbench should exit when a global minimum is not found. Default:
+  true.
+
+- `ExitOnProblem`  
+  If Lionbench should exit ungracefully upon the first encountered
+  problem. Default: true.
+
+- `Blacklist`  
+  A comma-separated list of subdirectories that shall be ignored.
+
+- `PartialBlacklist`  
+  A comma-separated list of to-be-ignored inputs.
+
+- `Whitelist`  
+  A comma-separated list of subdirectories that shall be used (inverts
+  the `Blacklist`)
+
+- `VerbosePerFolder`  
+  If verbose output for every folder of tests is wanted. Default: true.
+
+- `VerbosePerInput`  
+  If verbose output for every test input is wanted. Default: true.
+
+- `DeleteAllFiles`  
+  If files should be deleted after successful excecution. Default: true.
+
+- `SaveErrorErrout`  
+  If error and output stream of every
+  <span class="smallcaps">ogolem</span> run should be save. Default:
+  true.
+
+- `AllowedDiffToGlobMin`  
+  By how much the solution found by any input configuration is allowed
+  to differ from the known global minimum. The known global minimum
+  value is set in the .ogo-file with the `AcceptableFitness` option
+  (cf. pp.  and ). Default: 1E-6.
+
+## Input file format: Individual <span class="smallcaps">ogolem</span> and `.lion` input files
+
+Lionbench works based on a stub for an <span class="smallcaps">ogolem</span> input (e.g. test.ogo) and a corresponding Lionbench file (test.lion) defining how input parameters for ogolem should be manipulated. For convinience, it is possible to have one .lion file for all <span class="smallcaps">ogolem</span> inputs if they should be altered in the same way. This file must be named `generic.lion` and will be used if present.
+
+Every <span class="smallcaps">ogolem</span> input variable to be varied with Lionbench will be replaced by the `LIONVAR` identifier in the `.ogo` file, e.g., `GlobOptAlgo=LIONVAR`. It is possible to vary multiple variables at once, Lionbench will automatically test all variations of them. The `.lion` file contains information on how those variables should be substituted and which files are needed for this <span class="smallcaps">ogolem</span> run to complete (e.g. coordinate files, auxiliary files,...). For example:
+
+    <LIONOPTS>
+    germany AND portugal:1 AND holland
+    </LIONOPTS>
+    <LIONFILES>
+    dummy.xyz
+    </LIONFILES>
+
+where the first `LIONVAR` marked input option will be replaced with the identifiers `germany`, `portugal:1` and `holland`. If more than one input option are to be changed in the same Lionbench run, their order in both the `.ogo` and the `.lion` file must match.
+
+In case of numerical variables, another syntax is available. A start to end with increment can be specified as `XXX...YYY...ZZZ` where `XXX` is the numerical start value, `YYY` is the end value and `ZZZ` is the increment.
+
+Every directory with `.ogo`/`.lion` combinations must contain an executable shell script run ogolem named `runOGOLEM`. As an example:
+
+    #!/bin/sh
+    $JAVA_HOME/bin/java -jar $OGOLEMDIR/ogolem.jar --adaptive $1 $2 > errout 2>&1
+
+with the usual call of the `ogolem.jar`, the correct switch for the job to run and taking the input parameters \$1 and \$2 for the input file name and the number of threads, respectively.
+
+## Output format
+
+*Please note that the current output format is rather verbose and will be subject to change in later versions of Lionbench!*
+
+Depending on the chosen verbosity, Lionbench will report the average and standard deviation of each input combination to console. Also, individual reports for each run are possible. There is a Python-script written by Marvin Kammler available to parse and beautify the Lionbench output. Eventually, the output will be altered to provide a better out-of-the-box solution.
+

--- a/manual/md/07-lidthreshold-capabilites.md
+++ b/manual/md/07-lidthreshold-capabilites.md
@@ -1,0 +1,84 @@
+# Lid/Threshold capabilites
+
+<span class="smallcaps">ogolem</span>features an implementation of Schön and Sibanis lid/threshold algorithm that can be used to study funnels of the energy landscape of clusters and molecules. Please read the original publications for a description of this elegant algorithm.
+
+Our lid implementation is called with the `--lid` flag followed by the path to the .ogo file and the number of threads you intent to use for the lid search. The .ogo file must contain a geometry definition and a choice for the local optimization algorithm (please make sure to use something that also doubles as a backend!) and contains all settings for the lid run in `<LIDCONFIG>` tags.
+
+Relevant input keywords are
+
+- `ThreshMetaRuns=`  
+  The number of meta runs for the lid algorithm (read: how often the
+  total lid cycle will be run). Default: 2.
+
+- `ThreshUseKearsleyOverlap`  
+  Choose Kearsley’s aligner for structural comparison. Works only with
+  single molecules. Mutually exclusive with `TheshUseHundtOverlap`.
+  Default: off.
+
+- `ThreshUseHundtOverlap`  
+  Choose Hundt’s aligner for structural comparison. Mutually exclusive
+  with `ThreshUseKearsleyOverlap`. Default: off.
+
+- `ThreshKearslerRMSD=`  
+  Maximal RMSD in bohr for structures to be considered equal. Default:
+  0.1.
+
+- `ThreshOverlapCOnfig=`  
+  Modifies the settings of Hundt’s aligner. See description there.
+
+- `ThreshEnergyPrescreen=`  
+  The energy threshold in Hartree for structural comparison or, if a
+  secondary aligner is used, for prescreening. Default: 1E-4.
+
+- `NoVerboseSerialization`  
+  Disable storage of intermediate results after every meta run. Default:
+  on.
+
+- `ThreshMoveclass=`  
+  Choosing a move class for the MC steps of the lid run. Options:
+
+  - `mcmove:` MC moves in the Cartesian coordinate space. mcmove must be
+    followed by comma separated choices of move mode (0: move one atom,
+    1: move random number of atoms, 2: move all atoms) and the maximum
+    move in bohr.
+
+  - `mcextmove:` MC moves of fragements in the COM/Euler space.
+    mcextmove must be followed by comma separated choices of move mode
+    (0: move one fragment, 1: move random number of fragements, 2: move
+    all fragements), the maximum move in the COM space in bohr and the
+    maximum move in the Euler space as a fraction of the coordinate
+    defintion (e.g. 0.2 as 20% of the Euler coordinate).
+
+  - `mcintmove:` MC moves in the internal coordinate space. THIS MUST BE
+    USED ONLY FOR SYSTEMS CONTAINING ONE MOLECULE WITH A Z-MATRIX INPUT
+    PRESENT AND PROPAGATED IN DIHEDRALS! mcintmove must be followed by
+    comma separated choices of the usual mode definition and the maximum
+    move in the dihedral space, e.g., 0.2 for 20% of the $`-\pi`$ to
+    $`+\pi`$ defined dihedral space. This input options relies on the
+    previously mentioned `DOF` definition to allow specific dihedrals
+    for propagation.
+
+- `ThresholdProvider=`  
+  Defines which form the threshold increase should have. Currently, you
+  must use `simple:` followed by a comma separated list of the starting
+  energy, the end energy and the linear energy increment in Hartree
+  (e.g. `simple:0.02,0.20,0.01` to go from 0.02 to 0.2 Hartree in 0.01
+  Hartree increments).
+
+- `ThresholdConfig=`  
+  Can be used to modify the internals of the threshold algorithm. Tokens
+  are semicolon separated and may contain the following keywords
+
+  - `threshruns=` the number of propagations at a certain lid level.
+    Default: 30.
+
+  - `nomoves=` the number of MC moves in one threshold run. Default:
+    50000.
+
+  - `freqanalysis` carry out a frequency analysis to check each obtained
+    structure if it is a real minimum. NOT WORKING YET!
+
+Additionally, at least one starting structure is required. The defintion is enclosed in `<LIDMINIMA>` tags, containing one structure (represented by the path to an xyz file) per line, any number of lines is supported.
+
+When running the lid algorithm, intermediate data will be printed out (unless disabled) with the `intermediate` suffix and the number of the meta run finished. Ultimately, the final results will be printed. A folder containing all structures found by the algorithm, a dot file representing the graph and the same graph as an <span class="smallcaps">ogolem</span>internal binary for later reuse.
+

--- a/manual/md/08-jvm-based-distributed-memory-parallelization-rmi.md
+++ b/manual/md/08-jvm-based-distributed-memory-parallelization-rmi.md
@@ -1,0 +1,271 @@
+# JVM-based distributed-memory parallelization (RMI)
+
+The cluster, parameter and switch optimization parts of <span class="smallcaps">ogolem</span> can also use a JVM-based parallelization via RMI (remote method invocation). While possessing some unique features of its own, its targeted use is replacing the MPI-based parallelization layer. See Ref.  for a full discussion of the background rationale for this RMI parallelization mode, of its different modi, and of its performance, including in particular demonstrations of its excellent parallel scaling. The most important benefits include the ability to dynamically add or subtract clients at will during runtime, also resulting in almost total immunity against hardware failures, and parallelization across arbitrarily heterogenous ad-hoc networks, only needing a standard JVM on each node and standard TCP/IP connections between them.
+
+In order for this parallelization scheme to work, a standard Java distribution must be used, there need be two open TCP ports dedicated on the server and (if applicable) proxy nodes. While not recommended, one can run a server and (multiple) proxies on the same machine if different TCP ports are used.
+
+Also, some installation-dependent flags to the JVM must be passed for security policies, CLASSPATH settings etc. These are included in the startup syntax discussions below but are not yet explained further in this version of this manual.
+
+There are three possible modes:
+
+simple clients:   1 server communicating directly with $`N`$ clients,
+
+proxies:   1 server communicating with $`M`$ proxies, which in turn communicate with $`N_M`$ simple clients each,
+
+threading clients:   1 server communicating with $`N`$ tread-parallel clients.
+
+Essential similarities and differences between these modes (fully explained in Ref. ) include the following:
+
+- The clients in the “simple clients” and “proxies” modes are simple in
+  several ways:
+
+  - tasks they receive for execution always consist of just one single
+    global optimization step, i.e., crossover and mutation of one or two
+    “parents”, and local optimization of the resulting one or two
+    “children”;
+
+  - these tasks are executed serially (no parallelization);
+
+  - from the user, these clients do not receive any problem-specific
+    input (which is provided at runtime by the server).
+
+  In contrast,
+
+  - both proxies and threading clients receive chunks of tasks,
+    consisting of 1,2,…,$`m`$ global optimization steps;
+
+  - threading clients execute their task chunks in thread-parallel
+    manner;
+
+  - and both proxies and threading clients need a full `ogo`-file as
+    input.
+
+- From the viewpoint of the RMI server, there is no difference in
+  communication to proxies or to threaded clients. From the viewpoint of
+  the simple clients, there is no difference in communication to proxies
+  or directly to the server.
+
+Threading clients can be understood as combining the roles of one proxy and all the simple clients connected to this proxy into one single job that is then executed in shared-memory/thread-based parallelization. Alternatively, one proxy and all simple clients connected to it can be understood as a threading client executed in RMI parallelization.
+
+## Starting RMI job-hierarchies
+
+As things are set up inside <span class="smallcaps">ogolem</span>, all three of the above modes of RMI-mode hierarchies (simple clients, proxies, threading clients) consist of several (at least two) separate <span class="smallcaps">ogolem</span> jobs that need to be started separately, and jobs “higher” in the hierarchy (servers, proxies) always need to be started before jobs “lower” in the hierarchy (proxies, clients).
+
+### Starting the RMI server
+
+Hence, in every mode, first a server process must be started. This can be accomplished using the following (in one single, long line):
+
+    java -Djava.security.main -Djava.rmi.server.codebase=file:<path/to/ogolem-jar-file> 
+    -Djava.security.policy=polfile.txt -Djava.rmi.server.hostname=<IP-address> 
+    -jar <path/to/ogolem-jar-file> 
+    --rmiserver 
+    --jobtype <job type> 
+    --inputfile <input.ogo> 
+    --timeout <timeout> 
+    --timeoutjob <timeoutjob> 
+    --myserverport <server-port#> 
+    --myregistryport <registry-port#> 
+    --noproxies <#proxies>
+    --commname <nameofregistryobject>
+
+where
+
+- `-Djava.security.main` enables Java’s security manager (mandatory)
+
+- `-Djava.rmi.server.codebase=file:` tells the security manager where
+  the ogolem.jar lies (mandatory)
+
+- `-Djava.security.policy=` specifies the location of the security
+  policy file (mandatory)
+
+- `polfile.txt` is the filename of a java security policy file, with a
+  content like this one (as the simplest and most permissive version):
+
+      grant{
+              permission java.security.AllPermission;
+      };
+
+  We strongly advice you to only grant a minimum of permissions!
+
+- `-Djava.rmi.server.hostname=` sets the internally used hostname
+  (optional, use if there are problems with name resolution)
+
+- `IP-address` is a standard IP address for the machine this server job
+  is running on, e.g., a fully qualified numerical IPv4 address like
+  `121.232.212.202`, or a string-based one like “machine.domain.org” or
+  possibly even “localhost” (depending on the IP-setup of this machine);
+
+- `job type` is the optimization problem to be solved. Options are:
+  `geom` (cluster structure optimization), `param` (parameter fitting),
+  `switch` (switch design), this flag is mandatory;
+
+- `input.ogo` is a regular <span class="smallcaps">ogolem</span> input
+  file for the problem to be optimized (mandatory);
+
+- `timeout` is a timeout in seconds after which a client will be purged
+  from the server-internal list of active clients, provided there has
+  been no communication with or heart beat from this client within this
+  time interval. Default: 10s. Can be increased on stable networks.
+  (optional);
+
+- `timeoutjob` is a timeout in seconds after which a job will be purged.
+  This should correspond to the expected time a global optimization step
+  (for simple clients) or a chunk of steps (proxies, threading clients)
+  needs for normal execution, hence this timeout must be increased for
+  demanding problems. Default: 10s. (optional);
+
+- `server-port#` is the IP port number that the server will use for task
+  communication with the clients, typically/default 2500 (optional);
+
+- `registry-port#` is the IP port number where the RMI registry is
+  running on, typically/default 1099 (optional);
+
+- `#proxies` is the number of proxies or threading clients that are
+  initially expected to talk to this server. If there will be no
+  proxies, specify -1 (optional). Note that `#proxies` does *not* limit
+  (or otherwise affect) the number of actual proxies or threading
+  clients that can connect to this server at runtime. `#proxies = -1`
+  denotes the “simple client” mode, and `#proxies >= 0` denotes a
+  “proxies” or “threading clients” mode, where the initial value of
+  `#proxies` is only used to organize the initialization phase more
+  sensibly.
+
+- `commname#` is the String name of the RMI communication for RMI object
+  export it must match on server, proxy, and client, typically/default
+  RMICommunication (optional);
+
+After `--rmiserver`, the following flags can occur in any order.
+
+The server process will now setup and configure itself and listen to incoming connections on `server-port#` from clients.
+
+### Starting RMI proxies or threading clients
+
+Subsequently, proxy processes or threading clients can be started if wished.
+
+The proxy invocation is as follows (again with everything in one line):
+
+    java -Djava.rmi.server.codebase=file:<path/to/ogolem-jar-file> 
+    -Djava.security.policy=client.policy 
+    -jar <path/to/ogolem-jar-file> 
+    --rmiproxy
+    --jobtype <job type>
+    --inputfile <input.ogo>
+    --server <IP-address>
+    --serverregistryport <registry-port#>
+    --myserverport <myserver-port#>
+    --registryport <myregistry-port#>
+    --timeout <timeout> 
+    --timeoutjob <timeoutjob> 
+    --sleeptime <sleeptime>
+    --maxchunk <chunked steps>
+    --mergeinds <#indivs2merge>
+    --commname <nameofregistryobject>
+
+where
+
+- `IP-address`: As above; however, on a remote machine, the user should
+  make sure beforehand (with commands like `ping`, `telnet`, etc.) that
+  the address provided here is actually resolved in the desired way;
+  this is a mandatory flag;
+
+- `registry-port#` is the port number of the registry on the server
+  (optional). The additional `server-port#` provided at server startup
+  need not be re-specified here since it is communicated to the client
+  from the server.
+
+- `myserver-port#` and `myregistry-port#` are for the “server-like role”
+  this proxy plays towards the RMI clients to be associated with it, and
+  hence are fully analogous to the corresponding flags in the actual
+  server invocation, including their default values and optional status.
+  Only if proxy and server are located on the same physical machine, the
+  ports must differ between them;
+
+- `sleeptime` has a dual role: It specifies the time delay between
+  “heartbeat” signals sent to the server, indicating that the proxy is
+  still “alive”. And it also is the time this proxy waits after
+  contacting the server and finding that the server is busy (e.g.,
+  waiting for another client);
+
+- `chunked steps` is the number of global optimization steps packed
+  together into one chunk of tasks communicated from the server to the
+  proxy, and of results communicated back from the proxy to the server;
+  actual chunks may be smaller during initialization or in the final
+  phase.
+
+- `#indivs2merge` indicates how many individuals of the proxy’s pool (at
+  the time results of a chunk are communicated back to the server)
+  should be merged with the server’s pool. Default: -1 (full pool)
+  (optional). Note that the proxy pool size need not be equal to the
+  server pool size, since the proxy has its own input (where a pool size
+  is specified).
+
+- `client.policy` is an optional setting to specify restrictions on the
+  client JVM. Please see JVM documentation for options and syntax.
+
+After `--rmiproxy`, the following flags can occur in any order.
+
+Note that both server and proxy jobs do not do any actual calculations (global optimization steps) themselves, but initially they do parse their <span class="smallcaps">ogolem</span> input files. Hence, before simple or threading clients are started,
+
+- there will be no optimization progress;
+
+- but server and/or proxy jobs should report successful input parsing,
+
+- or may exit prematurely in case of input parsing errors (in which case
+  client jobs being started subsequently may fail to connect).
+
+Please note that both proxies and threading clients may output log files, binary snapshots etc. Hence, they should be started in a directory other than the server process to avoid random overwrites.
+
+The threading client invocation is as follows:
+
+    java -Djava.rmi.server.codebase=file:<path/to/ogolem-jar-file> 
+    -Djava.security.policy=client.policy 
+    -jar <path/to/ogolem-jar-file> 
+    --rmithreader 
+    --jobtype <job type> 
+    --inputfile <input.ogo> 
+    --server <IP-address>
+    --serverregistryport <registry-port#>
+    --threads <#threads> 
+    --sleeptime <sleeptime>
+    --maxchunk <chunked steps>
+    --mergeinds <#indiv2merge>
+    --commname <nameofregistryobject>
+
+Several of these flags have already been explained above. The remaining ones are:
+
+- `registry-port#` is the port number of the registry on the server. The
+  additional `server-port#` provided at server startup need not be
+  re-specified here since it is communicated to the client from the
+  server. In contrast to a proxy, this threading client does not play a
+  dual RMI role, hence further ports for interactions with RMI clients
+  need not be specified.
+
+- `#threads` specifies the number of shared-memory-parallel threads this
+  client should use on this machine. Note that a value of 1 (one) is
+  also possible, which establishes a mixture of features from simple
+  clients (serial execution) with those of threaded clients (chunking,
+  separate input file).
+
+### Starting RMI simple clients
+
+Lastly, one can start simple client processes. As explained above, in “simple client” mode, the simple clients connect directly to the server. In “proxies” mode, there typically are several groups of simple clients, each of which connects to one proxy, and from the viewpoint of this simple client group, this proxy takes the role of a server.
+
+As explained above, simple clients need only very little information from the user, hence their invocation is very simple, too:
+
+    java -Djava.rmi.server.codebase=file:<path/to/ogolem-jar-file> 
+    -Djava.security.policy=client.policy 
+    -jar <path/to/ogolem-jar-file> 
+    --rmiclient 
+    --server <IP-address>
+    --sleeptime <sleeptime>
+    --serverregistryport <server-port#>
+    --taskwaittime <taskwaittime>
+
+with
+
+- `taskwaittime` the time in seconds the client will wait for the server
+  upon receiving a wait signal before contacting again. Default: 5s
+  (optional).
+
+and all other options have already been explained above, and again all options after `--rmiclient` can appear in any order. Naturally, `--server` is mandatory, but the other options are optional. If proxies are used, `--server` and `--serverregistryport` denote the IP address and registry port of the desired proxy (which takes the role of the server here); the “actual server” is then effectively invisible to the simple clients.
+

--- a/manual/md/09-faqs.md
+++ b/manual/md/09-faqs.md
@@ -1,0 +1,42 @@
+# FAQs
+
+## <span class="smallcaps">ogolem</span> doesn’t run and/or behaves crazy
+
+Ensure that your environment is properly setup. In particular reduce the input to a minimal example and check the following things:
+
+- A JRE (preferably openJDK/JRE or Sun/Oracle-JDK/JRE) of at least
+  version 7 exists and works on your system.
+
+- If an external program is called, check whether is is properly
+  installed and all conditions specified in the corresponding section
+  are met.
+
+- Check whether your input is sane (in particular blow factors for
+  global geometry optimizations) and makes sense.
+
+- set DebugLevel= to 1 or higher and check the additional output for
+  hints.
+
+## I have problems running an external program
+
+Most of the times, this is due to the fact that the program cannot be found in the \$PATH environment variable (for unixoid systems). Setup a wrapper script
+
+    #!/bin/sh
+    PROGRAM $@
+
+in your \$HOME/bin directory named like the `PROGRAM` you want to call, mark it executable and see if it works (you might need to setup necessary environment variables and/or load modules in this script as well). Debug statements might help to make sure the wrapper is being executed:
+
+    #!/bin/sh
+    echo "Calling external program..." >> $HOME/debug_ogolem
+    PROGRAM $@
+    echo "Finished calling external program." >> $HOME/debug_ogolem
+
+## I want to report a bug, how does it work and what is required?
+
+In case your data is not confidential (or you can reduce the data set such that it is not confidential), please file a bug report to `developers@ogolem.org`, providing your input(s) and a description of the problems encountered. We will treat the data confidentially.
+
+Once the bug has been found and fixed, you can obtain a new snapshot of the ogolem.jar from the <span class="smallcaps">ogolem</span> homepage.
+
+## Does <span class="smallcaps">ogolem</span> loose or change features over time?
+
+In general, we strive to remain backwards compatible with regards to both features and input. However, we will remove features that have been superseded by superior solutions, with the same rationale applying to input formats. Either of the two has so far happened only most seldomly. If a regression should be introduced, please notify the authors as we will want to fix it.

--- a/manual/md/10-references.md
+++ b/manual/md/10-references.md
@@ -1,0 +1,15 @@
+# References
+
+- Buck, U., C. C. Pradzynski, T. Zeuch, J. M. Dieterich, and B. Hartke. 2014. *Phys. Chem. Chem. Phys.* 16: 6859.
+- Carstensen, N. O., J. M. Dieterich, and B. Hartke. 2011. *Phys. Chem. Chem. Phys.* 13: 2903.
+- Dieterich, J. M., G. H. Clever, and R. A. Mata. 2012. *Phys. Chem. Chem. Phys.* 14: 12746.
+- Dieterich, J. M., S. Gerke, and R. A. Mata. 2012. *J. Atom. Mol. Opt. Phys.* 2012: ID648386.
+- Dieterich, J. M., U. Gerstel, J.-M. Schröder, and B. Hartke. 2011. *J. Mol. Model.* 17: 3195.
+- Dieterich, J. M., and B. Hartke. 2010. *Mol. Phys.* 108: 279.
+- Dieterich, J. M., and B. Hartke. 2011. *J. Comput. Chem.* 32: 1377.
+- Dieterich, J. M., and B. Hartke. 2012. *Appl. Math.* 3: 1552.
+- Dieterich, J. M., and B. Hartke. 2014. *J. Comput. Chem.* 35: 1618.
+- Dieterich, J. M., and B. Hartke. 2017. “Improvd Cluster Structure Optimization: Hybridizing Evolutionary Algorithms with Local Heat Pulses.” *Inorganics* 5: 64. <https://doi.org/10.3390/inorganics5040064>.
+- Forck, R. M., J. M. Dieterich, C. C. Pradzynski, A. L. Huchting, T. Zeuch, and R. A. Mata. 2012. *Phys. Chem. Chem. Phys.* 14: 9054.
+- Frank, M., J. M. Dieterich, S. Freye, R. A. Mata, and G. H. Clever. 2013. *Dalton Trans.* 42: 15906.
+- Lau, H. T. 2003. *A Numerical Library in Java for Scientists & Engineers*. CRC Press.

--- a/manual/md/README.md
+++ b/manual/md/README.md
@@ -1,0 +1,20 @@
+# OGOLEM Manual
+
+This manual is generated from the LaTeX source (`manual.tex`). Below: links to each chapter (viewable on GitHub).
+
+## Chapters
+
+- [General remarks](01-general-remarks.md)
+- [Global optimization of clusters](02-global-optimization-of-clusters.md)
+- [Global parametrization of potentials, pseudopotentials, ...](03-global-parametrization-of-potentials-pseudopotentials.md)
+- [Molecular design: Switchable molecules](04-molecular-design-switchable-molecules.md)
+- [Molecular design: General molecular design](05-molecular-design-general-molecular-design.md)
+- [Meta-benchmarking ogolem using Lionbench](06-meta-benchmarking-ogolem-using-lionbench.md)
+- [Lid/Threshold capabilites](07-lidthreshold-capabilites.md)
+- [JVM-based distributed-memory parallelization (RMI)](08-jvm-based-distributed-memory-parallelization-rmi.md)
+- [FAQs](09-faqs.md)
+- [References](10-references.md)
+
+---
+
+*To rebuild from LaTeX, run from the `manual/` directory:* `python3 tex2md.py`

--- a/manual/tex2md.py
+++ b/manual/tex2md.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+Convert manual.tex to GitHub-friendly Markdown files (one per chapter) with
+internal links. Requires pandoc. Run from the manual/ directory:
+
+    python3 tex2md.py
+
+Produces:
+  - md/01-general-remarks.md, md/02-global-optimization-clusters.md, ...
+  - md/README.md (index with links to all chapters)
+
+GitHub renders these natively; links work across files.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+MANUAL_DIR = Path(__file__).resolve().parent
+MANUAL_TEX = MANUAL_DIR / "manual.tex"
+MANUAL_BIB = MANUAL_DIR / "manual.bib"
+MD_DIR = MANUAL_DIR / "md"
+FULL_MD = MANUAL_DIR / "_manual_full.md"
+
+
+def strip_html(text: str) -> str:
+    """Remove HTML tags for plain-text slug/title."""
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def title_to_slug(title: str) -> str:
+    """e.g. 'General remarks' -> 'general-remarks'. Safe for filenames."""
+    t = strip_html(title)
+    s = re.sub(r"[^\w\s-]", "", t.lower())
+    return re.sub(r"[-\s]+", "-", s).strip("-") or "chapter"
+
+
+def slug_from_index_and_title(index: int, title: str) -> str:
+    """e.g. 1, 'General remarks' -> '01-general-remarks'."""
+    return f"{index:02d}-{title_to_slug(title)}"
+
+
+def run_pandoc() -> bool:
+    """Convert manual.tex to a single Markdown file. Returns True on success."""
+    args = [
+        "pandoc",
+        str(MANUAL_TEX),
+        "-f", "latex",
+        "-t", "gfm",
+        "--number-sections",
+        "--wrap=auto",
+        "-o", str(FULL_MD),
+    ]
+    if MANUAL_BIB.exists():
+        args.extend(["--bibliography", str(MANUAL_BIB), "--citeproc"])
+    try:
+        subprocess.run(
+            args,
+            check=True,
+            capture_output=True,
+            cwd=str(MANUAL_DIR),
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        if isinstance(e, FileNotFoundError):
+            print("error: pandoc not found. Install pandoc to convert LaTeX to Markdown.", file=sys.stderr)
+        else:
+            print("error: pandoc failed:", e.stderr.decode() if e.stderr else e, file=sys.stderr)
+        return False
+    return True
+
+
+def split_and_collect_chapters() -> list[tuple[str, str, str]]:
+    """
+    Split _manual_full.md by top-level # (chapter) headings.
+    Pandoc outputs "# Title" without section numbers. We number chapters by order.
+    Returns list of (slug, chapter_num_str, markdown_content).
+    """
+    if not FULL_MD.exists():
+        return []
+
+    text = FULL_MD.read_text(encoding="utf-8", errors="replace")
+    # Split on any level-1 heading: "# Title" (pandoc does not add numbers in GFM)
+    pattern = re.compile(r"^# (.+)$", re.MULTILINE)
+    parts = pattern.split(text)
+
+    # parts[0] = content before first chapter (often empty or title/TOC)
+    # parts[1], parts[2] = "General remarks", "\n\n## This manual\n..."
+    # parts[3], parts[4] = "Global optimization...", "\n\n..."
+    chapters = []
+    i = 1
+    chapter_num = 1
+    while i + 1 < len(parts):
+        title, content = parts[i], parts[i + 1]
+        slug = slug_from_index_and_title(chapter_num, title)
+        full_content = f"# {title}\n{content}"
+        chapters.append((slug, str(chapter_num), full_content))
+        chapter_num += 1
+        i += 2
+
+    return chapters
+
+
+def normalize_paragraph_breaks(content: str) -> str:
+    """
+    Follow LaTeX convention: only double newline means a real line/paragraph break.
+    Within a paragraph, collapse single newlines to spaces so prose flows as one block.
+    Leave list items, code blocks, and tables unchanged.
+    """
+    blocks = re.split(r"\n\n+", content)
+    result = []
+    for block in blocks:
+        block = block.rstrip("\n")
+        if not block:
+            result.append("")
+            continue
+        lines = block.split("\n")
+        first_line = lines[0]
+        # Leave lists, indented code (4+ spaces), fenced code, tables as-is
+        if re.match(r"^[\s]*[-*+]\s", first_line):
+            result.append(block)
+            continue
+        if re.match(r"^[\s]{4,}", first_line):
+            result.append(block)
+            continue
+        if first_line.strip().startswith("```"):
+            result.append(block)
+            continue
+        if first_line.strip().startswith("|"):
+            result.append(block)
+            continue
+        if re.match(r"^[\s]*\d+\.\s", first_line):
+            result.append(block)
+            continue
+        # Heading on first line: keep heading, collapse the rest as one paragraph
+        if re.match(r"^#{1,6}\s", first_line):
+            rest = " ".join(lines[1:]) if len(lines) > 1 else ""
+            result.append(f"{first_line}\n\n{rest}" if rest else first_line)
+            continue
+        # Prose paragraph: join all lines with a single space
+        result.append(" ".join(lines))
+    return "\n\n".join(result)
+
+
+REFERENCE_SLUG = "10-references"
+
+
+def extract_references_block(content: str) -> tuple[str, Optional[str]]:
+    """
+    If content ends with a pandoc-citeproc references block (div id="refs" or
+    class="references csl-bib-body"), extract it and return (content_without_refs,
+    refs_as_markdown). Otherwise return (content, None).
+    """
+    refs_start = re.search(
+        r'<div\s+id="refs"\s+class="references[^"]*"[^>]*>',
+        content,
+        re.IGNORECASE,
+    )
+    if not refs_start:
+        refs_start = re.search(r'<div[^>]*class="references\s+csl-bib-body"[^>]*>', content)
+    if not refs_start:
+        return content, None
+
+    start_pos = refs_start.start()
+    # Find matching closing </div> by counting nested divs
+    pos = refs_start.end()
+    depth = 1
+    while depth > 0 and pos < len(content):
+        next_open = content.find("<div", pos)
+        next_close = content.find("</div>", pos)
+        if next_close == -1:
+            break
+        if next_open != -1 and next_open < next_close:
+            depth += 1
+            pos = next_open + 4
+        else:
+            depth -= 1
+            pos = next_close + 6
+            if depth == 0:
+                refs_html = content[start_pos:next_close + 6]
+                break
+    else:
+        return content, None
+
+    content_without = content[:start_pos].rstrip()
+    refs_md = references_html_to_markdown(refs_html)
+    return content_without, refs_md
+
+
+def references_html_to_markdown(refs_div_html: str) -> str:
+    """Convert pandoc refs div to a Markdown section: # References and a list of entries."""
+    entries = re.findall(
+        r'<div[^>]*class="csl-entry"[^>]*>\s*(.*?)\s*</div>',
+        refs_div_html,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if not entries:
+        return ""
+    lines = ["# References", ""]
+    for entry in entries:
+        # Normalize whitespace (single newlines to space, keep one line per entry)
+        text = " ".join(entry.split())
+        # Keep * for italics and <url> for links (valid in Markdown)
+        lines.append(f"- {text}")
+    return "\n".join(lines)
+
+
+def rewrite_cross_chapter_links(
+    content: str, this_anchor: str, slug_for_anchor: dict[str, str]
+) -> str:
+    """
+    Rewrite [text](#anchor) that point to another chapter to [text](slug.md#anchor).
+    slug_for_anchor: map of GFM anchor -> filename slug for each chapter.
+    """
+    def repl(m: re.Match) -> str:
+        anchor = m.group(1).lstrip("#")
+        if anchor == this_anchor:
+            return m.group(0)
+        slug = slug_for_anchor.get(anchor)
+        if slug:
+            return f"]({slug}.md#{anchor})"
+        return m.group(0)
+
+    content = re.sub(r"\]\((#[-\w]+)\)", repl, content)
+    return content
+
+
+def write_chapters(chapters: list[tuple[str, str, str]]) -> tuple[list[tuple[str, str]], bool]:
+    """Write each chapter to md/<slug>.md. Returns (chapter_slugs, had_references)."""
+    MD_DIR.mkdir(parents=True, exist_ok=True)
+    slug_for_anchor = {}
+    for slug, _num, content in chapters:
+        first_line = content.split("\n")[0].strip().lstrip("#").strip()
+        anchor = title_to_slug(strip_html(first_line))
+        slug_for_anchor[anchor] = slug
+
+    had_references = False
+    for idx, (slug, _num, content) in enumerate(chapters):
+        first_line = content.split("\n")[0].strip().lstrip("#").strip()
+        this_anchor = title_to_slug(strip_html(first_line))
+        content = rewrite_cross_chapter_links(content, this_anchor, slug_for_anchor)
+        content = normalize_paragraph_breaks(content)
+
+        # Last chapter: extract references into their own section if present
+        if idx == len(chapters) - 1:
+            content, refs_md = extract_references_block(content)
+            if refs_md:
+                (MD_DIR / f"{REFERENCE_SLUG}.md").write_text(refs_md, encoding="utf-8")
+                had_references = True
+
+        (MD_DIR / f"{slug}.md").write_text(content, encoding="utf-8")
+
+    return [(slug, num) for slug, num, _ in chapters], had_references
+
+
+def write_index(
+    chapter_slugs: list[tuple[str, str]],
+    chapters: list[tuple[str, str, str]],
+    has_references: bool = False,
+) -> None:
+    """Write md/README.md as the manual index."""
+    title = "OGOLEM Manual"
+    lines = [
+        f"# {title}",
+        "",
+        "This manual is generated from the LaTeX source (`manual.tex`). "
+        "Below: links to each chapter (viewable on GitHub).",
+        "",
+        "## Chapters",
+        "",
+    ]
+    for (slug, _num), (_, _, content) in zip(chapter_slugs, chapters):
+        first_line = content.split("\n")[0].strip()
+        title_text = strip_html(first_line.lstrip("#").strip())
+        lines.append(f"- [{title_text}]({slug}.md)")
+    if has_references:
+        lines.append(f"- [References]({REFERENCE_SLUG}.md)")
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("*To rebuild from LaTeX, run from the `manual/` directory:* `python3 tex2md.py`")
+    (MD_DIR / "README.md").write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    if not run_pandoc():
+        return 1
+
+    chapters = split_and_collect_chapters()
+    if not chapters:
+        print("error: no chapters found in pandoc output.", file=sys.stderr)
+        return 1
+
+    chapter_slugs, has_references = write_chapters(chapters)
+    write_index(chapter_slugs, chapters, has_references=has_references)
+
+    try:
+        FULL_MD.unlink()
+    except OSError:
+        pass
+
+    n = len(chapters) + (1 if has_references else 0)
+    print(f"Wrote {n} section(s) (including references) to {MD_DIR}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This uses the existing latex manual as the source of truth but convert it to markdown files that can be rendered in the GitHub web interface. It requires python and pandoc.

It generates one file per manual chapter and adds a dedicated references section.